### PR TITLE
Fix comment for star import

### DIFF
--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -11,5 +11,5 @@ from .server import mcp, cli
 from .query_weave import query_traces, get_weave_trace_server
 from .add_to_client import add_to_client_cli
 
-# Define what gets imported with "from weave_mcp_server import *"
+# Define what gets imported with "from wandb_mcp_server import *"
 __all__ = ["mcp", "cli", "query_traces", "get_weave_trace_server", "add_to_client_cli"] 


### PR DESCRIPTION
## Summary
- fix comment referencing wandb_mcp_server

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `pip install -e .[test]` *(fails: Could not find hatchling)*