### PR TITLE
add "server_label" parameter for openai sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ resp = client.responses.create(
         "type": "mcp",
         "server_url": "https://mcp.withwandb.com/mcp",
         "authorization": os.getenv('WANDB_API_KEY'),
+        "server_label": "WandB_MCP",
     }],
     input="How many traces are in my project?"
 )


### PR DESCRIPTION
I encountered the following error with the code before change. Need to add the "server_label" parameter.
BadRequestError: Error code: 400 - {'error': {'message': "Missing required parameter: 'tools[0].server_label'.", 'type': 'invalid_request_error', 'param': 'tools[0].server_label', 'code': 'missing_required_parameter'}}
