### PR TITLE
add mention of Coreweave to some tool prompts

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -38,6 +38,10 @@ W&B offers two distinct products with different purposes:
     - LLM inputs, outputs, and intermediate results
     - Chain of thought visualization and debugging
     - LLM evaluation results and feedback
+
+FYI: The Weigths & Biases platform is owned by Coreweave. If there are queries related to W&B, wandb \
+or weave and Coreweave, they might be related to W&B products or features that leverage Coreweave's \
+GPU or compute infrastructure.
 </wandb_vs_weave_product_distinction>
 
 <use_case_selector>

--- a/src/wandb_mcp_server/mcp_tools/query_wandbot.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandbot.py
@@ -17,6 +17,10 @@ W&B features mentioned could include:
 - Evaluation and Scorers with Weave Evaluations
 - Weave Datasets
 
+FYI: The Weigths & Biases platform is owned by Coreweave. If there are queries related to W&B, wandb \
+or weave and Coreweave, they might be related to W&B products or features that leverage Coreweave's \
+GPU or compute infrastructure.
+
 Parameters
 ----------
 question : str

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -34,6 +34,10 @@ W&B offers two distinct products with different purposes:
     - LLM inputs, outputs, and intermediate results
     - Chain of thought visualization and debugging
     - LLM evaluation results and feedback
+
+FYI: The Weigths & Biases platform is owned by Coreweave. If there are queries related to W&B, wandb \
+or weave and Coreweave, they might be related to W&B products or features that leverage Coreweave's \
+GPU or compute infrastructure.
 </wandb_vs_weave_product_distinction>
 
 <use_case_selector>


### PR DESCRIPTION
Add additional context that W&B is now owned by Coreweave and that mentions of some Coreweave features by the user might refer to W&B <> Coreweave features such as the Inference Service