### PR TITLE
feat(hackathon): GQL endpoint fixes + semantic truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Lint with ruff
+        run: |
+          pip install ruff
+          ruff check src/ tests/
+          ruff format --check src/ tests/
+
+      - name: Run unit tests
+        run: |
+          pytest tests/ -x -v --tb=short -q
+        env:
+          WANDB_SILENT: "True"
+          WEAVE_SILENT: "True"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ wandb/*
 
 # Local documentation and sensitive files
 local/
+resources/
 
 # Distribution / packaging
 .ruff_cache/
@@ -139,7 +140,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
-.vscode/
+# VS Code / Cursor -- track workspace settings, ignore personal state
+.vscode/*
+!.vscode/settings.json
 
 .cursor/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[python]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -511,6 +511,28 @@ print(resp.output_text)
 ```
 </details>
 
+### Development
+
+#### Running Tests
+
+Unit tests run without API keys or network access:
+
+```bash
+pip install -e ".[test]"
+pytest tests/ -v
+```
+
+CI runs automatically on every push and PR via GitHub Actions.
+
+#### Two-Repo Model
+
+| Repo | Visibility | Contains |
+|------|-----------|----------|
+| `wandb/wandb-mcp-server` | Public | Tool logic, core server, unit tests |
+| `wandb/wandb-mcp-server-internal` | Private | LLM evals, load tests, Dockerfile, Helm, CI/CD |
+
+The internal repo installs the public repo as a pip dependency.
+
 ### Support
 
 - [GitHub Issues](https://github.com/wandb/wandb-mcp-server/issues)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,20 @@ filterwarnings = [
     'ignore:The \`__fields_set__\` attribute is deprecated:pydantic.warnings.PydanticDeprecatedSince20:weave\.trace\.object_record',
 ]
 
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [dependency-groups]
 dev = [
     "ruff>=0.11.12",
+    "pre-commit>=4.0.0",
 ]

--- a/src/wandb_mcp_server/add_to_client.py
+++ b/src/wandb_mcp_server/add_to_client.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import sys
-import subprocess
 from dataclasses import dataclass, field
 from typing import Optional, Dict, List
 
@@ -87,21 +86,21 @@ def add_to_client(args: AddToClientArgs) -> None:
     """
     # Handle potential path parsing issues
     config_path = args.config_path
-    
+
     # Debug: Log the raw config_path to help diagnose issues
     logger.debug(f"Raw config_path argument: '{config_path}'")
-    
+
     # Check if config_path looks malformed (starts with --)
     if config_path.startswith("--"):
         logger.error(f"Invalid config path detected: '{config_path}'")
         logger.error("This usually happens when command line arguments are not properly parsed.")
         logger.error("Try running the command on a single line or check for syntax errors.")
         sys.exit(1)
-    
+
     # Expand user path and resolve to absolute path
     config_path = os.path.expanduser(config_path)
     config_path = os.path.abspath(config_path)
-    
+
     logger.info(f"Using config path: {config_path}")
 
     # Read existing config file or initialize a default structure
@@ -119,25 +118,17 @@ def add_to_client(args: AddToClientArgs) -> None:
                 else:
                     # Loaded JSON is not a dictionary (e.g. `null`, `[]`, `true`)
                     # This is unexpected for a config file that should hold mcpServers.
-                    logger.warning(
-                        f"Config file {config_path} did not contain a JSON object. Using default config."
-                    )
+                    logger.warning(f"Config file {config_path} did not contain a JSON object. Using default config.")
                     # config remains the default {"mcpServers": {}}
         else:
-            logger.info(
-                f"Config file {config_path} doesn't exist. Will create new file."
-            )
+            logger.info(f"Config file {config_path} doesn't exist. Will create new file.")
             # config remains the default {"mcpServers": {}}
     except json.JSONDecodeError as e:
         # This handles empty file or malformed JSON.
-        logger.warning(
-            f"Config file {config_path} is empty or contains invalid JSON: {e}. Using default config."
-        )
+        logger.warning(f"Config file {config_path} is empty or contains invalid JSON: {e}. Using default config.")
         # config remains the default {"mcpServers": {}}.
     except IOError as e:
-        logger.error(
-            f"Fatal error reading config file {config_path}: {e}. Cannot proceed."
-        )
+        logger.error(f"Fatal error reading config file {config_path}: {e}. Cannot proceed.")
         sys.exit(f"Fatal error reading config file: {e}")  # Exit if we can't read
 
     if not isinstance(config.get("mcpServers"), dict):
@@ -157,9 +148,7 @@ def add_to_client(args: AddToClientArgs) -> None:
     overlapping_keys = existing_keys.intersection(new_keys)
 
     if overlapping_keys:
-        logger.info(
-            "The following tools already exist in your config and will be overwritten:"
-        )
+        logger.info("The following tools already exist in your config and will be overwritten:")
         for key in overlapping_keys:
             logger.info(f"- {key}")
 
@@ -181,7 +170,7 @@ def add_to_client(args: AddToClientArgs) -> None:
     with open(config_path, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=2)
     logger.info(f"Successfully updated config at {config_path}")
-    
+
 
 def add_to_client_cli():
     args = simple_parsing.parse(AddToClientArgs)

--- a/src/wandb_mcp_server/api_client.py
+++ b/src/wandb_mcp_server/api_client.py
@@ -5,8 +5,7 @@ This module provides a consistent pattern for managing W&B API instances
 with per-request API keys, following the same pattern as WeaveApiClient.
 """
 
-import os
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 from contextvars import ContextVar
 import wandb
 from wandb_mcp_server.utils import get_rich_logger
@@ -15,25 +14,25 @@ from wandb_mcp_server.config import WANDB_BASE_URL
 logger = get_rich_logger(__name__)
 
 # Context variable for storing the current request's API key
-api_key_context: ContextVar[Optional[str]] = ContextVar('wandb_api_key', default=None)
+api_key_context: ContextVar[Optional[str]] = ContextVar("wandb_api_key", default=None)
 
 
 class WandBApiManager:
     """
     Manages W&B API instances with per-request API keys.
-    
+
     This class follows the same pattern as WeaveApiClient, providing
     a consistent interface for all W&B operations that need API access.
     """
-    
+
     @staticmethod
     def get_api_key() -> Optional[str]:
         """
         Get the API key for the current request context.
-        
+
         For HTTP mode: API key comes from auth middleware via contextvar.
         For STDIO mode: API key should be set via set_context_api_key() at startup.
-        
+
         Returns:
             The API key from context only, no fallbacks.
         """
@@ -42,53 +41,53 @@ class WandBApiManager:
         # STDIO: Set at startup from CLI/netrc/env
         api_key = api_key_context.get()
         return api_key
-    
+
     @staticmethod
     def get_api(api_key: Optional[str] = None) -> wandb.Api:
         """
         Get a W&B API instance with the specified or current API key.
-        
+
         Args:
             api_key: Optional API key to use. If not provided, uses context or environment.
-            
+
         Returns:
             A configured wandb.Api instance.
-            
+
         Raises:
             ValueError: If no API key is available.
         """
         if api_key is None:
             api_key = WandBApiManager.get_api_key()
-        
+
         if not api_key:
             raise ValueError(
                 "No W&B API key available in request context. "
                 "For HTTP: Ensure authentication middleware is configured. "
                 "For STDIO: Ensure API key is set at server startup."
             )
-        
+
         # Create API instance with the specific key
         # According to docs: https://docs.wandb.ai/ref/python/public-api/
         return wandb.Api(api_key=api_key, overrides={"base_url": WANDB_BASE_URL})
-    
+
     @staticmethod
     def set_context_api_key(api_key: str) -> Any:
         """
         Set the API key in the current context.
-        
+
         Args:
             api_key: The API key to set.
-            
+
         Returns:
             A token that can be used to reset the context.
         """
         return api_key_context.set(api_key)
-    
+
     @staticmethod
     def reset_context_api_key(token: Any) -> None:
         """
         Reset the API key context.
-        
+
         Args:
             token: The token returned from set_context_api_key.
         """
@@ -98,13 +97,13 @@ class WandBApiManager:
 def get_wandb_api(api_key: Optional[str] = None) -> wandb.Api:
     """
     Convenience function to get a W&B API instance.
-    
+
     This is the primary function that should be used throughout the codebase
     to get a W&B API instance with proper API key handling.
-    
+
     Args:
         api_key: Optional API key. If not provided, uses context or environment.
-        
+
     Returns:
         A configured wandb.Api instance.
     """

--- a/src/wandb_mcp_server/auth.py
+++ b/src/wandb_mcp_server/auth.py
@@ -1,7 +1,7 @@
 """
 Authentication middleware for W&B MCP Server.
 
-Implements Bearer token validation for HTTP transport as per 
+Implements Bearer token validation for HTTP transport as per
 MCP specification: https://modelcontextprotocol.io/specification/draft/basic/authorization
 
 Clients send their W&B API keys as Bearer tokens, which the server
@@ -11,7 +11,7 @@ then uses for all W&B operations on behalf of that client.
 import os
 import logging
 import re
-from typing import Optional, Dict, Any
+from typing import Optional
 from fastapi import HTTPException, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.responses import JSONResponse
@@ -25,10 +25,11 @@ bearer_scheme = HTTPBearer(auto_error=False)
 class MCPAuthConfig:
     """
     Configuration for MCP authentication.
-    
+
     For HTTP transport: Accepts any W&B API key as a Bearer token.
     The server uses the client's token for all W&B operations.
     """
+
     pass  # Simple config, no OAuth metadata needed
 
 
@@ -39,35 +40,32 @@ def is_valid_wandb_api_key(token: str) -> bool:
     """
     if not token:
         return False
-    
+
     # Strip any whitespace that might have been included
     token = token.strip()
-    
+
     # Be permissive - accept keys between 20 and 100 characters
     # The actual W&B API will validate the exact format
     if len(token) < 20 or len(token) > 100:
         return False
-    
+
     # Basic validation - W&B keys contain alphanumeric and some special characters
-    if re.match(r'^[a-zA-Z0-9_\-\.]+$', token):
+    if re.match(r"^[a-zA-Z0-9_\-\.]+$", token):
         return True
-    
+
     return False
 
 
-async def validate_bearer_token(
-    credentials: Optional[HTTPAuthorizationCredentials],
-    config: MCPAuthConfig
-) -> str:
+async def validate_bearer_token(credentials: Optional[HTTPAuthorizationCredentials], config: MCPAuthConfig) -> str:
     """
     Validate Bearer token (W&B API key) for MCP access.
-    
+
     Accepts any valid-looking W&B API key. The actual validation
     happens when the key is used to call W&B APIs.
-    
+
     Returns:
         The W&B API key to use for operations
-        
+
     Raises:
         HTTPException: 401 Unauthorized with WWW-Authenticate header
     """
@@ -75,24 +73,20 @@ async def validate_bearer_token(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Authorization required - please provide your W&B API key as a Bearer token",
-            headers={
-                "WWW-Authenticate": 'Bearer realm="W&B MCP"'
-            }
+            headers={"WWW-Authenticate": 'Bearer realm="W&B MCP"'},
         )
-    
+
     token = credentials.credentials.strip()  # Strip any whitespace
-    
+
     # Basic format validation
     if not is_valid_wandb_api_key(token):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Invalid W&B API key format. Got {len(token)} characters. "
-                   f"Get your key at: https://wandb.ai/authorize",
-            headers={
-                "WWW-Authenticate": 'Bearer realm="W&B MCP", error="invalid_token"'
-            }
+            f"Get your key at: https://wandb.ai/authorize",
+            headers={"WWW-Authenticate": 'Bearer realm="W&B MCP", error="invalid_token"'},
         )
-    
+
     logger.debug(f"Bearer token validated successfully (length: {len(token)})")
     return token
 
@@ -100,7 +94,7 @@ async def validate_bearer_token(
 async def mcp_auth_middleware(request: Request, call_next):
     """
     FastAPI middleware for MCP authentication on HTTP transport.
-    
+
     Only applies to MCP endpoints (/mcp/*).
     Extracts the client's W&B API key from the Bearer token and stores it
     for use in W&B operations.
@@ -108,14 +102,14 @@ async def mcp_auth_middleware(request: Request, call_next):
     # Only apply auth to MCP endpoints
     if not request.url.path.startswith("/mcp"):
         return await call_next(request)
-    
+
     # Skip auth if explicitly disabled (development only)
     if os.environ.get("MCP_AUTH_DISABLED", "false").lower() == "true":
         logger.warning("MCP authentication is disabled - endpoints are publicly accessible")
         return await call_next(request)
-    
+
     config = MCPAuthConfig()
-    
+
     try:
         # Extract bearer token from Authorization header
         authorization = request.headers.get("Authorization", "")
@@ -123,25 +117,23 @@ async def mcp_auth_middleware(request: Request, call_next):
         if authorization.startswith("Bearer "):
             # Remove "Bearer " prefix and strip any whitespace
             token = authorization[7:].strip()
-            credentials = HTTPAuthorizationCredentials(
-                scheme="Bearer",
-                credentials=token
-            )
-        
+            credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
         # Validate and get the W&B API key
         wandb_api_key = await validate_bearer_token(credentials, config)
-        
+
         # Make sure the key is clean (no extra whitespace or encoding issues)
         wandb_api_key = wandb_api_key.strip()
-        
+
         # Store the API key in request state for W&B operations
         request.state.wandb_api_key = wandb_api_key
-        
+
         # Set the API key in context for this request
         # Tools will use WandBApiManager.get_api_key() to retrieve it
         from wandb_mcp_server.api_client import WandBApiManager
+
         token = WandBApiManager.set_context_api_key(wandb_api_key)
-        
+
         # Debug logging
         logger.debug(f"Auth middleware: Set API key in context with length={len(wandb_api_key)}")
 
@@ -151,31 +143,25 @@ async def mcp_auth_middleware(request: Request, call_next):
             logger.info(f"Authenticated W&B viewer: {viewer}")
         except Exception as viewer_err:
             logger.warning(f"Could not fetch W&B viewer: {viewer_err}")
-        
+
         try:
             # Continue processing the request
             response = await call_next(request)
         finally:
             # Reset the context after request processing
             WandBApiManager.reset_context_api_key(token)
-        
+
         return response
-        
+
     except HTTPException as e:
         # Return proper error response
-        return JSONResponse(
-            status_code=e.status_code,
-            content={"error": e.detail},
-            headers=e.headers
-        )
+        return JSONResponse(status_code=e.status_code, content={"error": e.detail}, headers=e.headers)
     except Exception as e:
         logger.error(f"Authentication error: {e}")
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content={"error": "Authentication failed"},
-            headers={
-                "WWW-Authenticate": 'Bearer realm="W&B MCP"'
-            }
+            headers={"WWW-Authenticate": 'Bearer realm="W&B MCP"'},
         )
 
 

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -32,3 +32,7 @@ def _resolve_trace_server_url() -> str:
 
 # Weave Trace server URL used by the Weave API client and services
 WF_TRACE_SERVER_URL: str = _resolve_trace_server_url()
+
+# Maximum response tokens before progressive truncation kicks in.
+# Rough heuristic: 1 token ~ 4 characters of JSON.
+MAX_RESPONSE_TOKENS: int = int(os.getenv("MAX_RESPONSE_TOKENS", "30000"))

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -8,7 +8,5 @@ WANDB_BASE_URL: str = os.getenv("WANDB_BASE_URL", "https://api.wandb.ai")
 
 # Weave Trace server URL used by the Weave API client and services
 WF_TRACE_SERVER_URL: str = (
-    os.getenv("WF_TRACE_SERVER_URL")
-    or os.getenv("WEAVE_TRACE_SERVER_URL")
-    or "https://trace.wandb.ai"
+    os.getenv("WF_TRACE_SERVER_URL") or os.getenv("WEAVE_TRACE_SERVER_URL") or "https://trace.wandb.ai"
 )

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -6,7 +6,29 @@ import os
 # W&B Public API base URL
 WANDB_BASE_URL: str = os.getenv("WANDB_BASE_URL", "https://api.wandb.ai")
 
+# SaaS default host used to distinguish SaaS from dedicated/on-prem
+_SAAS_API_HOST = "api.wandb.ai"
+_SAAS_TRACE_HOST = "https://trace.wandb.ai"
+
+
+def _resolve_trace_server_url() -> str:
+    """Resolve the Weave trace server URL with auto-detection for dedicated/on-prem.
+
+    Priority:
+      1. Explicit WF_TRACE_SERVER_URL or WEAVE_TRACE_SERVER_URL env var -- use as-is.
+      2. WANDB_BASE_URL is SaaS default (api.wandb.ai) -- use trace.wandb.ai.
+      3. WANDB_BASE_URL is a dedicated/on-prem host -- append /traces suffix.
+    """
+    explicit = os.getenv("WF_TRACE_SERVER_URL") or os.getenv("WEAVE_TRACE_SERVER_URL")
+    if explicit:
+        return explicit
+
+    if _SAAS_API_HOST in WANDB_BASE_URL:
+        return _SAAS_TRACE_HOST
+
+    # Dedicated / on-prem: trace server lives at {base_url}/traces
+    return WANDB_BASE_URL.rstrip("/") + "/traces"
+
+
 # Weave Trace server URL used by the Weave API client and services
-WF_TRACE_SERVER_URL: str = (
-    os.getenv("WF_TRACE_SERVER_URL") or os.getenv("WEAVE_TRACE_SERVER_URL") or "https://trace.wandb.ai"
-)
+WF_TRACE_SERVER_URL: str = _resolve_trace_server_url()

--- a/src/wandb_mcp_server/mcp_tools/count_traces.py
+++ b/src/wandb_mcp_server/mcp_tools/count_traces.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import os
 from typing import Any, Dict
 
 import requests
@@ -16,7 +15,7 @@ logger = get_rich_logger(__name__)
 COUNT_WEAVE_TRACES_TOOL_DESCRIPTION = """count Weave traces and return the total storage \
 size in bytes for the given filters.
 
-Use this tool to query data from Weights & Biases Weave, an observability product for 
+Use this tool to query data from Weights & Biases Weave, an observability product for
 tracing and evaluating LLMs and GenAI apps.
 
 This tool only provides COUNT information and STORAGE SIZE (bytes) about traces, \
@@ -27,7 +26,7 @@ not actual logged traces data, metrics or run data.
 **IMPORTANT PRODUCT DISTINCTION:**
 W&B offers two distinct products with different purposes:
 
-1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model 
+1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model
     lifecycle management. Use `query_wandb_tool` for questions about:
     - Experiment runs, metrics, and performance comparisons
     - Artifact management and model registry
@@ -183,7 +182,7 @@ def count_traces(
     if not api_key:
         logger.error("W&B API key not found in context or environment variables.")
         raise ValueError("W&B API key is required to query Weave traces count.")
-    
+
     # Debug logging to diagnose API key issues
     logger.debug(f"Using W&B API key: length={len(api_key)}, is_40_chars={len(api_key) == 40}")
 
@@ -203,12 +202,8 @@ def count_traces(
         pass
 
     request_body: Dict[str, Any] = {"project_id": project_id}
-    filter_payload: Dict[
-        str, Any
-    ] = {}  # For fields that go into the top-level 'filter' object
-    complex_filters_for_query_expr: Dict[
-        str, Any
-    ] = {}  # For fields that go into query.$expr
+    filter_payload: Dict[str, Any] = {}  # For fields that go into the top-level 'filter' object
+    complex_filters_for_query_expr: Dict[str, Any] = {}  # For fields that go into query.$expr
 
     if filters:
         # Keys that belong inside the 'filter' object in the request body
@@ -281,9 +276,7 @@ def count_traces(
 
     # Build the query expression from remaining complex filters
     if complex_filters_for_query_expr:
-        query_expr_obj = QueryBuilder.build_query_expression(
-            complex_filters_for_query_expr
-        )
+        query_expr_obj = QueryBuilder.build_query_expression(complex_filters_for_query_expr)
         if query_expr_obj:
             dumped_query = query_expr_obj.model_dump(by_alias=True, exclude_none=True)
             if dumped_query and dumped_query.get("$expr"):
@@ -291,6 +284,7 @@ def count_traces(
 
     # Execute the HTTP query
     from wandb_mcp_server.config import WF_TRACE_SERVER_URL
+
     weave_server_url = WF_TRACE_SERVER_URL
     url = f"{weave_server_url}/calls/query_stats"
 
@@ -331,16 +325,10 @@ def count_traces(
         logger.error(f"HTTP Request failed for project {project_id}: {e}")
         if isinstance(e, requests.exceptions.RetryError):
             if e.__cause__ and hasattr(e.__cause__, "reason") and e.__cause__.reason:
-                logger.error(
-                    f"Specific reason for retry exhaustion: {e.__cause__.reason}"
-                )
-        logger.debug(
-            f"Failed request body during exception for {project_id}: {json.dumps(request_body)}"
-        )
+                logger.error(f"Specific reason for retry exhaustion: {e.__cause__.reason}")
+        logger.debug(f"Failed request body during exception for {project_id}: {json.dumps(request_body)}")
         # traceback.print_exc() # Uncomment for detailed traceback during development
-        raise Exception(
-            f"Failed to query Weave trace count for {project_id} due to network error: {e}"
-        )
+        raise Exception(f"Failed to query Weave trace count for {project_id} due to network error: {e}")
     except json.JSONDecodeError as e:
         logger.error(
             f"Failed to decode JSON response for {project_id}: {e}. Response text: {response.text if 'response' in locals() else 'N/A'}"

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -29,11 +29,12 @@ logger = get_rich_logger(__name__)
 def _get_api_from_context():
     """Patched _get_api that reads API key from request context."""
     from wandb_mcp_server.api_client import WandBApiManager
+
     api_key = WandBApiManager.get_api_key()
-    
+
     if not api_key:
         raise Exception("No W&B API key available in context")
-    
+
     try:
         # Uses explicit api_key from contextvar, not singleton
         # and points to the configured base URL
@@ -48,7 +49,7 @@ wr_interface._get_api = _get_api_from_context
 
 CREATE_WANDB_REPORT_TOOL_DESCRIPTION = """Create a new Weights & Biases Report to document analysis and findings.
 
-Only call this tool if the user explicitly asks to create a report or save to wandb/weights & biases. 
+Only call this tool if the user explicitly asks to create a report or save to wandb/weights & biases.
 Always provide the returned report link to the user.
 
 <markdown_generation_guide>
@@ -56,13 +57,13 @@ When generating the markdown_report_text parameter, structure your content using
 
 **Headers**: Organize content hierarchically
 - # Main Title (H1)
-- ## Section Title (H2) 
+- ## Section Title (H2)
 - ### Subsection Title (H3)
 
 **Paragraphs**: Write clear, informative text separated by blank lines
 
 **Lists**: Present information clearly
-- Bullet points: Use - or * 
+- Bullet points: Use - or *
 - Numbered lists: Use 1. 2. 3.
 
 **Formatting**:
@@ -140,26 +141,27 @@ def create_report(
 ) -> Dict[str, str]:
     """
     SAFE VERSION - Create W&B Report with markdown-only content.
-    
+
     Security improvements:
     - No singleton contamination (no wandb.login)
     - No wandb.init() that could use contaminated state
     - Reads API key from contextvar (concurrent-safe)
     - Markdown-only output for simplicity and safety
     - Ignores plots_html parameter (for backwards compatibility)
-    
+
     Thread Safety:
     - Uses patched _get_api (set at module import) that reads from contextvar
     - Each request has its own contextvar value - no cross-contamination
     - Safe for async/concurrent report creation
     """
-    
+
     # Note if plots_html was provided (for backwards compatibility)
     if plots_html:
         logger.info("Note: plots_html parameter provided but ignored in safe markdown-only mode")
 
     # Get the current API key from context
     from wandb_mcp_server.api_client import WandBApiManager
+
     api_key = WandBApiManager.get_api_key()
 
     if not api_key:
@@ -198,22 +200,18 @@ def create_report(
         blocks = parse_markdown_to_blocks(markdown_report_text or "")
 
         # Add security notice at the top
-        security_notice = wr.P(
-            "*Report created using SAFE markdown-only version (no wandb.init/login)*"
-        )
+        security_notice = wr.P("*Report created using SAFE markdown-only version (no wandb.init/login)*")
         report.blocks = [security_notice] + blocks
 
-        logger.info(f"SAFE: Creating markdown report without wandb.init/login")
-        
+        logger.info("SAFE: Creating markdown report without wandb.init/login")
+
         # Save the report
         # Uses patched _get_api which reads from contextvar (concurrent-safe)
         report.save()
-        
+
         logger.info(f"SAFE: Created report: {title}")
-        
-        return {
-            "url": report.url
-        }
+
+        return {"url": report.url}
 
     except Exception as e:
         logger.error(f"Error creating report (safe mode): {e}")
@@ -225,14 +223,14 @@ def parse_markdown_to_blocks(
 ) -> List[Union[wr.H1, wr.H2, wr.H3, wr.P, wr.TableOfContents, wr.MarkdownBlock, wr.CodeBlock]]:
     """
     Parse markdown text into W&B report blocks.
-    
+
     Supports the following W&B report blocks:
     - Headers: H1, H2, H3 (extracted for TOC support)
     - Table of Contents: TableOfContents (via [TOC] marker)
     - Code Blocks: CodeBlock (with language syntax highlighting)
     - Rich Markdown: MarkdownBlock (for tables, lists, blockquotes, etc.)
     - Paragraphs: P (for simple text)
-    
+
     Strategy:
     - Extract top-level headers (H1, H2, H3) as separate blocks for TOC
     - Use CodeBlock for code with syntax highlighting
@@ -241,21 +239,21 @@ def parse_markdown_to_blocks(
     """
     blocks = []
     lines = text.strip().split("\n") if text else []
-    
+
     current_content = []
     in_code_block = False
     code_language = None
     code_block_content = []
-    
+
     def flush_content():
         """Helper to flush accumulated content as MarkdownBlock or P"""
         if not current_content:
             return
-        
+
         content_text = "\n".join(current_content).strip()
         if not content_text:
             return
-        
+
         # Check if content has complex markdown (tables, lists, etc.)
         has_table = "|" in content_text and "---" in content_text
         has_list = re.search(r"^\s*[-*+]\s", content_text, re.MULTILINE)
@@ -263,7 +261,7 @@ def parse_markdown_to_blocks(
         has_blockquote = re.search(r"^\s*>\s", content_text, re.MULTILINE)
         has_inline_code = "`" in content_text
         has_bold_italic = re.search(r"[*_]{1,2}\w", content_text)
-        
+
         # Use MarkdownBlock for rich content, P for simple paragraphs
         if has_table or has_list or has_ordered_list or has_blockquote:
             blocks.append(wr.MarkdownBlock(content_text))
@@ -273,13 +271,13 @@ def parse_markdown_to_blocks(
         else:
             # Simple paragraph
             blocks.append(wr.P(content_text))
-        
+
         current_content.clear()
-    
+
     i = 0
     while i < len(lines):
         line = lines[i]
-        
+
         # Handle code blocks
         if line.startswith("```"):
             if in_code_block:
@@ -287,7 +285,18 @@ def parse_markdown_to_blocks(
                 flush_content()
                 code_content = "\n".join(code_block_content)
                 # Create CodeBlock with language if specified
-                if code_language and code_language in ["python", "javascript", "typescript", "css", "json", "html", "markdown", "yaml", "bash", "shell"]:
+                if code_language and code_language in [
+                    "python",
+                    "javascript",
+                    "typescript",
+                    "css",
+                    "json",
+                    "html",
+                    "markdown",
+                    "yaml",
+                    "bash",
+                    "shell",
+                ]:
                     blocks.append(wr.CodeBlock(code=code_content, language=code_language))
                 else:
                     blocks.append(wr.CodeBlock(code=code_content))
@@ -304,24 +313,24 @@ def parse_markdown_to_blocks(
                     code_language = lang_match.group(1).lower()
             i += 1
             continue
-        
+
         # If in code block, accumulate lines
         if in_code_block:
             code_block_content.append(line)
             i += 1
             continue
-        
+
         # Check for top-level headers (extract for TOC support)
         h1_match = re.match(r"^# (.+)$", line)
         h2_match = re.match(r"^## (.+)$", line)
         h3_match = re.match(r"^### (.+)$", line)
-        
+
         # Check for Table of Contents marker
         is_toc = line.strip().lower() == "[toc]"
-        
+
         if h1_match or h2_match or h3_match or is_toc:
             flush_content()
-            
+
             if h1_match:
                 blocks.append(wr.H1(h1_match.group(1)))
             elif h2_match:
@@ -333,14 +342,14 @@ def parse_markdown_to_blocks(
         else:
             # Accumulate content
             current_content.append(line)
-        
+
         i += 1
-    
+
     # Flush any remaining content
     flush_content()
-    
+
     # If no blocks were created, add a default paragraph
     if not blocks:
         blocks.append(wr.P("*Empty report*"))
-    
+
     return blocks

--- a/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
+++ b/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
@@ -1,16 +1,15 @@
 from typing import Any
 
-import wandb
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.mcp_tools.tools_utils import log_tool_call
 
 
 LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION = """
-Fetch all projects for a specific wandb or weave entity. Useful to use when 
-the user hasn't specified a project name or queries are failing due to a 
+Fetch all projects for a specific wandb or weave entity. Useful to use when
+the user hasn't specified a project name or queries are failing due to a
 missing or incorrect Weights & Biases project name.
 
-If no entity is provided, the tool will fetch all projects for the current user 
+If no entity is provided, the tool will fetch all projects for the current user
 as well as all the project in the teams they are part of.
 
 <critical_info>
@@ -26,19 +25,19 @@ the user to provide either their W&B username or W&B team name.
 **Error Handling:**
 
 If this function throws an error, it's likely because the W&B entity name is incorrect.
-If this is the case, ask the user to double check the W&B entity name given by the user, 
+If this is the case, ask the user to double check the W&B entity name given by the user,
 either their personal user or their W&B Team name.
 
 **Expected Project Name Not Found:**
 
 If the user doesn't see the project they're looking for in the list of projects,
-ask them to double check the W&B entity name, either their personal W&B username or their 
+ask them to double check the W&B entity name, either their personal W&B username or their
 W&B Team name.
 </debugging_tips>
 
 Args:
     entity (str): The wandb entity (username or team name)
-    
+
 Returns:
     List[Dict[str, Any]]: List of project dictionaries containing:
         - name: Project name
@@ -78,8 +77,9 @@ def list_entity_projects(entity: str | None = None) -> dict[str, list[dict[str, 
     # Will use WANDB_API_KEY from environment (set by auth middleware or user)
     # Get API instance with proper key handling
     from wandb_mcp_server.api_client import get_wandb_api
+
     api = get_wandb_api()
-   
+
     viewer = None
     # Merge entity and teams into a single list
     if entity is None:

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -518,6 +518,14 @@ use the tool again with additional filters or pagination to get a more complete 
 *   `"Cannot query field 'step' on type 'Run'"`: The `Run` type does not have a direct `step` field. To find the maximum step count or total steps logged, query the `summaryMetrics` field (look for a key like `_step` or similar in the returned JSON string) or use the `historyLineCount` field which indicates the total number of history rows logged (often corresponding to steps).
 
 **Notes:**
+
+<deduplication_warning>
+**IMPORTANT: Do NOT re-call this tool with identical or very similar parameters.**
+If you have already received a response, work with the data you have. If the response
+was large or truncated, narrow your query by adding filters, reducing `max_items`,
+or requesting fewer fields. Do NOT re-submit the same query hoping for different results.
+</deduplication_warning>
+
 *   Refer to the official W&B GraphQL schema (via introspection or documentation) for the most up-to-date field names, types, and available filters/arguments.
 *   Structure your query to request only the necessary data fields to minimize response size and improve performance.
 *   **Sorting:** Use the `order` parameter string. Prefix with `+` for ascending, `-` for descending (default).

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -5,7 +5,6 @@ import logging
 import traceback
 from typing import Any, Dict, List, Optional
 
-import wandb
 from graphql import parse
 from graphql.language import ast as gql_ast
 from graphql.language import printer as gql_printer
@@ -19,14 +18,14 @@ logger = get_rich_logger(__name__)
 
 QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute an arbitrary GraphQL query against the Weights & Biases (W&B) Models API.
 
-Use this tool to query data from Weights & Biases Models features, including experiment tracking runs, 
-model registry, reports, artifacts, sweeps. 
+Use this tool to query data from Weights & Biases Models features, including experiment tracking runs,
+model registry, reports, artifacts, sweeps.
 
 <wandb_vs_weave_product_distinction>
 **IMPORTANT PRODUCT DISTINCTION:**
 W&B offers two distinct products with different purposes:
 
-1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model 
+1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model
     lifecycle management. Use `query_wandb_tool` for questions about:
     - Experiment runs, metrics, and performance comparisons
     - Artifact management and model registry
@@ -61,8 +60,8 @@ If user question contains:
 - "traces", "LLM calls" etc → Use query_weave_traces_tool
 
 **COMMON MISUSE CASES:**
-❌ "Looking at performance of my latest weave evals" - Use query_weave_traces_tool 
-❌ "what system prompt was used for my openai call" - Use query_weave_traces_tool 
+❌ "Looking at performance of my latest weave evals" - Use query_weave_traces_tool
+❌ "what system prompt was used for my openai call" - Use query_weave_traces_tool
 ❌ "Show me the traces for my weave evals" - Use query_weave_traces_tool
 
 <query_analysis_step>
@@ -103,8 +102,8 @@ variables : dict[str, Any] | None, optional
                                             Keys should match variable names defined in the query
                                             (e.g., $entity, $project). Values should match the
                                             expected types (String, Int, Float, Boolean, ID, JSONString).
-                                            **Crucially, complex arguments like `filters` MUST be provided 
-                                            as a JSON formatted *string*. Use `json.dumps()` in Python 
+                                            **Crucially, complex arguments like `filters` MUST be provided
+                                            as a JSON formatted *string*. Use `json.dumps()` in Python
                                             to create this string.**
 max_items : int, optional
     Maximum number of items to fetch across all pages. Default is 100.
@@ -133,7 +132,7 @@ All collection queries MUST include the complete W&B connection pattern with the
     - `endCursor` field (to enable pagination)
     - `hasNextPage` field (to determine if more data exists)
 
-This is a strict requirement enforced by the pagination system. Queries without this 
+This is a strict requirement enforced by the pagination system. Queries without this
 structure will fail with the error "Query doesn't follow the W&B connection pattern."
 
 Example of required pagination structure for any collection:
@@ -161,7 +160,7 @@ runs(first: 10) {  # or artifacts, files, etc.
 The results of this tool are returned to a LLM. Be mindful of the context window of the LLM!
 
 <warning_about_open_ended_queries>
-**WARNING: AVOID OPEN-ENDED QUERIES!** 
+**WARNING: AVOID OPEN-ENDED QUERIES!**
 
 Open-ended queries should be strictly avoided when:
 - There are a lot of runs in the project (e.g., hundreds or thousands)
@@ -194,13 +193,13 @@ query LimitedRuns($entity: String!, $project: String!) {
     project(name: $project, entityName: $entity) {
     # Limits runs, specifies filters, and selects only necessary fields
     runs(first: 5, filters: "{\\"state\\":\\"finished\\"}") {
-        edges { 
-        node { 
-            id 
-            name 
-            createdAt 
+        edges {
+        node {
+            id
+            name
+            createdAt
             summaryMetrics # Get summary JSON, parse later if needed
-        } 
+        }
         }
         pageInfo { endCursor hasNextPage } # Always include pageInfo for collections
     }
@@ -230,7 +229,7 @@ use the tool again with additional filters or pagination to get a more complete 
 
 *   **Core Types:** `Entity`, `Project`, `Run`, `Artifact`, `Sweep`, `Report`, `User`, `Team`.
 *   **Relationships:** Entities contain Projects. Projects contain Runs, Sweeps, Artifacts. Runs use/are used by Artifacts. Sweeps contain Runs.
-*   **Common Fields:** `id`, `name`, `description`, `createdAt`, `config` (JSONString), `summaryMetrics` (JSONString - **Note:** use this field, 
+*   **Common Fields:** `id`, `name`, `description`, `createdAt`, `config` (JSONString), `summaryMetrics` (JSONString - **Note:** use this field,
         not `summary`, to access the run's summary dictionary as a JSON string), `historyKeys` (List of String), etc.
 *   **Connections (Lists):** Many lists (like `project.runs`, `artifact.files`) use a connection pattern:
     ```graphql
@@ -366,8 +365,8 @@ use the tool again with additional filters or pagination to get a more complete 
         "filters": "{\"state\": \"finished\", \"summary_metrics.accuracy\": {\"$gt\": 0.9}}", # Escaped JSON string
         # "cursor": previous_pageInfo_endCursor # Optional for next page
     }
-    # Note: The *content* of the `filters` JSON string must adhere to the specific 
-    # filtering syntax supported by the W&B API (e.g., using operators like `$gt`, `$eq`, `$in`). 
+    # Note: The *content* of the `filters` JSON string must adhere to the specific
+    # filtering syntax supported by the W&B API (e.g., using operators like `$gt`, `$eq`, `$in`).
     # Refer to W&B documentation for the full filter specification.
     ```
 <!-- WANDB_GQL_EXAMPLE_END name=GetFilteredRuns -->
@@ -389,7 +388,7 @@ use the tool again with additional filters or pagination to get a more complete 
     variables = {"entity": "my-entity", "project": "my-project", "runName": "run-abc"}
     ```
 <!-- WANDB_GQL_EXAMPLE_END name=GetRunHistoryKeys -->
-    
+
 <!-- WANDB_GQL_EXAMPLE_START name=GetRunHistorySampled -->
 *   **Get Specific Run History Data:** (Uses `sampledHistory` for specific keys)
     ```graphql
@@ -400,11 +399,11 @@ use the tool again with additional filters or pagination to get a more complete 
             id
             name
             # Use sampledHistory with specs to get actual values for specific keys
-            sampledHistory(specs: $specs) { 
+            sampledHistory(specs: $specs) {
                 step # The step number
                 timestamp # Timestamp of the log
                 item # JSON string containing {key: value} for requested keys at this step
-            } 
+            }
         }
         }
     }
@@ -412,13 +411,13 @@ use the tool again with additional filters or pagination to get a more complete 
     ```python
     # Corrected: Define specs variable with escaped JSON string literal for keys
     variables = {
-        "entity": "my-entity", 
-        "project": "my-project", 
-        "runName": "run-abc", 
+        "entity": "my-entity",
+        "project": "my-project",
+        "runName": "run-abc",
         "specs": ["{\"keys\": [\"loss\", \"val_accuracy\"]}}"] # List containing escaped JSON string
     }
     # Note: sampledHistory returns rows where *at least one* of the specified keys was logged.
-    # The 'item' field is a JSON string, you'll need to parse it (e.g., json.loads(row['item'])) 
+    # The 'item' field is a JSON string, you'll need to parse it (e.g., json.loads(row['item']))
     # to get the actual key-value pairs for that step. It might not contain all requested keys
     # if they weren't logged together at that specific step.
     ```
@@ -475,11 +474,11 @@ use the tool again with additional filters or pagination to get a more complete 
             metadata # JSON String
             aliases { alias } # Corrected: Use 'alias' field instead of 'name'
             files { # Files is a collection, requires pagination structure
-            edges { 
+            edges {
                 node { name url digest } # Corrected: Removed 'size' from File fields
-            } 
+            }
             pageInfo { endCursor hasNextPage } # Required for files collection
-            } 
+            }
         }
         }
     }
@@ -521,15 +520,13 @@ use the tool again with additional filters or pagination to get a more complete 
 **Notes:**
 *   Refer to the official W&B GraphQL schema (via introspection or documentation) for the most up-to-date field names, types, and available filters/arguments.
 *   Structure your query to request only the necessary data fields to minimize response size and improve performance.
-*   **Sorting:** Use the `order` parameter string. Prefix with `+` for ascending, `-` for descending (default). 
+*   **Sorting:** Use the `order` parameter string. Prefix with `+` for ascending, `-` for descending (default).
         Common sortable fields: `createdAt`, `updatedAt`, `heartbeatAt`, `config.*`, `summary_metrics.*`.
 *   Handle potential errors in the returned dictionary (e.g., check for an 'errors' key in the response).
 """
 
 
-def find_paginated_collections(
-    obj: Dict, current_path: Optional[List[str]] = None
-) -> List[List[str]]:
+def find_paginated_collections(obj: Dict, current_path: Optional[List[str]] = None) -> List[List[str]]:
     """Find collections in a response that follow the W&B connection pattern. Returns List[List[str]]."""
     # Ensure this implementation correctly builds and returns List[List[str]]
     if current_path is None:
@@ -595,6 +592,7 @@ def query_paginated_wandb_gql(
         # Use API key from environment (set by auth middleware for HTTP, or by user for STDIO)
         # Get API instance with proper key handling
         from wandb_mcp_server.api_client import get_wandb_api
+
         api = get_wandb_api()
         try:
             log_tool_call(
@@ -609,9 +607,7 @@ def query_paginated_wandb_gql(
             )
         except Exception:
             pass
-        logger.info(
-            "--- Inside query_paginated_wandb_gql: Step 0: Execute Initial Query ---"
-        )
+        logger.info("--- Inside query_paginated_wandb_gql: Step 0: Execute Initial Query ---")
 
         # Determine limit key and set initial page vars
         page1_vars_func = variables.copy() if variables is not None else {}
@@ -622,15 +618,11 @@ def query_paginated_wandb_gql(
                 break
         if limit_key:
             # Ensure first page uses items_per_page if limit is too high or missing
-            page1_vars_func[limit_key] = min(
-                items_per_page, page1_vars_func.get(limit_key) or items_per_page
-            )
+            page1_vars_func[limit_key] = min(items_per_page, page1_vars_func.get(limit_key) or items_per_page)
         else:
             limit_key = "limit"
             page1_vars_func[limit_key] = items_per_page
-            logger.debug(
-                f"No limit variable found in input, adding '{limit_key}={items_per_page}'"
-            )
+            logger.debug(f"No limit variable found in input, adding '{limit_key}={items_per_page}'")
 
         # Parse for execution
         try:
@@ -641,14 +633,10 @@ def query_paginated_wandb_gql(
 
         # Execute initial query
         try:
-            result1 = api.client.execute(
-                parsed_initial_query, variable_values=page1_vars_func
-            )
+            result1 = api.client.execute(parsed_initial_query, variable_values=page1_vars_func)
             result_dict = copy.deepcopy(result1)  # Work on a copy
             if "errors" in result_dict:
-                logger.error(
-                    f"GraphQL errors in initial response: {result_dict['errors']}"
-                )
+                logger.error(f"GraphQL errors in initial response: {result_dict['errors']}")
                 return result_dict  # Return errors if found
         except Exception as e:
             logger.error(f"Failed to execute initial GraphQL query: {e}", exc_info=True)
@@ -711,18 +699,12 @@ def query_paginated_wandb_gql(
                     :max_items
                 ]  # Ensure initial list respects max_items
                 current_edge_count = len(target_collection_dict["edges"])
-            logging.info(
-                f"Stored {current_edge_count} unique edges after page 1 (max: {max_items})."
-            )
+            logging.info(f"Stored {current_edge_count} unique edges after page 1 (max: {max_items}).")
 
         if not has_next or not cursor or current_edge_count >= max_items:
-            logger.info(
-                "No further pages needed based on page 1 info or max_items reached."
-            )
+            logger.info("No further pages needed based on page 1 info or max_items reached.")
             # Ensure final pageInfo reflects reality
-            target_pi_dict = get_nested_value(
-                result_dict, path_to_paginate + ["pageInfo"]
-            )
+            target_pi_dict = get_nested_value(result_dict, path_to_paginate + ["pageInfo"])
             if target_pi_dict:
                 target_pi_dict["hasNextPage"] = False
             return result_dict
@@ -748,9 +730,7 @@ def query_paginated_wandb_gql(
         if generated_paginated_query_string is None:
             return result_dict
 
-        logging.info(
-            "\n--- Loop: Execute, Deduplicate, Aggregate In-Place, Check Limit ---"
-        )
+        logging.info("\n--- Loop: Execute, Deduplicate, Aggregate In-Place, Check Limit ---")
         page_num = 1
         current_cursor = cursor
         current_has_next = has_next
@@ -764,26 +744,18 @@ def query_paginated_wandb_gql(
 
             page_num += 1
             logging.info(f"\nFetching Page {page_num}...")
-            page_vars = (
-                variables.copy() if variables is not None else {}
-            )  # Start with original vars
+            page_vars = variables.copy() if variables is not None else {}  # Start with original vars
             page_vars[limit_key] = items_per_page  # Set correct page size
             page_vars[after_variable_name] = current_cursor  # Set cursor
 
             try:
                 # Parse and execute for the current page
                 parsed_generated = gql(generated_paginated_query_string)
-                logging.info(
-                    f"Executing generated query for page {page_num} with vars: {page_vars}"
-                )
-                result_page = api.client.execute(
-                    parsed_generated, variable_values=page_vars
-                )
+                logging.info(f"Executing generated query for page {page_num} with vars: {page_vars}")
+                result_page = api.client.execute(parsed_generated, variable_values=page_vars)
 
                 if "errors" in result_page:
-                    logger.error(
-                        f"GraphQL errors on page {page_num}: {result_page['errors']}. Stopping pagination."
-                    )
+                    logger.error(f"GraphQL errors on page {page_num}: {result_page['errors']}. Stopping pagination.")
                     current_has_next = False
                     final_page_info = {
                         **final_page_info,
@@ -803,9 +775,7 @@ def query_paginated_wandb_gql(
                     page_info = get_nested_value(runs_data, ["pageInfo"]) or {}
                     final_page_info = page_info  # Store latest page info
 
-                logging.info(
-                    f"Result (Page {page_num}): {len(edges_this_page)} runs returned."
-                )
+                logging.info(f"Result (Page {page_num}): {len(edges_this_page)} runs returned.")
                 logging.info(f"Page Info (Page {page_num}): {page_info}")
 
                 # Deduplicate & Find edges to append
@@ -813,13 +783,8 @@ def query_paginated_wandb_gql(
                 duplicates_skipped = 0
                 if edges_this_page:
                     for edge in edges_this_page:
-                        if (
-                            current_edge_count + len(new_edges_for_aggregation)
-                            >= max_items
-                        ):
-                            logging.info(
-                                f"Max items ({max_items}) reached mid-page {page_num}."
-                            )
+                        if current_edge_count + len(new_edges_for_aggregation) >= max_items:
+                            logging.info(f"Max items ({max_items}) reached mid-page {page_num}.")
                             final_page_info = {**final_page_info, "hasNextPage": False}
                             current_has_next = False
                             break
@@ -835,41 +800,27 @@ def query_paginated_wandb_gql(
                             new_edges_for_aggregation.append(edge)
 
                     if duplicates_skipped > 0:
-                        logging.info(
-                            f"Skipped {duplicates_skipped} duplicate edges on page {page_num}."
-                        )
+                        logging.info(f"Skipped {duplicates_skipped} duplicate edges on page {page_num}.")
 
                     # Append new unique edges IN-PLACE
                     if new_edges_for_aggregation:
-                        target_collection_dict_inplace = get_nested_value(
-                            result_dict, path_to_paginate
-                        )
+                        target_collection_dict_inplace = get_nested_value(result_dict, path_to_paginate)
                         if target_collection_dict_inplace and isinstance(
                             target_collection_dict_inplace.get("edges"), list
                         ):
-                            target_collection_dict_inplace["edges"].extend(
-                                new_edges_for_aggregation
-                            )
-                            current_edge_count = len(
-                                target_collection_dict_inplace["edges"]
-                            )
+                            target_collection_dict_inplace["edges"].extend(new_edges_for_aggregation)
+                            current_edge_count = len(target_collection_dict_inplace["edges"])
                             logging.info(
                                 f"Appended {len(new_edges_for_aggregation)} new edges. Total unique edges: {current_edge_count}"
                             )
                         else:
-                            logging.error(
-                                "Could not find target edges list in result_dict to append in-place."
-                            )
+                            logging.error("Could not find target edges list in result_dict to append in-place.")
                             current_has_next = False
                     else:
                         if len(edges_this_page) > 0:
-                            logging.info(
-                                "No new unique edges found on page {page_num} after deduplication."
-                            )
+                            logging.info("No new unique edges found on page {page_num} after deduplication.")
                         else:
-                            logging.info(
-                                "No edges returned on page {page_num} to aggregate."
-                            )
+                            logging.info("No edges returned on page {page_num} to aggregate.")
                 else:
                     logging.info("No edges returned on page {page_num} to aggregate.")
 
@@ -881,20 +832,14 @@ def query_paginated_wandb_gql(
 
                 # Safety checks
                 if current_has_next and not current_cursor:
-                    logging.warning(
-                        "hasNextPage is true but no endCursor received. Stopping loop."
-                    )
+                    logging.warning("hasNextPage is true but no endCursor received. Stopping loop.")
                     current_has_next = False
                 if not edges_this_page:
-                    logging.warning(
-                        f"No edges received for page {page_num}. Stopping loop."
-                    )
+                    logging.warning(f"No edges received for page {page_num}. Stopping loop.")
                     current_has_next = False
 
             except Exception as e:
-                logging.error(
-                    f"Execution failed for page {page_num}: {e}", exc_info=True
-                )
+                logging.error(f"Execution failed for page {page_num}: {e}", exc_info=True)
                 current_has_next = False  # Stop loop on error
 
         logging.info(f"\n--- Pagination Loop Finished after page {page_num} ---")
@@ -915,24 +860,16 @@ def query_paginated_wandb_gql(
         if result_dict:
             if "errors" not in result_dict:
                 result_dict["errors"] = []
-            result_dict["errors"].append(
-                {"message": "Pagination failed", "details": str(e)}
-            )
+            result_dict["errors"].append({"message": "Pagination failed", "details": str(e)})
             return result_dict
         else:
-            return {
-                "errors": [
-                    {"message": "Pagination failed catastrophically", "details": str(e)}
-                ]
-            }
+            return {"errors": [{"message": "Pagination failed catastrophically", "details": str(e)}]}
 
 
 class AddPaginationArgsVisitor(gql_visitor.Visitor):
     """Adds first/after args and variables"""
 
-    def __init__(
-        self, field_paths, first_variable_name="limit", after_variable_name="after"
-    ):
+    def __init__(self, field_paths, first_variable_name="limit", after_variable_name="after"):
         super().__init__()
         self.field_paths = set(tuple(p) for p in field_paths)
         self.first_variable_name = first_variable_name
@@ -950,23 +887,15 @@ class AddPaginationArgsVisitor(gql_visitor.Visitor):
             has_first = any(arg.name.value == "first" for arg in existing_args)
             if not has_first:
                 # Defaulting variable name to 'limit' if not found, might need refinement
-                limit_var_node = gql_ast.VariableNode(
-                    name=gql_ast.NameNode(value=self.first_variable_name)
-                )
-                existing_args.append(
-                    gql_ast.ArgumentNode(
-                        name=gql_ast.NameNode(value="first"), value=limit_var_node
-                    )
-                )
+                limit_var_node = gql_ast.VariableNode(name=gql_ast.NameNode(value=self.first_variable_name))
+                existing_args.append(gql_ast.ArgumentNode(name=gql_ast.NameNode(value="first"), value=limit_var_node))
                 args_changed = True
             has_after = any(arg.name.value == "after" for arg in existing_args)
             if not has_after:
                 existing_args.append(
                     gql_ast.ArgumentNode(
                         name=gql_ast.NameNode(value="after"),
-                        value=gql_ast.VariableNode(
-                            name=gql_ast.NameNode(value=self.after_variable_name)
-                        ),
+                        value=gql_ast.VariableNode(name=gql_ast.NameNode(value=self.after_variable_name)),
                     )
                 )
                 args_changed = True
@@ -993,9 +922,7 @@ class AddPaginationArgsVisitor(gql_visitor.Visitor):
         if current_limit_var not in existing_vars:
             new_defs_list.append(
                 gql_ast.VariableDefinitionNode(
-                    variable=gql_ast.VariableNode(
-                        name=gql_ast.NameNode(value=current_limit_var)
-                    ),
+                    variable=gql_ast.VariableNode(name=gql_ast.NameNode(value=current_limit_var)),
                     type=gql_ast.NamedTypeNode(name=gql_ast.NameNode(value="Int")),
                 )
             )
@@ -1003,9 +930,7 @@ class AddPaginationArgsVisitor(gql_visitor.Visitor):
         if self.after_variable_name not in existing_vars:
             new_defs_list.append(
                 gql_ast.VariableDefinitionNode(
-                    variable=gql_ast.VariableNode(
-                        name=gql_ast.NameNode(value=self.after_variable_name)
-                    ),
+                    variable=gql_ast.VariableNode(name=gql_ast.NameNode(value=self.after_variable_name)),
                     type=gql_ast.NamedTypeNode(name=gql_ast.NameNode(value="String")),
                 )
             )

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -526,7 +526,34 @@ use the tool again with additional filters or pagination to get a more complete 
 """
 
 
-def find_paginated_collections(obj: Dict, current_path: Optional[List[str]] = None) -> List[List[str]]:
+def _prefix_gql_operation_name(query_string: str, prefix: str = "mcp_") -> str:
+    """Prefix GraphQL operation names with a given prefix for analytics filtering.
+
+    If the query already has a prefixed operation name, it is returned unchanged.
+    Anonymous operations (no name) are left untouched.
+
+    Args:
+        query_string: The raw GraphQL query string.
+        prefix: Prefix to prepend (default ``mcp_``).
+
+    Returns:
+        The query string with the operation name prefixed.
+    """
+    try:
+        doc = parse(query_string.strip())
+        for definition in doc.definitions:
+            if hasattr(definition, "name") and definition.name:
+                current_name = definition.name.value
+                if not current_name.startswith(prefix):
+                    definition.name = gql_ast.NameNode(value=f"{prefix}{current_name}")
+        return gql_printer.print_ast(doc)
+    except Exception:
+        return query_string
+
+
+def find_paginated_collections(
+    obj: Dict, current_path: Optional[List[str]] = None
+) -> List[List[str]]:
     """Find collections in a response that follow the W&B connection pattern. Returns List[List[str]]."""
     # Ensure this implementation correctly builds and returns List[List[str]]
     if current_path is None:
@@ -623,6 +650,9 @@ def query_paginated_wandb_gql(
             limit_key = "limit"
             page1_vars_func[limit_key] = items_per_page
             logger.debug(f"No limit variable found in input, adding '{limit_key}={items_per_page}'")
+
+        # Prefix operation name for analytics filtering (MCP-9)
+        query = _prefix_gql_operation_name(query)
 
         # Parse for execution
         try:

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -531,6 +531,54 @@ or requesting fewer fields. Do NOT re-submit the same query hoping for different
 *   **Sorting:** Use the `order` parameter string. Prefix with `+` for ascending, `-` for descending (default).
         Common sortable fields: `createdAt`, `updatedAt`, `heartbeatAt`, `config.*`, `summary_metrics.*`.
 *   Handle potential errors in the returned dictionary (e.g., check for an 'errors' key in the response).
+
+<common_pitfalls>
+**CRITICAL: Common mistakes that cause query failures:**
+
+1. **`summaryMetrics` vs `summary_metrics` naming:**
+   - In GraphQL **field names**: use `summaryMetrics` (camelCase)
+   - In the `order` **parameter value**: use `summary_metrics` (snake_case)
+   - WRONG: `order: "-summaryMetrics.accuracy"` (capital M in order param)
+   - CORRECT: `order: "-summary_metrics.accuracy"` (snake_case in order param)
+
+2. **`filters` MUST be a JSON-encoded string, not a dict:**
+   - WRONG: `"filters": {"state": "finished"}`
+   - CORRECT: `"filters": "{\"state\": \"finished\"}"`
+   - Always use escaped JSON string syntax for the filters variable value.
+
+3. **Use `$exists` when sorting by metrics:**
+   - Runs missing the sort metric cause errors. Pre-filter:
+   - `"filters": "{\"summary_metrics.eval/accuracy\": {\"$exists\": true}}"`
+
+4. **`summaryMetrics` returns a JSON string, not an object:**
+   - The value of `summaryMetrics` in the response is a raw JSON string.
+   - You must parse it (e.g., `json.loads(run["summaryMetrics"])`) to access individual metrics.
+
+**Complete working example -- top 5 runs by accuracy:**
+```graphql
+query TopRuns($entity: String!, $project: String!, $order: String, $perPage: Int, $filters: JSONString) {
+  project(entityName: $entity, name: $project) {
+    runCount(filters: $filters)
+    runs(first: $perPage, order: $order, filters: $filters) {
+      edges {
+        node { id name displayName state summaryMetrics config createdAt }
+      }
+      pageInfo { endCursor hasNextPage }
+    }
+  }
+}
+```
+Variables:
+```json
+{
+  "entity": "my-team",
+  "project": "my-project",
+  "order": "-summary_metrics.eval/accuracy",
+  "perPage": 5,
+  "filters": "{\"summary_metrics.eval/accuracy\": {\"$exists\": true}}"
+}
+```
+</common_pitfalls>
 """
 
 

--- a/src/wandb_mcp_server/mcp_tools/query_wandbot.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandbot.py
@@ -42,7 +42,9 @@ def query_wandbot_api(question: str) -> Dict[str, Any]:
         )
     except Exception:
         pass
-    wandbot_base_url = os.getenv("WANDBOT_BASE_URL", "https://weightsandbiases-wandbot--wandbot-api-wandbotapi-serve.modal.run")
+    wandbot_base_url = os.getenv(
+        "WANDBOT_BASE_URL", "https://weightsandbiases-wandbot--wandbot-api-wandbotapi-serve.modal.run"
+    )
     QUERY_ENDPOINT = f"{wandbot_base_url}/chat/query"
     STATUS_ENDPOINT = f"{wandbot_base_url}/status"
     QUERY_TIMEOUT_SECONDS = 40
@@ -106,11 +108,7 @@ def query_wandbot_api(question: str) -> Dict[str, Any]:
                     }
 
                 # Ensure sources is a list
-                sources = (
-                    result["sources"]
-                    if isinstance(result["sources"], list)
-                    else [result["sources"]]
-                )
+                sources = result["sources"] if isinstance(result["sources"], list) else [result["sources"]]
                 return {"answer": result["answer"], "sources": sources}
 
             except requests.Timeout:

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -8,16 +8,18 @@ from wandb_mcp_server.mcp_tools.tools_utils import log_tool_call
 
 logger = get_rich_logger(__name__)
 
+
 def get_trace_service():
     """
     Get a TraceService instance with the current request's API key.
-    
+
     This creates a new TraceService for each request to ensure
     the correct API key is used from the context.
     """
     # Get the API key from context (set by auth middleware) or environment
     api_key = WandBApiManager.get_api_key()
     return TraceService(api_key=api_key)
+
 
 QUERY_WEAVE_TRACES_TOOL_DESCRIPTION = """
 Query Weave traces, trace metadata, and trace costs with filtering and sorting options.
@@ -32,7 +34,7 @@ Query Weave traces, trace metadata, and trace costs with filtering and sorting o
 **IMPORTANT PRODUCT DISTINCTION:**
 W&B offers two distinct products with different purposes:
 
-1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model 
+1. W&B Models: A system for ML experiment tracking, hyperparameter optimization, and model
     lifecycle management. Use `query_wandb_tool` for questions about:
     - Experiment runs, metrics, and performance comparisons
     - Artifact management and model registry
@@ -138,13 +140,13 @@ before querying for them as query_trace_tool can return a lot of data.
 are unsure of the exact op name.
 
 - Weave Evaluations: If asked about weave evaluations or evals traces:
-    - Evals are complicated to query, prompt the user with follow up questions if needed. 
+    - Evals are complicated to query, prompt the user with follow up questions if needed.
     - First, always try and oritent yourself - pull a summary of the evaluation, get all of the top level column names in the eval \
 and always get a count of the total number of child traces in this eval by filtering by parent_id and using the count_traces tool.
     - As part of orienting yourself, just pull a subset of child traces from the eval, maybe 3 to 5, to understand the column structure \
 and values.
     - Always be explicit about the amount of data returned and limits used in your query - return to the user the count of traces \
-analysed. 
+analysed.
     - Always stay filterd on the evaluation id (filter by `parent_id`) unless specifically asked questions across different evaulations, e.g. \
 if a parent id (or parentId) is provided then ensure to use that filter in the query.
     - filter for traces with `op_name_contains = "Evaluation.evaluate"` as a first step. These ops are parent traces that contain
@@ -167,7 +169,7 @@ project_name : str
     The Weights & Biases project name
 filters : dict
     Dict of filter conditions, supporting:
-    
+
     - display_name : str or regex pattern
         Filter by display name seen in the Weave UI
     - op_name : str or regex pattern
@@ -192,7 +194,7 @@ if given an evaluation trace id or name.
     - status : str
         Filter by trace status, defined as whether or not the trace had an exception or not. Can be
         `success` or `error`.
-        NOTE: When users ask for "failed", "wrong", or "incorrect" traces, use `status:'error'` or 
+        NOTE: When users ask for "failed", "wrong", or "incorrect" traces, use `status:'error'` or
         `has_exception:True` as the filter.
     - time_range : dict
         Dict with "start" and "end" datetime strings. Datetime strings should be in ISO format
@@ -380,9 +382,7 @@ def query_traces(
                     traces_as_dicts.append(dict(trace))
                 except Exception:
                     # If all else fails, convert to string
-                    traces_as_dicts.append(
-                        {"error": f"Could not convert {type(trace)} to dict"}
-                    )
+                    traces_as_dicts.append({"error": f"Could not convert {type(trace)} to dict"})
         return traces_as_dicts
     else:
         return []
@@ -508,7 +508,5 @@ async def query_paginated_weave_traces(
         # Convert back to QueryResult
         result = QueryResult.model_validate(result_dict)
 
-    assert isinstance(result, QueryResult), (
-        f"Result type must be a QueryResult, found: {type(result)}"
-    )
+    assert isinstance(result, QueryResult), f"Result type must be a QueryResult, found: {type(result)}"
     return result

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -124,6 +124,17 @@ default 200 characters. Otherwise the trace data is returned in full.
 </truncating_trace_data_values>
 
 Remember, LLM context window is precious, only return the minimum amount of data needed to complete an analysis.
+
+<deduplication_warning>
+**IMPORTANT: Do NOT re-call this tool with identical or very similar parameters.**
+If you have already received a response, work with the data you have. If the response
+was truncated, narrow your query by:
+- Adding more specific filters (op_name_contains, time_range, status)
+- Requesting fewer columns
+- Setting metadata_only=True first to understand the data shape
+- Using count_weave_traces_tool to check project size before querying
+Do NOT re-submit the same query hoping for different results.
+</deduplication_warning>
 </managing_llm_context_window>
 
 <usage_guidance>

--- a/src/wandb_mcp_server/mcp_tools/tools_utils.py
+++ b/src/wandb_mcp_server/mcp_tools/tools_utils.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from typing import Any, Callable, Dict, Type, Union, Tuple, Optional
+from typing import Any, Callable, Dict, Type, Union, Tuple
 from wandb_mcp_server.utils import get_rich_logger
 import requests
 from requests.adapters import HTTPAdapter
@@ -90,9 +90,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
     main_description = "\n".join(main_description_lines).strip()
 
     # 2. Process Parameters section if found
-    if param_definitions_start_index != -1 and param_definitions_start_index < len(
-        lines
-    ):
+    if param_definitions_start_index != -1 and param_definitions_start_index < len(lines):
         current_param_name = None
         current_param_desc_lines = []
         param_def_indent = -1
@@ -104,9 +102,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
             stripped_line = line.strip()
 
             # Regex to find 'name :' at the start of the stripped line
-            param_match = re.match(
-                r"^(?P<name>[a-zA-Z_]\w*)\s*:(?P<desc_start>.*)$", stripped_line
-            )
+            param_match = re.match(r"^(?P<name>[a-zA-Z_]\w*)\s*:(?P<desc_start>.*)$", stripped_line)
 
             # --- Determine if this line starts a new parameter ---
             is_new_parameter_line = False
@@ -124,9 +120,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
                     if expected_desc_indent != -1:
                         # If we have an established description indent
                         if current_indent < expected_desc_indent:
-                            is_new_parameter_line = (
-                                True  # Definitely ends previous block
-                            )
+                            is_new_parameter_line = True  # Definitely ends previous block
                     elif current_indent <= param_def_indent:
                         # If no description started yet, or if back at original indent
                         is_new_parameter_line = True
@@ -135,16 +129,12 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
             if is_new_parameter_line:
                 # Save the previous parameter's description
                 if current_param_name:
-                    param_descriptions[current_param_name] = "\n".join(
-                        current_param_desc_lines
-                    ).strip()
+                    param_descriptions[current_param_name] = "\n".join(current_param_desc_lines).strip()
 
                 # Start the new parameter
                 current_param_name = param_match.group("name")
                 desc_start = param_match.group("desc_start").strip()
-                current_param_desc_lines = (
-                    [desc_start] if desc_start else []
-                )  # Use first line if present
+                current_param_desc_lines = [desc_start] if desc_start else []  # Use first line if present
                 param_def_indent = current_indent
                 expected_desc_indent = -1  # Reset for the new parameter
 
@@ -154,10 +144,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
                     # Handle blank lines within the description
                     # Keep blank lines if they are indented same/more than expected desc indent OR
                     # if they are more indented than param def and we haven't set expected yet.
-                    if (
-                        expected_desc_indent != -1
-                        and current_indent >= expected_desc_indent
-                    ) or (
+                    if (expected_desc_indent != -1 and current_indent >= expected_desc_indent) or (
                         expected_desc_indent == -1 and current_indent > param_def_indent
                     ):
                         current_param_desc_lines.append("")  # Preserve paragraph breaks
@@ -173,9 +160,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
                     else:
                         # Indentation is not correct for a description start. End of this param.
                         if current_param_name:  # Save description if any collected
-                            param_descriptions[current_param_name] = "\n".join(
-                                current_param_desc_lines
-                            ).strip()
+                            param_descriptions[current_param_name] = "\n".join(current_param_desc_lines).strip()
                         current_param_name = None
                         # Assume end of parameters section, stop parsing this section
                         break
@@ -185,9 +170,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
                 else:
                     # Indentation decreased below expected description indent. End of this parameter's description.
                     if current_param_name:
-                        param_descriptions[current_param_name] = "\n".join(
-                            current_param_desc_lines
-                        ).strip()
+                        param_descriptions[current_param_name] = "\n".join(current_param_desc_lines).strip()
                     current_param_name = None
                     # Assume end of parameters section, stop parsing this section
                     break
@@ -199,9 +182,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
 
         # Save the last parameter description after the loop finishes
         if current_param_name:
-            param_descriptions[current_param_name] = "\n".join(
-                current_param_desc_lines
-            ).strip()
+            param_descriptions[current_param_name] = "\n".join(current_param_desc_lines).strip()
 
     # Filter out empty descriptions that might result from parsing issues or empty entries
     param_descriptions = {k: v for k, v in param_descriptions.items() if v}
@@ -210,9 +191,7 @@ def _parse_docstring(docstring: str) -> Tuple[Dict[str, str], str]:
 
 
 # generate_anthropic_tool_schema remains the same, but needs slight adjustment for required logic
-def generate_anthropic_tool_schema(
-    func: Callable[..., Any], description: str | None = None
-) -> Dict[str, Any]:
+def generate_anthropic_tool_schema(func: Callable[..., Any], description: str | None = None) -> Dict[str, Any]:
     """
     Generates an Anthropic tool schema dictionary from a Python function.
 

--- a/src/wandb_mcp_server/secrets_resolver.py
+++ b/src/wandb_mcp_server/secrets_resolver.py
@@ -52,5 +52,3 @@ def get_secrets_resolver_from_env() -> Optional[SecretsResolver]:
         return None
     project = os.environ.get("MCP_SERVER_SECRETS_PROJECT")
     return SecretsResolver(provider=provider, secrets_project=project)
-
-

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -4,14 +4,13 @@ Weights & Biases MCP Server - A Model Context Protocol server for querying Weigh
 
 This server provides tools for:
 - Querying Weave traces and evaluations
-- Counting traces efficiently  
+- Counting traces efficiently
 - Executing GraphQL queries against W&B experiment data
 - Creating shareable reports with visualizations
 - Getting help via wandbot support agent
 - Discovering available entities and projects
 """
 
-import io
 import json
 import logging
 import os
@@ -27,6 +26,7 @@ from wandb_mcp_server.config import WANDB_BASE_URL
 # Import Weave for tracing MCP tool calls
 try:
     import weave
+
     WEAVE_AVAILABLE = True
 except ImportError:
     weave = None
@@ -60,40 +60,39 @@ from wandb_mcp_server.utils import get_rich_logger, get_server_args, ServerMCPAr
 
 # Export key functions for HF Spaces app
 __all__ = [
-    'validate_and_get_api_key',
-    'validate_api_key',
-    'configure_wandb_logging',
-    'initialize_weave_tracing',
-    'create_mcp_server',
-    'register_tools',
-    'ServerMCPArgs',
-    'cli'
+    "validate_and_get_api_key",
+    "validate_api_key",
+    "configure_wandb_logging",
+    "initialize_weave_tracing",
+    "create_mcp_server",
+    "register_tools",
+    "ServerMCPArgs",
+    "cli",
 ]
 from wandb_mcp_server.weave_api.models import QueryResult
 
-print('Starting W&B MCP Server...', file=sys.stderr)
+print("Starting W&B MCP Server...", file=sys.stderr)
 
 # Load environment variables
 load_dotenv(dotenv_path=Path(__file__).parent.parent.parent / ".env")
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
-logger = get_rich_logger(
-    "weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL"
-)
+logger = get_rich_logger("weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL")
 
 
 # ===============================================================================
 # SECTION 1: W&B AUTHENTICATION & API KEY SETUP
 # ===============================================================================
 
+
 def validate_api_key(api_key: str) -> bool:
     """
     Validate a W&B API key by attempting to use it.
-    
+
     Args:
         api_key: The W&B API key to validate
-        
+
     Returns:
         True if the API key is valid, False otherwise
     """
@@ -112,27 +111,27 @@ def validate_api_key(api_key: str) -> bool:
 def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
     """
     Validate and retrieve the W&B API key from various sources.
-    
+
     For HTTP transport: API key is optional (clients provide their own)
     For STDIO transport: API key is required from environment
-    
+
     Priority order:
     1. Command-line argument (--wandb-api-key)
     2. Environment variable (WANDB_API_KEY)
     3. .netrc file
     4. .env file
-    
+
     Args:
         args: Parsed command-line arguments
-        
+
     Returns:
         The W&B API key if found, None otherwise
-        
+
     Raises:
         ValueError: If no API key is found for STDIO transport
     """
     api_key = args.wandb_api_key or get_server_args().wandb_api_key
-    
+
     # For HTTP transport, API key is optional (clients provide their own)
     if args.transport == "http":
         if api_key:
@@ -140,7 +139,7 @@ def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
         else:
             logger.info("No server W&B API key configured (clients will provide their own)")
         return api_key
-    
+
     # For STDIO transport, API key is required
     if not api_key:
         raise ValueError(
@@ -151,7 +150,7 @@ def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
             "4. .netrc file: machine api.wandb.ai login user password YOUR_KEY\n"
             "\nGet your API key at: https://wandb.ai/authorize"
         )
-    
+
     return api_key
 
 
@@ -159,35 +158,36 @@ def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
 # SECTION 2: W&B LOGGING CONFIGURATION
 # ===============================================================================
 
+
 def configure_wandb_logging() -> None:
     """
     Configure W&B and Weave logging behavior to avoid interference with MCP protocol.
     (because Weave outputs created or fetched traces)
-    
+
     Environment variables that control logging:
     - WANDB_SILENT: Set to "True" to suppress all W&B output (default: True)
-    - WEAVE_SILENT: Set to "True" to suppress all Weave output (default: True) 
+    - WEAVE_SILENT: Set to "True" to suppress all Weave output (default: True)
     - MCP_SERVER_LOG_LEVEL: Set server log level (DEBUG, INFO, WARNING, ERROR)
     - WANDB_CONSOLE: Set to "off" to disable console output (default: off)
     """
     # Ensure W&B operates silently by default to not interfere with MCP protocol
     os.environ.setdefault("WANDB_SILENT", "True")
     os.environ.setdefault("WEAVE_SILENT", "True")
-    
+
     # Configure W&B to suppress console output
     try:
         wandb.setup(settings=wandb.Settings(silent=True, console="off", base_url=WANDB_BASE_URL))
         logger.debug("W&B configured for silent operation")
     except Exception as e:
         logger.warning(f"Could not apply wandb.setup settings: {e}")
-    
+
     # Silence specific loggers that might interfere with MCP
     weave_logger = get_rich_logger("weave")
     weave_logger.setLevel(logging.ERROR)
-    
+
     gql_transport_logger = get_rich_logger("gql.transport.requests")
     gql_transport_logger.setLevel(logging.ERROR)
-    
+
     # Allow users to enable more verbose W&B logging if needed for debugging
     if os.environ.get("WANDB_DEBUG", "").lower() == "true":
         logger.info("W&B debug logging enabled via WANDB_DEBUG=true")
@@ -199,42 +199,42 @@ def configure_wandb_logging() -> None:
 def initialize_weave_tracing() -> bool:
     """
     Initialize Weave tracing for MCP operations using the official FastMCP integration.
-    
+
     According to https://weave-docs.wandb.ai/guides/integrations/mcp, Weave automatically
     traces FastMCP operations (tools, resources, prompts) when weave.init() is called.
-    
+
     Returns:
         True if Weave was successfully initialized, False otherwise
     """
     if not WEAVE_AVAILABLE:
         logger.debug("Weave not available - MCP operations will not be traced")
         return False
-    
+
     # Check if Weave tracing is disabled
     if os.environ.get("WEAVE_DISABLED", "true").lower() == "true":
         logger.debug("Weave tracing disabled via WEAVE_DISABLED=true")
         return False
-    
+
     # Get Weave project configuration
     entity = os.environ.get("MCP_LOGS_WANDB_ENTITY") or os.environ.get("WANDB_ENTITY")
     project = os.environ.get("MCP_LOGS_WANDB_PROJECT", "wandb-mcp-logs")
-    
+
     if not entity:
         logger.debug("No WANDB_ENTITY or MCP_LOGS_WANDB_ENTITY set - MCP operations will not be traced to Weave")
         return False
-    
+
     try:
         weave_project = f"{entity}/{project}"
         logger.info(f"Initializing Weave tracing for MCP operations: {weave_project}")
-        
+
         # Set optional MCP configuration for list operations tracing
         if os.environ.get("MCP_TRACE_LIST_OPERATIONS", "").lower() == "true":
             os.environ["MCP_TRACE_LIST_OPERATIONS"] = "true"
             logger.info("MCP list operations tracing enabled")
-        
+
         # Initialize Weave - this automatically enables tracing for FastMCP operations
         weave.init(weave_project)
-        
+
         logger.info("Weave tracing initialized - FastMCP operations will be automatically traced")
         return True
     except Exception as e:
@@ -246,10 +246,11 @@ def initialize_weave_tracing() -> bool:
 # SECTION 3: MCP TOOL REGISTRATION
 # ===============================================================================
 
+
 def register_tools(mcp_instance: FastMCP) -> None:
     """
     Register all W&B MCP tools on the given FastMCP instance.
-    
+
     Available tools:
     - query_weave_traces_tool: Query LLM traces with filtering and pagination
     - count_weave_traces_tool: Efficiently count traces without returning data
@@ -257,11 +258,11 @@ def register_tools(mcp_instance: FastMCP) -> None:
     - create_wandb_report_tool: Create shareable reports with visualizations
     - query_wandb_entity_projects: List available entities and projects
     - query_wandb_support_bot: Get help via wandbot RAG-powered support
-    
+
     Args:
         mcp_instance: The FastMCP instance to register tools on
     """
-    
+
     @mcp_instance.tool(description=QUERY_WEAVE_TRACES_TOOL_DESCRIPTION)
     async def query_weave_traces_tool(
         entity_name: str,
@@ -305,9 +306,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         entity_name: str, project_name: str, filters: Optional[Dict[str, Any]] = None
     ) -> str:
         try:
-            total_count = count_traces(
-                entity_name=entity_name, project_name=project_name, filters=filters or {}
-            )
+            total_count = count_traces(entity_name=entity_name, project_name=project_name, filters=filters or {})
 
             # Also count root traces for better understanding of project scope
             root_filters = filters.copy() if filters else {}
@@ -318,9 +317,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 filters=root_filters,
             )
 
-            return json.dumps(
-                {"total_count": total_count, "root_traces_count": root_traces_count}
-            )
+            return json.dumps({"total_count": total_count, "root_traces_count": root_traces_count})
         except Exception as e:
             logger.error(f"Error in count_weave_traces_tool: {e}")
             return f"Error counting traces: {str(e)}"
@@ -352,7 +349,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 markdown_report_text=markdown_report_text,
                 plots_html=plots_html,  # Kept for backwards compatibility, ignored by safe version
             )
-            
+
             # Simple return message
             return f"The report was saved here: {result['url']}"
         except Exception as e:
@@ -371,21 +368,22 @@ def register_tools(mcp_instance: FastMCP) -> None:
 # SECTION 4: MCP SERVER SETUP (STDIO & HTTP)
 # ===============================================================================
 
+
 def create_mcp_server(transport: str, host: str = "localhost", port: Optional[int] = None) -> FastMCP:
     """
     Create and configure a FastMCP server for the specified transport.
-    
+
     Args:
         transport: Transport type ("stdio" or "http")
         host: Host for HTTP transport (default: "localhost")
         port: Port for HTTP transport (default: 8080)
-        
+
     Returns:
         Configured FastMCP instance with all tools registered
-        
+
     Raises:
         ValueError: If transport type is invalid
-    
+
     Authentication:
         - STDIO transport: Uses environment variables (WANDB_API_KEY required)
         - HTTP transport: Clients provide W&B API key as Bearer token
@@ -395,23 +393,23 @@ def create_mcp_server(transport: str, host: str = "localhost", port: Optional[in
         port = port if port is not None else 8080
         logger.info(f"Configuring HTTP server on {host}:{port}")
         mcp = FastMCP("weave-mcp-server", host=host, port=port, stateless_http=True)
-        
+
         # Log authentication status for HTTP
         if os.environ.get("MCP_AUTH_DISABLED", "false").lower() == "true":
             logger.warning("⚠️  MCP authentication is DISABLED - server is publicly accessible")
         else:
             logger.info("🔒 MCP authentication enabled - clients must provide W&B API key as Bearer token")
-            
+
     elif transport == "stdio":
         logger.info("Configuring stdio server")
         mcp = FastMCP("weave-mcp-server")
         logger.info("STDIO transport uses environment variable authentication")
     else:
         raise ValueError(f"Invalid transport type: {transport}. Must be 'stdio' or 'http'")
-    
+
     # Register all tools
     register_tools(mcp)
-    
+
     return mcp
 
 
@@ -419,19 +417,20 @@ def create_mcp_server(transport: str, host: str = "localhost", port: Optional[in
 # SECTION 5: MAIN CLI ENTRY POINT
 # ===============================================================================
 
+
 def cli():
     """
     Main command-line interface for starting the Weights & Biases MCP Server.
-    
+
     Usage:
         wandb_mcp_server [OPTIONS]
-        
+
     Options:
         --transport {stdio,http}     Transport type (default: stdio)
-        --host HOST                  Host for HTTP transport (default: localhost)  
+        --host HOST                  Host for HTTP transport (default: localhost)
         --port PORT                  Port for HTTP transport (default: 8080)
         --wandb-api-key KEY         W&B API key (can also use env var)
-        
+
     Environment Variables:
         WANDB_API_KEY               W&B API key (required for STDIO, optional for HTTP)
         MCP_SERVER_LOG_LEVEL        Server log level (DEBUG, INFO, WARNING, ERROR)
@@ -442,22 +441,24 @@ def cli():
     """
     # Parse command line arguments
     import simple_parsing
+
     args = simple_parsing.parse(ServerMCPArgs)
-    
+
     # Configure W&B logging behavior
     configure_wandb_logging()
-    
+
     # Validate and get API key
     api_key = validate_and_get_api_key(args)
-    
+
     # Validate API key if we have one (but don't set global state)
     if api_key:
         validate_api_key(api_key)
-        
+
         # For STDIO transport, set the API key in context for all operations
         # This is essential since STDIO doesn't have per-request auth
         if args.transport == "stdio":
             from wandb_mcp_server.api_client import WandBApiManager
+
             # Set the API key in context for the entire session
             # No need to reset since STDIO runs for the whole session
             WandBApiManager.set_context_api_key(api_key)
@@ -469,21 +470,21 @@ def cli():
                 logger.info(f"Authenticated W&B viewer: {viewer}")
             except Exception as viewer_err:
                 logger.warning(f"Could not fetch W&B viewer: {viewer_err}")
-    
+
     # Initialize Weave tracing for MCP tool calls
-    weave_initialized = initialize_weave_tracing()
-    
+    initialize_weave_tracing()
+
     logger.info("Starting Weights & Biases MCP Server")
     logger.info(f"Transport: {args.transport}")
-    logger.info(f"API Key configured: Yes")
-    
+    logger.info("API Key configured: Yes")
+
     # Validate transport type
     if args.transport not in ["stdio", "http"]:
         raise ValueError(f"Invalid transport type: {args.transport}. Must be 'stdio' or 'http'")
-    
+
     # Create and run the MCP server
     server = create_mcp_server(args.transport, args.host, args.port)
-    
+
     if args.transport == "http":
         logger.info(f"Starting HTTP server on {args.host}:{args.port or 8080}")
         server.run(transport="streamable-http")

--- a/src/wandb_mcp_server/session_manager.py
+++ b/src/wandb_mcp_server/session_manager.py
@@ -31,13 +31,14 @@ logger = get_rich_logger(__name__)
 
 
 # Context variables for session management
-current_session_id: ContextVar[Optional[str]] = ContextVar('session_id', default=None)
-current_api_key_hash: ContextVar[Optional[str]] = ContextVar('api_key_hash', default=None)
+current_session_id: ContextVar[Optional[str]] = ContextVar("session_id", default=None)
+current_api_key_hash: ContextVar[Optional[str]] = ContextVar("api_key_hash", default=None)
 
 
 @dataclass
 class Session:
     """Represents an isolated session for a specific API key."""
+
     session_id: str
     api_key_hash: str  # Store hash for comparison
     created_at: datetime
@@ -45,7 +46,7 @@ class Session:
     request_count: int = 0
     active_requests: Set[str] = field(default_factory=set)
     metadata: Dict[str, Any] = field(default_factory=dict)
-    
+
     def update_access(self):
         """Update last access time and increment request count."""
         self.last_accessed = datetime.now()
@@ -55,17 +56,19 @@ class Session:
 class MultiTenantSessionManager:
     """
     Enhanced session manager for multi-tenant environments.
-    
+
     Provides strong isolation between concurrent requests with different API keys.
     """
-    
-    def __init__(self, 
-                 session_ttl_seconds: int = 3600,  # 1 hour default
-                 max_sessions_per_key: int = 10,
-                 enable_hmac_sha256_sessions: bool = False):
+
+    def __init__(
+        self,
+        session_ttl_seconds: int = 3600,  # 1 hour default
+        max_sessions_per_key: int = 10,
+        enable_hmac_sha256_sessions: bool = False,
+    ):
         """
         Initialize the session manager.
-        
+
         Args:
             session_ttl_seconds: Time-to-live for idle sessions
             max_sessions_per_key: Maximum concurrent sessions per API key
@@ -78,7 +81,7 @@ class MultiTenantSessionManager:
         self._max_sessions_per_key = max_sessions_per_key
         self._enable_hmac_sha256_sessions = enable_hmac_sha256_sessions
         self._hmac_sha256_key: Optional[bytes] = None
-        
+
         # Initialize HMAC-SHA256 key if enabled
         if self._enable_hmac_sha256_sessions:
             try:
@@ -94,47 +97,49 @@ class MultiTenantSessionManager:
                 logger.error("Failed to initialize HMAC-SHA256 sessions: %s", e)
                 raise
         else:
-            logger.warning("MultiTenantSessionManager using plain SHA-256 hashing. For stronger security, set MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS=true and configure a secrets provider.")
-        
+            logger.warning(
+                "MultiTenantSessionManager using plain SHA-256 hashing. For stronger security, set MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS=true and configure a secrets provider."
+            )
+
         # Start cleanup task
         self._cleanup_task = None
         self._start_cleanup_task()
-        
+
         logger.info(
             "MultiTenantSessionManager initialized (TTL: %ss, Max sessions/key: %s, HMAC sessions: %s)",
             session_ttl_seconds,
             max_sessions_per_key,
             self._enable_hmac_sha256_sessions,
         )
-    
+
     def _hash_api_key(self, api_key: str) -> str:
         """Create a secure hash of the API key for storage."""
         api_key_bytes = api_key.encode()
         if self._hmac_sha256_key:
             return hmac.new(self._hmac_sha256_key, api_key_bytes, hashlib.sha256).hexdigest()
         return hashlib.sha256(api_key_bytes).hexdigest()
-    
+
     def create_session(self, api_key: str, session_id: Optional[str] = None) -> str:
         """
         Create a new session for an API key.
-        
+
         Args:
             api_key: The W&B API key
             session_id: Optional session ID (will generate if not provided)
-            
+
         Returns:
             The session ID
-            
+
         Raises:
             ValueError: If max sessions per key is exceeded
         """
         with self._lock:
             api_key_hash = self._hash_api_key(api_key)
-            
+
             # Generate session ID if not provided
             if not session_id:
                 session_id = f"sess_{uuid.uuid4().hex}"
-            
+
             _session_prefix = get_session_prefix_from_session(session_id)
             _log = logging.LoggerAdapter(
                 logger, {"session_id_prefix": f"[{_session_prefix}] " if _session_prefix else ""}
@@ -149,40 +154,44 @@ class MultiTenantSessionManager:
                     raise ValueError("Session API key mismatch!")
                 session.update_access()
                 return session_id
-            
+
             # Check max sessions per API key
             existing_sessions = self._api_key_sessions[api_key_hash]
             if len(existing_sessions) >= self._max_sessions_per_key:
                 # Clean up old sessions for this key
                 self._cleanup_api_key_sessions(api_key_hash)
-                
+
                 # Check again after cleanup
                 if len(existing_sessions) >= self._max_sessions_per_key:
-                    _log.warning(f"Max sessions ({self._max_sessions_per_key}) reached for API key hash {api_key_hash[:8]}...")
-                    raise ValueError(f"Maximum concurrent sessions ({self._max_sessions_per_key}) exceeded for this API key")
-            
+                    _log.warning(
+                        f"Max sessions ({self._max_sessions_per_key}) reached for API key hash {api_key_hash[:8]}..."
+                    )
+                    raise ValueError(
+                        f"Maximum concurrent sessions ({self._max_sessions_per_key}) exceeded for this API key"
+                    )
+
             # Create new session
             session = Session(
                 session_id=session_id,
                 api_key_hash=api_key_hash,
                 created_at=datetime.now(),
-                last_accessed=datetime.now()
+                last_accessed=datetime.now(),
             )
-            
+
             self._sessions[session_id] = session
             self._api_key_sessions[api_key_hash].add(session_id)
-            
+
             _log.info("Created session %s...", get_session_prefix_from_session(session_id))
             return session_id
-    
+
     def validate_session(self, session_id: str, api_key: str) -> bool:
         """
         Validate that a session ID matches the provided API key.
-        
+
         Args:
             session_id: The session ID to validate
             api_key: The API key to validate against
-            
+
         Returns:
             True if valid, False otherwise
         """
@@ -194,31 +203,31 @@ class MultiTenantSessionManager:
             if session_id not in self._sessions:
                 _log.warning("Session not found")
                 return False
-            
+
             session = self._sessions[session_id]
             api_key_hash = self._hash_api_key(api_key)
-            
+
             if session.api_key_hash != api_key_hash:
                 _log.error("API key validation failed!")
                 return False
-            
+
             # Update access time
             session.update_access()
             return True
-    
+
     def get_session(self, session_id: str) -> Optional[Session]:
         """Get a session by ID."""
         with self._lock:
             return self._sessions.get(session_id)
-    
+
     def start_request(self, session_id: str, request_id: str) -> bool:
         """
         Mark a request as active in a session.
-        
+
         Args:
             session_id: The session ID
             request_id: Unique request identifier
-            
+
         Returns:
             True if successful, False if session not found
         """
@@ -229,18 +238,18 @@ class MultiTenantSessionManager:
             )
             if session_id not in self._sessions:
                 return False
-            
+
             session = self._sessions[session_id]
             session.active_requests.add(request_id)
             session.update_access()
-            
+
             _log.debug("Started request %s...", get_session_prefix_from_session(request_id) or request_id)
             return True
-    
+
     def end_request(self, session_id: str, request_id: str):
         """
         Mark a request as completed in a session.
-        
+
         Args:
             session_id: The session ID
             request_id: Unique request identifier
@@ -254,11 +263,11 @@ class MultiTenantSessionManager:
                 session = self._sessions[session_id]
                 session.active_requests.discard(request_id)
                 _log.debug("Ended request %s...", get_session_prefix_from_session(request_id) or request_id)
-    
+
     def cleanup_session(self, session_id: str):
         """
         Explicitly cleanup a session.
-        
+
         Args:
             session_id: The session ID to cleanup
         """
@@ -269,9 +278,9 @@ class MultiTenantSessionManager:
             )
             if session_id not in self._sessions:
                 return
-            
+
             session = self._sessions[session_id]
-            
+
             # Check for active requests
             if session.active_requests:
                 _log.warning(
@@ -279,57 +288,59 @@ class MultiTenantSessionManager:
                     get_session_prefix_from_session(session_id),
                     len(session.active_requests),
                 )
-            
+
             # Remove from api_key_sessions
             self._api_key_sessions[session.api_key_hash].discard(session_id)
             if not self._api_key_sessions[session.api_key_hash]:
                 del self._api_key_sessions[session.api_key_hash]
-            
+
             # Remove session
             del self._sessions[session_id]
-            
+
             _log.info(
                 "Cleaned up session %s... (requests: %s)",
                 get_session_prefix_from_session(session_id),
                 session.request_count,
             )
-    
+
     def _cleanup_api_key_sessions(self, api_key_hash: str):
         """Cleanup old sessions for a specific API key."""
         with self._lock:
             session_ids = list(self._api_key_sessions[api_key_hash])
-            now = datetime.now()
-            
+            datetime.now()
+
             # Sort by last accessed time
             sessions_by_age = sorted(
                 [(sid, self._sessions[sid]) for sid in session_ids if sid in self._sessions],
-                key=lambda x: x[1].last_accessed
+                key=lambda x: x[1].last_accessed,
             )
-            
+
             # Remove oldest sessions until we're under the limit
             while len(sessions_by_age) > self._max_sessions_per_key - 1:
                 old_session_id, _ = sessions_by_age.pop(0)
                 self.cleanup_session(old_session_id)
-    
+
     def _cleanup_expired_sessions(self):
         """Cleanup expired sessions based on TTL."""
         with self._lock:
             now = datetime.now()
             ttl_delta = timedelta(seconds=self._session_ttl)
-            
+
             expired_sessions = [
-                sid for sid, session in self._sessions.items()
+                sid
+                for sid, session in self._sessions.items()
                 if (now - session.last_accessed) > ttl_delta and not session.active_requests
             ]
-            
+
             for session_id in expired_sessions:
                 self.cleanup_session(session_id)
-            
+
             if expired_sessions:
                 logger.info(f"Cleaned up {len(expired_sessions)} expired sessions")
-    
+
     def _start_cleanup_task(self):
         """Start the background cleanup task."""
+
         def cleanup_loop():
             while True:
                 try:
@@ -337,26 +348,26 @@ class MultiTenantSessionManager:
                     self._cleanup_expired_sessions()
                 except Exception as e:
                     logger.error(f"Error in cleanup task: {e}")
-        
+
         import threading
+
         self._cleanup_thread = threading.Thread(target=cleanup_loop, daemon=True)
         self._cleanup_thread.start()
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get session manager statistics."""
         with self._lock:
             total_sessions = len(self._sessions)
             unique_api_keys = len(self._api_key_sessions)
             active_requests = sum(len(s.active_requests) for s in self._sessions.values())
-            
+
             return {
                 "total_sessions": total_sessions,
                 "unique_api_keys": unique_api_keys,
                 "active_requests": active_requests,
                 "session_ttl_seconds": self._session_ttl,
-                "max_sessions_per_key": self._max_sessions_per_key
+                "max_sessions_per_key": self._max_sessions_per_key,
             }
-    
 
 
 # Global session manager instance
@@ -380,7 +391,7 @@ def get_session_manager() -> MultiTenantSessionManager:
         except Exception:
             # Server-side logging has already occurred; surface opaque message upward
             raise RuntimeError("Unable to initialize _session_manager")
-        
+
     return _session_manager
 
 

--- a/src/wandb_mcp_server/trace_utils.py
+++ b/src/wandb_mcp_server/trace_utils.py
@@ -46,9 +46,7 @@ def truncate_value(value: Any, max_length: int = 200) -> Any:
         try:
             # Handle special case for inputs/outputs that might have complex object references
             if "__type__" in value or "_type" in value:
-                logger.info(
-                    f"Found potential complex object: {value.get('__type__') or value.get('_type')}"
-                )
+                logger.info(f"Found potential complex object: {value.get('__type__') or value.get('_type')}")
                 # For very small max_length, return empty dict to ensure proper truncation tests pass
                 if max_length < 50:
                     return {}
@@ -70,11 +68,7 @@ def truncate_value(value: Any, max_length: int = 200) -> Any:
     # For datetime objects and other non-JSON serializable types, convert to string
     elif not isinstance(value, (int, float, bool)):
         try:
-            return (
-                str(value)[:max_length] + "..."
-                if len(str(value)) > max_length
-                else str(value)
-            )
+            return str(value)[:max_length] + "..." if len(str(value)) > max_length else str(value)
         except Exception as e:
             logger.warning(f"Error converting value to string: {e}, returning None")
             return None
@@ -107,9 +101,7 @@ def calculate_token_counts(traces: List[Dict]) -> Dict[str, int]:
         "total_tokens": total_tokens,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
-        "average_tokens_per_trace": round(total_tokens / len(traces), 2)
-        if traces
-        else 0,
+        "average_tokens_per_trace": round(total_tokens / len(traces), 2) if traces else 0,
     }
 
 
@@ -173,9 +165,7 @@ def extract_op_name_distribution(traces: List[Dict]) -> Dict[str, int]:
     return dict(sorted(op_counts.items(), key=lambda x: x[1], reverse=True))
 
 
-def process_traces(
-    traces: List[Dict], truncate_length: int = 200, return_full_data: bool = False
-) -> Dict[str, Any]:
+def process_traces(traces: List[Dict], truncate_length: int = 200, return_full_data: bool = False) -> Dict[str, Any]:
     """Process traces and generate metadata."""
     # Add debug logging
     logger = get_rich_logger(__name__)
@@ -203,10 +193,7 @@ def process_traces(
     # Log before truncation
     logger.info(f"Truncating {len(traces)} traces to length {truncate_length}")
 
-    truncated_traces = [
-        {k: truncate_value(v, truncate_length) for k, v in trace.items()}
-        for trace in traces
-    ]
+    truncated_traces = [{k: truncate_value(v, truncate_length) for k, v in trace.items()} for trace in traces]
 
     # Log after truncation
     logger.info(f"After truncation: {len(truncated_traces)} traces")

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -64,6 +64,7 @@ def get_rich_logger(
         show_path=False,
         markup=True,
     )
+
     # Inject session prefix into message if provided via LoggerAdapter extra
     class _SessionPrefixInjectFilter(logging.Filter):
         def filter(self, record: logging.LogRecord) -> bool:
@@ -92,9 +93,7 @@ def get_rich_logger(
         env_level_value = os.environ.get(env_var_name)
         if env_level_value:
             effective_level_str = env_level_value.upper()
-            source_of_level = (
-                f"environment variable '{env_var_name}' ('{env_level_value}')"
-            )
+            source_of_level = f"environment variable '{env_var_name}' ('{env_level_value}')"
 
     # Attempt to convert the string to a logging level integer
     final_log_level = getattr(logging, effective_level_str, None)
@@ -107,19 +106,11 @@ def get_rich_logger(
         ]
 
         # Check if the issue was with an environment variable and if the original default_level_str is valid
-        if (
-            env_var_name
-            and os.environ.get(env_var_name)
-            and effective_level_str != default_level_str.upper()
-        ):
-            fallback_to_default_level = getattr(
-                logging, default_level_str.upper(), None
-            )
+        if env_var_name and os.environ.get(env_var_name) and effective_level_str != default_level_str.upper():
+            fallback_to_default_level = getattr(logging, default_level_str.upper(), None)
             if isinstance(fallback_to_default_level, int):
                 final_log_level = fallback_to_default_level
-                warning_msg_parts.append(
-                    f"Falling back to function default '{default_level_str.upper()}'."
-                )
+                warning_msg_parts.append(f"Falling back to function default '{default_level_str.upper()}'.")
             else:  # Function default is also bad, use hardcoded INFO
                 final_log_level = logging.INFO
                 warning_msg_parts.append(
@@ -145,32 +136,22 @@ utils_logger = get_rich_logger(__name__)
 class ServerMCPArgs:
     """Arguments for the Weave MCP Server."""
 
-    wandb_api_key: Optional[str] = field(
-        default=None, metadata=dict(help="Weights & Biases API key")
-    )
+    wandb_api_key: Optional[str] = field(default=None, metadata=dict(help="Weights & Biases API key"))
     weave_entity: Optional[str] = field(
         default=None,
-        metadata=dict(
-            help="The Weights & Biases entity to log traced MCP server calls to"
-        ),
+        metadata=dict(help="The Weights & Biases entity to log traced MCP server calls to"),
     )
     weave_project: Optional[str] = field(
         default="weave-mcp-server",
-        metadata=dict(
-            help="The Weights & Biases project to log traced MCP server calls to"
-        ),
+        metadata=dict(help="The Weights & Biases project to log traced MCP server calls to"),
     )
     transport: str = field(
         default="stdio",
-        metadata=dict(
-            help="Transport type: 'stdio' for local MCP client communication or 'http' for HTTP server"
-        ),
+        metadata=dict(help="Transport type: 'stdio' for local MCP client communication or 'http' for HTTP server"),
     )
     port: Optional[int] = field(
         default=None,
-        metadata=dict(
-            help="Port to run the HTTP server on. Defaults to 8080 when using HTTP transport."
-        ),
+        metadata=dict(help="Port to run the HTTP server on. Defaults to 8080 when using HTTP transport."),
     )
     host: str = field(
         default="localhost",
@@ -277,16 +258,10 @@ def merge_metadata(metadata_list: List[Dict]) -> Dict:
         # Update time range
         time_range = metadata.get("time_range", {})
         if time_range.get("earliest"):
-            if (
-                not merged["time_range"]["earliest"]
-                or time_range["earliest"] < merged["time_range"]["earliest"]
-            ):
+            if not merged["time_range"]["earliest"] or time_range["earliest"] < merged["time_range"]["earliest"]:
                 merged["time_range"]["earliest"] = time_range["earliest"]
         if time_range.get("latest"):
-            if (
-                not merged["time_range"]["latest"]
-                or time_range["latest"] > merged["time_range"]["latest"]
-            ):
+            if not merged["time_range"]["latest"] or time_range["latest"] > merged["time_range"]["latest"]:
                 merged["time_range"]["latest"] = time_range["latest"]
 
         # Sum up status counts
@@ -311,9 +286,7 @@ def merge_metadata(metadata_list: List[Dict]) -> Dict:
 def get_git_commit():
     logger = get_rich_logger(__name__)
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "HEAD"], capture_output=True, text=True
-        )
+        result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
         return str(result.stdout.strip())[:8]
     except Exception as e:
         logger.warning(f"Failed to get git commit: {e}")

--- a/src/wandb_mcp_server/weave_api/client.py
+++ b/src/wandb_mcp_server/weave_api/client.py
@@ -13,7 +13,7 @@ import requests
 from requests.exceptions import RetryError
 
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.config import WF_TRACE_SERVER_URL
+from wandb_mcp_server.config import WF_TRACE_SERVER_URL, WANDB_BASE_URL
 
 logger = get_rich_logger(__name__)
 
@@ -32,7 +32,7 @@ class WeaveApiClient:
 
         Args:
             api_key: API key for authentication. If None, try to get from environment.
-            server_url: Weave API server URL. Defaults to 'https://trace.wandb.ai'.
+            server_url: Weave API server URL. Defaults to auto-detected URL.
             retries: Number of retries for failed requests.
             timeout: Request timeout in seconds.
 
@@ -56,6 +56,11 @@ class WeaveApiClient:
         self.server_url = server_url or WF_TRACE_SERVER_URL
         self.retries = retries
         self.timeout = timeout
+
+        logger.info(
+            f"WeaveApiClient initialized: trace_server={self.server_url}, "
+            f"wandb_base_url={WANDB_BASE_URL}"
+        )
 
     def _get_auth_headers(self) -> Dict[str, str]:
         """Get authentication headers for the Weave API.
@@ -120,8 +125,18 @@ class WeaveApiClient:
             if isinstance(e, RetryError):
                 cause = e.__cause__
                 if cause and hasattr(cause, "reason"):
-                    logger.error(f"Specific reason for retry exhaustion: {cause.reason}")
-            raise Exception(f"Failed to query Weave traces due to network error: {e}")
+                    logger.error(
+                        f"Specific reason for retry exhaustion: {cause.reason}"
+                    )
+            raise Exception(
+                f"Failed to query Weave traces due to network error: {e}\n"
+                f"Trace server URL: {self.server_url}\n"
+                f"W&B base URL: {WANDB_BASE_URL}\n"
+                f"If you are using a dedicated/on-prem W&B instance, ensure "
+                f"WANDB_BASE_URL is set correctly. The trace server URL is "
+                f"auto-detected as {{WANDB_BASE_URL}}/traces for non-SaaS deployments. "
+                f"You can override it explicitly with WF_TRACE_SERVER_URL."
+            )
         except json.JSONDecodeError as e:
             logger.error(f"Error decoding JSON from Weave server: {e}")
             raise Exception(f"Failed to parse Weave API response: {e}")

--- a/src/wandb_mcp_server/weave_api/client.py
+++ b/src/wandb_mcp_server/weave_api/client.py
@@ -7,7 +7,6 @@ It handles authentication, request construction, and response parsing.
 
 import base64
 import json
-import os
 from typing import Any, Dict, Iterator, Optional
 
 import requests
@@ -46,12 +45,11 @@ class WeaveApiClient:
         # NO FALLBACKS! API key must be explicitly provided
         # For HTTP: Comes from auth middleware via TraceService
         # For STDIO: Set at server startup via TraceService
-        
+
         # Validate API key
         if not api_key:
             raise ValueError(
-                "API key not provided to WeaveApiClient. "
-                "API key must be explicitly passed from TraceService."
+                "API key not provided to WeaveApiClient. API key must be explicitly passed from TraceService."
             )
 
         self.api_key = api_key
@@ -87,9 +85,7 @@ class WeaveApiClient:
         url = f"{self.server_url}/calls/stream_query"
         headers = self._get_auth_headers()
 
-        logger.info(
-            f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n"
-        )
+        logger.info(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
         logger.debug(f"Full query parameters:\n{json.dumps(query_params, indent=2)}\n")
 
         try:
@@ -119,15 +115,12 @@ class WeaveApiClient:
 
         except requests.RequestException as e:
             logger.error(
-                f"Error executing HTTP request to Weave server: {e}. "
-                f"Request body snippet: {str(query_params)[:1000]}"
+                f"Error executing HTTP request to Weave server: {e}. Request body snippet: {str(query_params)[:1000]}"
             )
             if isinstance(e, RetryError):
                 cause = e.__cause__
                 if cause and hasattr(cause, "reason"):
-                    logger.error(
-                        f"Specific reason for retry exhaustion: {cause.reason}"
-                    )
+                    logger.error(f"Specific reason for retry exhaustion: {cause.reason}")
             raise Exception(f"Failed to query Weave traces due to network error: {e}")
         except json.JSONDecodeError as e:
             logger.error(f"Error decoding JSON from Weave server: {e}")

--- a/src/wandb_mcp_server/weave_api/models.py
+++ b/src/wandb_mcp_server/weave_api/models.py
@@ -113,6 +113,7 @@ class TraceMetadata(BaseModel):
     time_range: Dict[str, Optional[datetime]] = Field(default_factory=dict)
     status_summary: Dict[str, int] = Field(default_factory=dict)
     op_distribution: Dict[str, int] = Field(default_factory=dict)
+    truncation_warning: Optional[str] = None
 
 
 class WeaveTrace(BaseModel):

--- a/src/wandb_mcp_server/weave_api/processors.py
+++ b/src/wandb_mcp_server/weave_api/processors.py
@@ -273,6 +273,115 @@ class TraceProcessor:
         # Sort by count in descending order
         return dict(sorted(op_counts.items(), key=lambda x: x[1], reverse=True))
 
+    # Field priority tiers for semantic-aware truncation.
+    # HIGH: small fields that carry the most diagnostic value.
+    # MEDIUM: structured metadata; useful but can be summarised.
+    # LOW: large payloads (inputs/output) that dominate token count.
+    HIGH_SIGNAL_FIELDS: set = {
+        "id", "op_name", "display_name", "trace_id", "parent_id",
+        "started_at", "ended_at", "status", "latency_ms", "exception",
+    }
+    MEDIUM_SIGNAL_FIELDS: set = {
+        "attributes", "summary", "costs", "feedback",
+        "wb_run_id", "wb_user_id", "project_id", "deleted_at",
+    }
+    LOW_SIGNAL_FIELDS: set = {"inputs", "output"}
+
+    @classmethod
+    def estimate_tokens(cls, text: str) -> int:
+        """Cheap token estimate: 1 token ~ 4 chars of JSON."""
+        return max(1, len(text) // 4)
+
+    @classmethod
+    def _trace_to_dict(cls, trace: Any) -> dict:
+        """Normalise a trace (Pydantic model or dict) to a plain dict."""
+        if hasattr(trace, "model_dump"):
+            return trace.model_dump()
+        if isinstance(trace, dict):
+            return trace.copy()
+        return trace
+
+    @classmethod
+    def enforce_token_budget(
+        cls,
+        result_json: str,
+        traces: List[Any],
+        budget: int,
+    ) -> tuple:
+        """Progressively truncate *traces* until they fit within *budget* tokens.
+
+        Uses a **semantic-aware** strategy that preserves the most diagnostically
+        valuable fields first, per Nico's review feedback.
+
+        Levels:
+          L0 -- Under budget: return as-is.
+          L1 -- Truncate LOW_SIGNAL fields (inputs, output) to 100 chars.
+          L2 -- Drop LOW_SIGNAL fields entirely; truncate MEDIUM_SIGNAL to 200 chars.
+          L3 -- Keep only HIGH_SIGNAL fields (compact diagnostic view).
+          L4 -- Sample every Nth trace, HIGH_SIGNAL only.
+
+        Returns:
+            ``(truncated_traces, warning_message | None, applied_level)``
+        """
+        est = cls.estimate_tokens(result_json)
+        if est <= budget:
+            return traces, None, 0
+
+        dicts = [cls._trace_to_dict(t) for t in traces]
+        warnings: list[str] = []
+
+        def _est(data: list) -> int:
+            return cls.estimate_tokens(
+                json.dumps(data, cls=DateTimeEncoder, default=str)
+            )
+
+        # L1: truncate LOW_SIGNAL to 100 chars, leave HIGH/MEDIUM intact
+        l1 = []
+        for d in dicts:
+            row = {}
+            for k, v in d.items():
+                if k in cls.LOW_SIGNAL_FIELDS:
+                    row[k] = cls.truncate_value(v, 100)
+                else:
+                    row[k] = v
+            l1.append(row)
+        if _est(l1) <= budget:
+            warnings.append(
+                "Inputs/output truncated to 100 chars (high-signal fields preserved)."
+            )
+            return l1, " ".join(warnings), 1
+
+        # L2: drop LOW_SIGNAL entirely, truncate MEDIUM_SIGNAL to 200 chars
+        l2 = []
+        for row in l1:
+            filtered = {}
+            for k, v in row.items():
+                if k in cls.LOW_SIGNAL_FIELDS:
+                    continue
+                if k in cls.MEDIUM_SIGNAL_FIELDS:
+                    filtered[k] = cls.truncate_value(v, 200)
+                else:
+                    filtered[k] = v
+            l2.append(filtered)
+        warnings.append("Dropped inputs/output; medium-signal fields truncated.")
+        if _est(l2) <= budget:
+            return l2, " ".join(warnings), 2
+
+        # L3: keep only HIGH_SIGNAL fields
+        l3 = [
+            {k: v for k, v in row.items() if k in cls.HIGH_SIGNAL_FIELDS}
+            for row in l2
+        ]
+        warnings.append("Kept only high-signal diagnostic fields.")
+        if _est(l3) <= budget:
+            return l3, " ".join(warnings), 3
+
+        # L4: sample every Nth trace (HIGH_SIGNAL only)
+        n = max(2, len(l3) // max(1, budget // max(1, _est(l3[:1]))))
+        l4 = l3[::n]
+        warnings.append(f"Sampled {len(l4)} of {len(traces)} traces.")
+        return l4, " ".join(warnings), 4
+
     @classmethod
     def process_traces(
         cls,
@@ -417,15 +526,40 @@ class TraceProcessor:
                     # Keep the original dictionary if conversion fails
                     converted_traces.append(trace)
 
-            return QueryResult(metadata=metadata, traces=converted_traces)
+            result = QueryResult(metadata=metadata, traces=converted_traces)
         except ImportError:
-            # If WeaveTrace can't be imported for some reason, return dicts
             logger.warning("Could not import WeaveTrace model, returning dictionaries")
-            return QueryResult(metadata=metadata, traces=processed_traces)
+            result = QueryResult(metadata=metadata, traces=processed_traces)
         except Exception as e:
-            # If there's any other error in conversion, return dictionaries
             logger.warning(f"Error converting traces to WeaveTrace: {e}")
-            return QueryResult(metadata=metadata, traces=processed_traces)
+            result = QueryResult(metadata=metadata, traces=processed_traces)
+
+        # Enforce token budget -- semantic-aware progressive truncation (MCP-6)
+        from wandb_mcp_server.config import MAX_RESPONSE_TOKENS
+
+        try:
+            result_json = result.model_dump_json()
+            est_tokens = cls.estimate_tokens(result_json)
+            if est_tokens > MAX_RESPONSE_TOKENS and result.traces:
+                logger.warning(
+                    f"Response exceeds token budget ({est_tokens} > {MAX_RESPONSE_TOKENS}). "
+                    f"Applying semantic-aware truncation."
+                )
+                truncated, warning_msg, level = cls.enforce_token_budget(
+                    result_json, result.traces, MAX_RESPONSE_TOKENS
+                )
+                if warning_msg:
+                    note = (
+                        f"NOTE: Response truncated to fit {MAX_RESPONSE_TOKENS} token budget "
+                        f"(level {level}). {warning_msg} "
+                        f"Narrow your query with filters or request fewer traces for full data."
+                    )
+                    result.metadata.truncation_warning = note
+                    result = QueryResult(metadata=result.metadata, traces=truncated)
+        except Exception as e:
+            logger.warning(f"Token budget enforcement failed (non-fatal): {e}")
+
+        return result
 
     @staticmethod
     def get_cost(trace: Dict[str, Any], which_cost: str) -> float:

--- a/src/wandb_mcp_server/weave_api/processors.py
+++ b/src/wandb_mcp_server/weave_api/processors.py
@@ -62,27 +62,20 @@ class TraceProcessor:
         # Regular truncation for non-zero max_length
         if isinstance(value, str):
             if len(value) > max_length:
-                logger.debug(
-                    f"Truncating string of length {len(value)} to {max_length}"
-                )
+                logger.debug(f"Truncating string of length {len(value)} to {max_length}")
             return value[:max_length] + "..." if len(value) > max_length else value
         elif isinstance(value, dict):
             try:
                 # Handle special case for inputs/outputs that might have complex object references
                 if "__type__" in value or "_type" in value:
-                    logger.info(
-                        f"Found potential complex object: {value.get('__type__') or value.get('_type')}"
-                    )
+                    logger.info(f"Found potential complex object: {value.get('__type__') or value.get('_type')}")
                     # For very small max_length, return empty dict to ensure proper truncation tests pass
                     if max_length < 50:
                         return {}
                     # Otherwise, convert to a simplified representation
                     return {"type": value.get("__type__") or value.get("_type")}
 
-                result = {
-                    k: TraceProcessor.truncate_value(v, max_length)
-                    for k, v in value.items()
-                }
+                result = {k: TraceProcessor.truncate_value(v, max_length) for k, v in value.items()}
                 return result
             except Exception as e:
                 logger.warning(f"Error truncating dict: {e}, returning empty dict")
@@ -97,11 +90,7 @@ class TraceProcessor:
         # For datetime objects and other non-JSON serializable types, convert to string
         elif not isinstance(value, (int, float, bool)):
             try:
-                return (
-                    str(value)[:max_length] + "..."
-                    if len(str(value)) > max_length
-                    else str(value)
-                )
+                return str(value)[:max_length] + "..." if len(str(value)) > max_length else str(value)
             except Exception as e:
                 logger.warning(f"Error converting value to string: {e}, returning None")
                 return None
@@ -121,9 +110,7 @@ class TraceProcessor:
             encoding = tiktoken.get_encoding("cl100k_base")  # Using OpenAI's encoding
             return len(encoding.encode(text))
         except Exception as e:
-            logger.warning(
-                f"Error counting tokens with tiktoken: {e}, falling back to approximation"
-            )
+            logger.warning(f"Error counting tokens with tiktoken: {e}, falling back to approximation")
             # Fallback to approximate token count if tiktoken fails
             return len(text.split())
 
@@ -170,9 +157,7 @@ class TraceProcessor:
             "total_tokens": total_tokens,
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
-            "average_tokens_per_trace": round(total_tokens / len(traces), 2)
-            if traces
-            else 0,
+            "average_tokens_per_trace": round(total_tokens / len(traces), 2) if traces else 0,
         }
 
     @staticmethod
@@ -384,16 +369,10 @@ class TraceProcessor:
                 for trace in traces:
                     if hasattr(trace, "model_dump"):  # Pydantic model
                         trace_dict = trace.model_dump()
-                        processed_trace = {
-                            k: cls.truncate_value(v, truncate_length)
-                            for k, v in trace_dict.items()
-                        }
+                        processed_trace = {k: cls.truncate_value(v, truncate_length) for k, v in trace_dict.items()}
                         processed_traces.append(processed_trace)
                     elif isinstance(trace, dict):  # Dict
-                        processed_trace = {
-                            k: cls.truncate_value(v, truncate_length)
-                            for k, v in trace.items()
-                        }
+                        processed_trace = {k: cls.truncate_value(v, truncate_length) for k, v in trace.items()}
                         processed_traces.append(processed_trace)
 
             # Log after truncation
@@ -418,22 +397,14 @@ class TraceProcessor:
                 if "started_at" in trace and isinstance(trace["started_at"], str):
                     try:
                         # Try to parse ISO format string
-                        trace["started_at"] = datetime.fromisoformat(
-                            trace["started_at"].replace("Z", "+00:00")
-                        )
+                        trace["started_at"] = datetime.fromisoformat(trace["started_at"].replace("Z", "+00:00"))
                     except (ValueError, TypeError):
                         # If parsing fails, use current time
                         trace["started_at"] = datetime.now()
 
-                if (
-                    "ended_at" in trace
-                    and trace["ended_at"]
-                    and isinstance(trace["ended_at"], str)
-                ):
+                if "ended_at" in trace and trace["ended_at"] and isinstance(trace["ended_at"], str):
                     try:
-                        trace["ended_at"] = datetime.fromisoformat(
-                            trace["ended_at"].replace("Z", "+00:00")
-                        )
+                        trace["ended_at"] = datetime.fromisoformat(trace["ended_at"].replace("Z", "+00:00"))
                     except (ValueError, TypeError):
                         trace["ended_at"] = None
 
@@ -442,9 +413,7 @@ class TraceProcessor:
                     converted_trace = WeaveTrace(**trace)
                     converted_traces.append(converted_trace)
                 except Exception as e:
-                    logger.warning(
-                        f"Failed to convert trace {trace.get('id')} to WeaveTrace: {e}"
-                    )
+                    logger.warning(f"Failed to convert trace {trace.get('id')} to WeaveTrace: {e}")
                     # Keep the original dictionary if conversion fails
                     converted_traces.append(trace)
 
@@ -534,9 +503,7 @@ class TraceProcessor:
         return None
 
     @classmethod
-    def synthesize_fields(
-        cls, trace: Dict[str, Any], requested_fields: List[str]
-    ) -> Dict[str, Any]:
+    def synthesize_fields(cls, trace: Dict[str, Any], requested_fields: List[str]) -> Dict[str, Any]:
         """Synthesize additional fields in a trace.
 
         Args:

--- a/src/wandb_mcp_server/weave_api/processors.py
+++ b/src/wandb_mcp_server/weave_api/processors.py
@@ -335,6 +335,17 @@ class TraceProcessor:
                 json.dumps(data, cls=DateTimeEncoder, default=str)
             )
 
+        # Estimate per-category token sizes for informative warnings
+        low_signal_tokens = 0
+        medium_signal_tokens = 0
+        for d in dicts:
+            for k, v in d.items():
+                v_est = cls.estimate_tokens(json.dumps(v, cls=DateTimeEncoder, default=str)) if v else 0
+                if k in cls.LOW_SIGNAL_FIELDS:
+                    low_signal_tokens += v_est
+                elif k in cls.MEDIUM_SIGNAL_FIELDS:
+                    medium_signal_tokens += v_est
+
         # L1: truncate LOW_SIGNAL to 100 chars, leave HIGH/MEDIUM intact
         l1 = []
         for d in dicts:
@@ -345,9 +356,12 @@ class TraceProcessor:
                 else:
                     row[k] = v
             l1.append(row)
-        if _est(l1) <= budget:
+        l1_est = _est(l1)
+        if l1_est <= budget:
             warnings.append(
-                "Inputs/output truncated to 100 chars (high-signal fields preserved)."
+                f"L1: inputs/output shortened to 100 chars "
+                f"(saved ~{est - l1_est} tokens from LOW_SIGNAL fields). "
+                f"Tip: request specific columns=['id','op_name','status','latency_ms'] to avoid truncation."
             )
             return l1, " ".join(warnings), 1
 
@@ -363,8 +377,13 @@ class TraceProcessor:
                 else:
                     filtered[k] = v
             l2.append(filtered)
-        warnings.append("Dropped inputs/output; medium-signal fields truncated.")
-        if _est(l2) <= budget:
+        l2_est = _est(l2)
+        warnings.append(
+            f"L2: dropped inputs/output (~{low_signal_tokens} tokens), "
+            f"trimmed attributes/summary/costs (~{medium_signal_tokens} tokens). "
+            f"Use metadata_only=True first to estimate response size before querying."
+        )
+        if l2_est <= budget:
             return l2, " ".join(warnings), 2
 
         # L3: keep only HIGH_SIGNAL fields
@@ -372,14 +391,22 @@ class TraceProcessor:
             {k: v for k, v in row.items() if k in cls.HIGH_SIGNAL_FIELDS}
             for row in l2
         ]
-        warnings.append("Kept only high-signal diagnostic fields.")
-        if _est(l3) <= budget:
+        l3_est = _est(l3)
+        warnings.append(
+            f"L3: kept only HIGH_SIGNAL fields "
+            f"(id, op_name, status, latency_ms, exception, timestamps). "
+            f"Re-query with filters or smaller limit for full trace data."
+        )
+        if l3_est <= budget:
             return l3, " ".join(warnings), 3
 
         # L4: sample every Nth trace (HIGH_SIGNAL only)
         n = max(2, len(l3) // max(1, budget // max(1, _est(l3[:1]))))
         l4 = l3[::n]
-        warnings.append(f"Sampled {len(l4)} of {len(traces)} traces.")
+        warnings.append(
+            f"L4: sampled {len(l4)} of {len(traces)} traces (every {n}th). "
+            f"Add time_range, status, or op_name_contains filters to reduce result set."
+        )
         return l4, " ".join(warnings), 4
 
     @classmethod

--- a/src/wandb_mcp_server/weave_api/query_builder.py
+++ b/src/wandb_mcp_server/weave_api/query_builder.py
@@ -89,15 +89,11 @@ class QueryBuilder:
             if field_name.startswith("attributes."):
                 # For general attributes, convert to double if comparing with a number
                 if isinstance(value, (int, float)):
-                    field_op = ConvertOperation(
-                        **{"$convert": {"input": field_op_base, "to": "double"}}
-                    )
+                    field_op = ConvertOperation(**{"$convert": {"input": field_op_base, "to": "double"}})
 
             literal_op = LiteralOperation(**{"$literal": value})
         except Exception as e:
-            logger.warning(
-                f"Invalid value for {field_name} comparison {operator}: {value}. Error: {e}"
-            )
+            logger.warning(f"Invalid value for {field_name} comparison {operator}: {value}. Error: {e}")
             return None
 
         if operator == FilterOperator.GREATER_THAN:
@@ -113,9 +109,7 @@ class QueryBuilder:
             gt_op = GtOperation(**{"$gt": (field_op, literal_op)})
             return NotOperation(**{"$not": [gt_op]})
         else:
-            logger.warning(
-                f"Unsupported comparison operator '{operator}' for {field_name}"
-            )
+            logger.warning(f"Unsupported comparison operator '{operator}' for {field_name}")
             return None
 
     @classmethod
@@ -176,9 +170,7 @@ class QueryBuilder:
                         )
                     )
             elif hasattr(op_name, "pattern"):  # Regex pattern
-                operations.append(
-                    cls.create_contains_operation("op_name", op_name.pattern)
-                )
+                operations.append(cls.create_contains_operation("op_name", op_name.pattern))
 
         # Handle op_name_contains custom filter (for simple substring matching)
         if "op_name_contains" in filters:
@@ -193,9 +185,7 @@ class QueryBuilder:
                 if "*" in display_name or ".*" in display_name:
                     # Extract the part between wildcards
                     pattern = display_name.replace("*", "").replace(".*", "")
-                    operations.append(
-                        cls.create_contains_operation("display_name", pattern)
-                    )
+                    operations.append(cls.create_contains_operation("display_name", pattern))
                 else:
                     # Exact match
                     operations.append(
@@ -209,9 +199,7 @@ class QueryBuilder:
                         )
                     )
             elif hasattr(display_name, "pattern"):  # Regex pattern
-                operations.append(
-                    cls.create_contains_operation("display_name", display_name.pattern)
-                )
+                operations.append(cls.create_contains_operation("display_name", display_name.pattern))
 
         # Handle display_name_contains custom filter (for simple substring matching)
         if "display_name_contains" in filters:
@@ -228,9 +216,7 @@ class QueryBuilder:
                 if comp_op:
                     operations.append(comp_op)
             else:
-                logger.warning(
-                    f"Invalid status filter value: {target_status}. Expected a string."
-                )
+                logger.warning(f"Invalid status filter value: {target_status}. Expected a string.")
 
         # Handle time range filter (convert ISO datetime strings to Unix seconds)
         if "time_range" in filters:
@@ -240,9 +226,7 @@ class QueryBuilder:
             if "start" in time_range and time_range["start"]:
                 start_ts = cls.datetime_to_timestamp(time_range["start"])
                 if start_ts > 0:
-                    comp_op = cls.create_comparison_operation(
-                        "started_at", FilterOperator.GREATER_THAN_EQUAL, start_ts
-                    )
+                    comp_op = cls.create_comparison_operation("started_at", FilterOperator.GREATER_THAN_EQUAL, start_ts)
                     if comp_op:
                         operations.append(comp_op)
 
@@ -250,9 +234,7 @@ class QueryBuilder:
             if "end" in time_range and time_range["end"]:
                 end_ts = cls.datetime_to_timestamp(time_range["end"])
                 if end_ts > 0:
-                    comp_op = cls.create_comparison_operation(
-                        "started_at", FilterOperator.LESS_THAN, end_ts
-                    )
+                    comp_op = cls.create_comparison_operation("started_at", FilterOperator.LESS_THAN, end_ts)
                     if comp_op:
                         operations.append(comp_op)
 
@@ -261,15 +243,9 @@ class QueryBuilder:
             run_id = filters["wb_run_id"]
             # This filter expects a string for wb_run_id and uses $contains or $eq.
             if isinstance(run_id, str):
-                if (
-                    "$contains" in run_id or "*" in run_id
-                ):  # Simple check for contains style
-                    pattern = run_id.replace("$contains:", "").replace(
-                        "*", ""
-                    )  # Basic cleanup
-                    operations.append(
-                        cls.create_contains_operation("wb_run_id", pattern.strip())
-                    )
+                if "$contains" in run_id or "*" in run_id:  # Simple check for contains style
+                    pattern = run_id.replace("$contains:", "").replace("*", "")  # Basic cleanup
+                    operations.append(cls.create_contains_operation("wb_run_id", pattern.strip()))
                 else:
                     operations.append(
                         EqOperation(
@@ -281,22 +257,14 @@ class QueryBuilder:
                             }
                         )
                     )
-            elif (
-                isinstance(run_id, dict) and "$contains" in run_id
-            ):  # wb_run_id: {"$contains": "foo"}
+            elif isinstance(run_id, dict) and "$contains" in run_id:  # wb_run_id: {"$contains": "foo"}
                 pattern = run_id["$contains"]
                 if isinstance(pattern, str):
-                    operations.append(
-                        cls.create_contains_operation("wb_run_id", pattern)
-                    )
+                    operations.append(cls.create_contains_operation("wb_run_id", pattern))
                 else:
-                    logger.warning(
-                        f"Invalid $contains value for wb_run_id: {pattern}. Expected string."
-                    )
+                    logger.warning(f"Invalid $contains value for wb_run_id: {pattern}. Expected string.")
             else:
-                logger.warning(
-                    f"Invalid wb_run_id filter value: {run_id}. Expected a string or dict with $contains."
-                )
+                logger.warning(f"Invalid wb_run_id filter value: {run_id}. Expected a string or dict with $contains.")
 
         # Handle latency filter based on summary.weave.latency_ms
         if "latency" in filters:
@@ -306,9 +274,7 @@ class QueryBuilder:
                 op_key, value = next(iter(latency_filter.items()))
                 try:
                     op = FilterOperator(op_key)
-                    comp_op = cls.create_comparison_operation(
-                        "summary.weave.latency_ms", op, value
-                    )
+                    comp_op = cls.create_comparison_operation("summary.weave.latency_ms", op, value)
                     if comp_op:
                         operations.append(comp_op)
                 except (ValueError, KeyError):
@@ -329,32 +295,22 @@ class QueryBuilder:
                     if (
                         isinstance(attr_value_or_op, dict)
                         and len(attr_value_or_op) == 1
-                        and next(iter(attr_value_or_op.keys()))
-                        in [op.value for op in FilterOperator]
+                        and next(iter(attr_value_or_op.keys())) in [op.value for op in FilterOperator]
                     ):
                         # It's a comparison operation
                         op_key, value = next(iter(attr_value_or_op.items()))
                         try:
                             op = FilterOperator(op_key)
-                            comp_op = cls.create_comparison_operation(
-                                full_attr_path, op, value
-                            )
+                            comp_op = cls.create_comparison_operation(full_attr_path, op, value)
                             if comp_op:
                                 operations.append(comp_op)
                         except (ValueError, KeyError):
-                            logger.warning(
-                                f"Invalid operator for attribute filter: {op_key}"
-                            )
-                    elif (
-                        isinstance(attr_value_or_op, dict)
-                        and "$contains" in attr_value_or_op
-                    ):
+                            logger.warning(f"Invalid operator for attribute filter: {op_key}")
+                    elif isinstance(attr_value_or_op, dict) and "$contains" in attr_value_or_op:
                         # It's a contains operation
                         if isinstance(attr_value_or_op["$contains"], str):
                             operations.append(
-                                cls.create_contains_operation(
-                                    full_attr_path, attr_value_or_op["$contains"]
-                                )
+                                cls.create_contains_operation(full_attr_path, attr_value_or_op["$contains"])
                             )
                         else:
                             logger.warning(
@@ -368,9 +324,7 @@ class QueryBuilder:
                         if comp_op:
                             operations.append(comp_op)
             else:
-                logger.warning(
-                    f"Invalid format for 'attributes' filter: {attributes_filters}. Expected a dictionary."
-                )
+                logger.warning(f"Invalid format for 'attributes' filter: {attributes_filters}. Expected a dictionary.")
 
         # Handle has_exception filter (checking top-level exception field)
         if "has_exception" in filters:
@@ -407,9 +361,7 @@ class QueryBuilder:
         return None  # No complex filters, so no Query object needed
 
     @classmethod
-    def separate_filters(
-        cls, filters: Union[Dict[str, Any], QueryFilter]
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def separate_filters(cls, filters: Union[Dict[str, Any], QueryFilter]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         """Separate filters into direct and complex filters.
 
         Args:
@@ -459,9 +411,7 @@ class QueryBuilder:
 
                 # Ensure call_ids are strings
                 if key == "call_ids" and isinstance(direct_filters[key], list):
-                    direct_filters[key] = [
-                        str(call_id) for call_id in direct_filters[key]
-                    ]
+                    direct_filters[key] = [str(call_id) for call_id in direct_filters[key]]
 
         # Handle individual op_name and trace_id if op_names/trace_ids not already set
         if "op_name" in filters_dict and "op_names" not in direct_filters:
@@ -516,9 +466,7 @@ class QueryBuilder:
         return direct_filters, complex_filters
 
     @classmethod
-    def prepare_query_params(
-        cls, params: Union[QueryParams, Dict[str, Any]]
-    ) -> Dict[str, Any]:
+    def prepare_query_params(cls, params: Union[QueryParams, Dict[str, Any]]) -> Dict[str, Any]:
         """Prepare query parameters for the Weave API.
 
         Args:
@@ -600,17 +548,11 @@ class QueryBuilder:
                     filtered_columns.append(col)
 
             # If we need to synthesize status, ensure we request summary field
-            if (
-                "status" in synthetic_fields_to_add
-                and "summary" not in filtered_columns
-            ):
+            if "status" in synthetic_fields_to_add and "summary" not in filtered_columns:
                 filtered_columns.append("summary")
 
             # If we need to synthesize latency_ms, ensure we request summary field
-            if (
-                "latency_ms" in synthetic_fields_to_add
-                and "summary" not in filtered_columns
-            ):
+            if "latency_ms" in synthetic_fields_to_add and "summary" not in filtered_columns:
                 filtered_columns.append("summary")
 
             # Only send filtered columns to the API

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Set
 
-from wandb_mcp_server.utils import get_rich_logger, get_server_args
+from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.config import WF_TRACE_SERVER_URL
 from wandb_mcp_server.weave_api.client import WeaveApiClient
 from wandb_mcp_server.api_client import WandBApiManager
@@ -81,10 +81,10 @@ class TraceService:
         if api_key is None:
             # Get from context (set by auth middleware for HTTP, at startup for STDIO)
             api_key = WandBApiManager.get_api_key()
-            
+
             # NO FALLBACKS to get_server_args or environment!
             # API key must be explicitly set in context
-        
+
         # Validate we have an API key before creating client
         if not api_key:
             raise ValueError(
@@ -128,9 +128,7 @@ class TraceService:
         requested_synthetic_columns: list[str] = []
         invalid_columns_reported: set[str] = set()
 
-        processed_columns = (
-            set()
-        )  # To avoid duplicate processing if a column is listed multiple times
+        processed_columns = set()  # To avoid duplicate processing if a column is listed multiple times
 
         for col_name in columns:
             if col_name in processed_columns:
@@ -145,10 +143,7 @@ class TraceService:
                 if source_field not in filtered_columns_for_api:
                     filtered_columns_for_api.append(source_field)
                 # Also ensure 'summary' itself is added if not already, as 'summary.weave.latency_ms' implies 'summary'
-                if (
-                    "summary" not in filtered_columns_for_api
-                    and source_field.startswith("summary.")
-                ):
+                if "summary" not in filtered_columns_for_api and source_field.startswith("summary."):
                     filtered_columns_for_api.append("summary")
                 logger.info(
                     f"Column 'latency_ms' requested: will be synthesized from '{source_field}'. Added '{source_field}' to API columns."
@@ -171,9 +166,7 @@ class TraceService:
                 # If not present, it will be synthesized from summary.
                 if "status" not in filtered_columns_for_api:
                     filtered_columns_for_api.append("status")
-                if (
-                    "summary" not in filtered_columns_for_api
-                ):  # Also ensure summary for fallback
+                if "summary" not in filtered_columns_for_api:  # Also ensure summary for fallback
                     filtered_columns_for_api.append("summary")
                 logger.info(
                     "Column 'status' requested: will attempt direct fetch or synthesize from 'summary.weave.status'."
@@ -190,9 +183,7 @@ class TraceService:
                     # Valid nested field (e.g., "summary.weave.latency_ms", "attributes.foo")
                     if col_name not in filtered_columns_for_api:
                         filtered_columns_for_api.append(col_name)
-                    logger.info(
-                        f"Nested column field '{col_name}' requested, added to API columns."
-                    )
+                    logger.info(f"Nested column field '{col_name}' requested, added to API columns.")
                 else:
                     logger.warning(
                         f"Invalid base field '{base_field}' in nested column '{col_name}'. It will be ignored."
@@ -200,9 +191,7 @@ class TraceService:
                     invalid_columns_reported.add(col_name)
             else:
                 # Neither a direct valid column, nor a recognized synthetic, nor a valid-looking nested path
-                logger.warning(
-                    f"Invalid column '{col_name}' requested. It will be ignored."
-                )
+                logger.warning(f"Invalid column '{col_name}' requested. It will be ignored.")
                 invalid_columns_reported.add(col_name)
 
         # Ensure filtered_columns_for_api does not have duplicates and maintains order as much as possible
@@ -278,9 +267,7 @@ class TraceService:
             if "costs" in requested_synthetic_columns:
                 costs_data = trace.get("summary", {}).get("weave", {}).get("costs", {})
                 if costs_data:
-                    logger.debug(
-                        f"Adding synthetic 'costs' column with {len(costs_data)} providers"
-                    )
+                    logger.debug(f"Adding synthetic 'costs' column with {len(costs_data)} providers")
                     updated_trace["costs"] = costs_data
                 else:
                     logger.warning(f"No costs data found in trace {trace.get('id')}")
@@ -293,14 +280,10 @@ class TraceService:
                     # Extract from summary.weave.status
                     status = trace.get("summary", {}).get("weave", {}).get("status")
                     if status:
-                        logger.debug(
-                            f"Adding synthetic 'status' from summary: {status}"
-                        )
+                        logger.debug(f"Adding synthetic 'status' from summary: {status}")
                         updated_trace["status"] = status
                     else:
-                        logger.warning(
-                            f"No status data found in trace {trace.get('id')}"
-                        )
+                        logger.warning(f"No status data found in trace {trace.get('id')}")
                         updated_trace["status"] = None
 
             # Add latency_ms from summary if requested
@@ -308,18 +291,12 @@ class TraceService:
                 latency = trace.get("latency_ms")  # Check if it's already in the trace
                 if latency is None:
                     # Extract from summary.weave.latency_ms
-                    latency = (
-                        trace.get("summary", {}).get("weave", {}).get("latency_ms")
-                    )
+                    latency = trace.get("summary", {}).get("weave", {}).get("latency_ms")
                     if latency is not None:
-                        logger.debug(
-                            f"Adding synthetic 'latency_ms' from summary: {latency}"
-                        )
+                        logger.debug(f"Adding synthetic 'latency_ms' from summary: {latency}")
                         updated_trace["latency_ms"] = latency
                     else:
-                        logger.warning(
-                            f"No latency_ms data found in trace {trace.get('id')}"
-                        )
+                        logger.warning(f"No latency_ms data found in trace {trace.get('id')}")
                         updated_trace["latency_ms"] = None
 
             # Add warnings for invalid columns
@@ -377,9 +354,7 @@ class TraceService:
 
         # Handle latency field mapping
         if sort_by in self.LATENCY_FIELD_MAPPING:
-            logger.info(
-                f"Mapping sort field '{sort_by}' to '{self.LATENCY_FIELD_MAPPING[sort_by]}'"
-            )
+            logger.info(f"Mapping sort field '{sort_by}' to '{self.LATENCY_FIELD_MAPPING[sort_by]}'")
             server_sort_by = self.LATENCY_FIELD_MAPPING[sort_by]
             server_sort_direction = sort_direction
         elif client_side_cost_sort:
@@ -405,9 +380,7 @@ class TraceService:
                 server_sort_by = "started_at"
                 server_sort_direction = sort_direction
         elif sort_by not in VALID_COLUMNS:
-            logger.warning(
-                f"Invalid sort field '{sort_by}', falling back to 'started_at'."
-            )
+            logger.warning(f"Invalid sort field '{sort_by}', falling back to 'started_at'.")
             server_sort_by = "started_at"
             server_sort_direction = sort_direction
         else:  # sort_by is in VALID_COLUMNS and not a special case
@@ -415,9 +388,7 @@ class TraceService:
             server_sort_direction = sort_direction
 
         # Validate and filter columns using CallSchema
-        filtered_api_columns, rs_columns, inv_columns = (
-            self._validate_and_filter_columns(columns)
-        )
+        filtered_api_columns, rs_columns, inv_columns = self._validate_and_filter_columns(columns)
 
         # Store invalid columns for later
         self.invalid_columns = inv_columns  # Corrected variable name
@@ -440,9 +411,7 @@ class TraceService:
             "filters": filters or {},
             "sort_by": server_sort_by,
             "sort_direction": server_sort_direction,
-            "limit": None
-            if client_side_cost_sort
-            else limit,  # No limit if we're sorting by cost
+            "limit": None if client_side_cost_sort else limit,  # No limit if we're sorting by cost
             "offset": offset,
             "include_costs": include_costs,
             "include_feedback": include_feedback,
@@ -454,11 +423,7 @@ class TraceService:
         request_body = QueryBuilder.prepare_query_params(query_params)
 
         # Extract synthetic fields if any were specified
-        synthetic_fields = (
-            request_body.pop("_synthetic_fields", [])
-            if "_synthetic_fields" in request_body
-            else []
-        )
+        synthetic_fields = request_body.pop("_synthetic_fields", []) if "_synthetic_fields" in request_body else []
 
         # Make sure all requested synthetic columns are included in synthetic_fields
         for col in rs_columns:  # Use rs_columns
@@ -470,9 +435,7 @@ class TraceService:
 
         # Add synthetic columns and invalid column warnings back to the results
         if rs_columns or inv_columns:  # Use corrected variables
-            all_traces = self._add_synthetic_columns(
-                all_traces, rs_columns, inv_columns
-            )
+            all_traces = self._add_synthetic_columns(all_traces, rs_columns, inv_columns)
 
         # Client-side cost-based sorting if needed
         if client_side_cost_sort and all_traces:
@@ -489,10 +452,7 @@ class TraceService:
         # If we need to synthesize fields, do it
         if synthetic_fields:
             logger.info(f"Synthesizing fields: {synthetic_fields}")
-            all_traces = [
-                TraceProcessor.synthesize_fields(trace, synthetic_fields)
-                for trace in all_traces
-            ]
+            all_traces = [TraceProcessor.synthesize_fields(trace, synthetic_fields) for trace in all_traces]
 
         # Process traces
         result = TraceProcessor.process_traces(
@@ -549,36 +509,24 @@ class TraceService:
         effective_sort_by = "started_at"  # Default
         if sort_by == "latency_ms":
             effective_sort_by = self.LATENCY_FIELD_MAPPING["latency_ms"]
-            logger.info(
-                f"Paginated sort by 'latency_ms', server will use '{effective_sort_by}'."
-            )
+            logger.info(f"Paginated sort by 'latency_ms', server will use '{effective_sort_by}'.")
         elif "." in sort_by:
             base_field = sort_by.split(".")[0]
             if base_field in VALID_COLUMNS:
                 effective_sort_by = sort_by
-                logger.info(
-                    f"Paginated sort by nested field '{sort_by}', server will use it directly."
-                )
+                logger.info(f"Paginated sort by nested field '{sort_by}', server will use it directly.")
             else:
-                logger.warning(
-                    f"Paginated sort by invalid nested field '{sort_by}', defaulting to 'started_at'."
-                )
+                logger.warning(f"Paginated sort by invalid nested field '{sort_by}', defaulting to 'started_at'.")
         elif (
             sort_by in VALID_COLUMNS and sort_by not in self.COST_FIELDS
         ):  # Exclude COST_FIELDS as they are client-sorted
             effective_sort_by = sort_by
-        elif (
-            sort_by not in self.COST_FIELDS
-        ):  # If not valid and not cost, warn and default
-            logger.warning(
-                f"Paginated sort by invalid field '{sort_by}', defaulting to 'started_at'."
-            )
+        elif sort_by not in self.COST_FIELDS:  # If not valid and not cost, warn and default
+            logger.warning(f"Paginated sort by invalid field '{sort_by}', defaulting to 'started_at'.")
 
         # Validate and filter columns using CallSchema
         # Pass the original 'columns'
-        filtered_api_columns, rs_columns, inv_columns = (
-            self._validate_and_filter_columns(columns)
-        )
+        filtered_api_columns, rs_columns, inv_columns = self._validate_and_filter_columns(columns)
 
         # Store invalid columns for later
         self.invalid_columns = inv_columns  # Corrected
@@ -612,15 +560,9 @@ class TraceService:
             current_offset = 0
 
             while True:
-                logger.info(
-                    f"Querying chunk with offset {current_offset}, size {chunk_size}"
-                )
-                remaining = (
-                    target_limit - len(all_traces) if target_limit else chunk_size
-                )
-                current_chunk_size = (
-                    min(chunk_size, remaining) if target_limit else chunk_size
-                )
+                logger.info(f"Querying chunk with offset {current_offset}, size {chunk_size}")
+                remaining = target_limit - len(all_traces) if target_limit else chunk_size
+                current_chunk_size = min(chunk_size, remaining) if target_limit else chunk_size
 
                 chunk_result = self.query_traces(
                     entity_name=entity_name,
@@ -641,17 +583,13 @@ class TraceService:
                 )
 
                 # Get the traces from the QueryResult and handle both None and empty list cases
-                traces_from_chunk = (
-                    chunk_result.traces if chunk_result and chunk_result.traces else []
-                )
+                traces_from_chunk = chunk_result.traces if chunk_result and chunk_result.traces else []
                 if not traces_from_chunk:
                     break
 
                 all_traces.extend(traces_from_chunk)
 
-                if len(traces_from_chunk) < current_chunk_size or (
-                    target_limit and len(all_traces) >= target_limit
-                ):
+                if len(traces_from_chunk) < current_chunk_size or (target_limit and len(all_traces) >= target_limit):
                     break
 
                 current_offset += chunk_size
@@ -666,12 +604,8 @@ class TraceService:
             return_full_data=return_full_data,
             metadata_only=metadata_only,
         )
-        logger.debug(
-            f"Final result from query_paginated_traces:\n\n{len(result.model_dump_json(indent=2))}\n"
-        )
-        assert isinstance(result, QueryResult), (
-            f"Result type must be a QueryResult, found: {type(result)}"
-        )
+        logger.debug(f"Final result from query_paginated_traces:\n\n{len(result.model_dump_json(indent=2))}\n")
+        assert isinstance(result, QueryResult), f"Result type must be a QueryResult, found: {type(result)}"
         return result
 
     def _query_for_cost_sorting(
@@ -727,16 +661,10 @@ class TraceService:
         first_pass_request = QueryBuilder.prepare_query_params(first_pass_query)
         first_pass_results = list(self.client.query_traces(first_pass_request))
 
-        logger.info(
-            f"First pass of cost sorting request retrieved {len(first_pass_results)} traces"
-        )
+        logger.info(f"First pass of cost sorting request retrieved {len(first_pass_results)} traces")
 
         # Filter and sort by cost
-        filtered_results = [
-            t
-            for t in first_pass_results
-            if TraceProcessor.get_cost(t, sort_by) is not None
-        ]
+        filtered_results = [t for t in first_pass_results if TraceProcessor.get_cost(t, sort_by) is not None]
 
         filtered_results.sort(
             key=lambda t: TraceProcessor.get_cost(t, sort_by),
@@ -790,8 +718,6 @@ class TraceService:
 
         # Ensure the results are in the same order as the IDs
         id_to_index = {id: i for i, id in enumerate(top_ids)}
-        second_pass_results.sort(
-            key=lambda t: id_to_index.get(t.get("id"), float("inf"))
-        )
+        second_pass_results.sort(key=lambda t: id_to_index.get(t.get("id"), float("inf")))
 
         return second_pass_results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 """Pytest configuration and shared fixtures for wandb-mcp-server tests."""
 
 import os
+
 import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration and shared fixtures for wandb-mcp-server tests."""
+
+import os
+import pytest
+
+
+@pytest.fixture
+def fake_api_key():
+    """Provide a deterministic fake API key for unit tests."""
+    return "fake_api_key_for_testing_1234567890"
+
+
+@pytest.fixture
+def server_url():
+    """Get the server URL from environment or use default."""
+    return os.environ.get("MCP_TEST_SERVER_URL", "http://localhost:7860")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for authentication logic in the W&B MCP Server.
+
+Ported from wandb-mcp-server-internal. These tests use mocks
+so no real API keys or network calls are needed.
+"""
+
+import json
+import requests
+from unittest.mock import patch, MagicMock
+
+
+def parse_sse_response(text):
+    """Parse SSE response to extract JSON data."""
+    for line in text.split("\n"):
+        if line.startswith("data: "):
+            try:
+                return json.loads(line[6:])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+class TestAuthentication:
+    """Test authentication functionality."""
+
+    def test_request_without_auth_returns_401(self, server_url):
+        """Requests without authentication should be rejected."""
+        with patch("requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.text = "Unauthorized"
+            mock_post.return_value = mock_response
+
+            response = requests.post(
+                f"{server_url}/mcp",
+                headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "1.0.0",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "1.0"},
+                    },
+                    "id": 1,
+                },
+            )
+            assert response.status_code == 401
+
+    def test_request_with_invalid_token_returns_401(self, server_url):
+        """Requests with invalid tokens should be rejected."""
+        with patch("requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.text = "Invalid API key"
+            mock_post.return_value = mock_response
+
+            response = requests.post(
+                f"{server_url}/mcp",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": "Bearer invalid_token_123",
+                },
+                json={"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1},
+            )
+            assert response.status_code == 401
+
+    def test_request_with_valid_token_succeeds(self, server_url, fake_api_key):
+        """Requests with valid API keys should succeed."""
+        with patch("requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"mcp-session-id": "test-session-123"}
+            mock_response.text = (
+                'data: {"jsonrpc":"2.0","result":{"serverInfo":{"name":"wandb-mcp-server","version":"1.0.0"}},"id":1}'
+            )
+            mock_post.return_value = mock_response
+
+            response = requests.post(
+                f"{server_url}/mcp",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": f"Bearer {fake_api_key}",
+                },
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "1.0.0",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test", "version": "1.0"},
+                    },
+                    "id": 1,
+                },
+            )
+            assert response.status_code == 200
+            assert response.headers.get("mcp-session-id") is not None
+
+            data = parse_sse_response(response.text)
+            assert data is not None
+            assert "result" in data
+            assert "serverInfo" in data["result"]
+
+    def test_session_id_returned_on_initialize(self, server_url, fake_api_key):
+        """Session ID should be returned when initializing."""
+        with patch("requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.headers = {"mcp-session-id": "session-abc-123"}
+            mock_response.text = 'data: {"jsonrpc":"2.0","result":{},"id":1}'
+            mock_post.return_value = mock_response
+
+            response = requests.post(
+                f"{server_url}/mcp",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": f"Bearer {fake_api_key}",
+                },
+                json={"jsonrpc": "2.0", "method": "initialize", "params": {}, "id": 1},
+            )
+            session_id = response.headers.get("mcp-session-id")
+            assert session_id is not None
+            assert len(session_id) > 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,65 @@
+"""Unit tests for config.py -- trace server URL resolution (MCP-5).
+
+Tests the 3-tier resolution: explicit env var > SaaS default > dedicated {base_url}/traces.
+"""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _resolve_with_env(env: dict) -> str:
+    """Reload config module with given env overrides and return resolved URL."""
+    import wandb_mcp_server.config as cfg
+
+    clean = {k: v for k, v in env.items()}
+    remove = {"WF_TRACE_SERVER_URL", "WEAVE_TRACE_SERVER_URL", "WANDB_BASE_URL"} - set(clean.keys())
+
+    with patch.dict(os.environ, clean, clear=False):
+        for key in remove:
+            os.environ.pop(key, None)
+        importlib.reload(cfg)
+        return cfg.WF_TRACE_SERVER_URL
+
+
+class TestResolveTraceServerUrl:
+    """Tests for _resolve_trace_server_url() 3-tier resolution."""
+
+    def test_saas_default_resolves_to_trace_wandb(self):
+        url = _resolve_with_env({"WANDB_BASE_URL": "https://api.wandb.ai"})
+        assert url == "https://trace.wandb.ai"
+
+    def test_dedicated_url_appends_traces(self):
+        url = _resolve_with_env({"WANDB_BASE_URL": "https://t-mobile.wandb.io"})
+        assert url == "https://t-mobile.wandb.io/traces"
+
+    def test_dedicated_url_strips_trailing_slash(self):
+        url = _resolve_with_env({"WANDB_BASE_URL": "https://custom.wandb.io/"})
+        assert url == "https://custom.wandb.io/traces"
+
+    def test_explicit_wf_trace_server_url_overrides(self):
+        url = _resolve_with_env({
+            "WANDB_BASE_URL": "https://t-mobile.wandb.io",
+            "WF_TRACE_SERVER_URL": "https://my-custom-trace.example.com",
+        })
+        assert url == "https://my-custom-trace.example.com"
+
+    def test_explicit_weave_trace_server_url_overrides(self):
+        url = _resolve_with_env({
+            "WANDB_BASE_URL": "https://t-mobile.wandb.io",
+            "WEAVE_TRACE_SERVER_URL": "https://alt-trace.example.com",
+        })
+        assert url == "https://alt-trace.example.com"
+
+    def test_wf_takes_priority_over_weave(self):
+        url = _resolve_with_env({
+            "WF_TRACE_SERVER_URL": "https://wf-wins.example.com",
+            "WEAVE_TRACE_SERVER_URL": "https://weave-loses.example.com",
+        })
+        assert url == "https://wf-wins.example.com"
+
+    def test_on_prem_style_url(self):
+        url = _resolve_with_env({"WANDB_BASE_URL": "https://wandb.internal.corp.net"})
+        assert url == "https://wandb.internal.corp.net/traces"

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,69 @@
+"""Unit tests for .env loading and env var alignment.
+
+Verifies that MCP_LOGS_WANDB_ENTITY, MCP_LOGS_WANDB_PROJECT, and related
+variables are read correctly by the server initialization code.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+class TestEnvVarAlignment:
+    """Verify server reads the right env vars for Weave project config."""
+
+    def test_mcp_logs_entity_used_for_weave_project(self):
+        """MCP_LOGS_WANDB_ENTITY should be the primary entity source."""
+        with patch.dict(os.environ, {
+            "MCP_LOGS_WANDB_ENTITY": "my-team",
+            "MCP_LOGS_WANDB_PROJECT": "mcp-logs",
+            "WEAVE_DISABLED": "false",
+        }, clear=False):
+            entity = os.environ.get("MCP_LOGS_WANDB_ENTITY") or os.environ.get("WANDB_ENTITY")
+            project = os.environ.get("MCP_LOGS_WANDB_PROJECT", "wandb-mcp-logs")
+            assert entity == "my-team"
+            assert project == "mcp-logs"
+            assert f"{entity}/{project}" == "my-team/mcp-logs"
+
+    def test_wandb_entity_fallback(self):
+        """WANDB_ENTITY should be used if MCP_LOGS_WANDB_ENTITY is not set."""
+        env = {"WANDB_ENTITY": "fallback-team"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("MCP_LOGS_WANDB_ENTITY", None)
+            entity = os.environ.get("MCP_LOGS_WANDB_ENTITY") or os.environ.get("WANDB_ENTITY")
+            assert entity == "fallback-team"
+
+    def test_mcp_logs_project_defaults_to_wandb_mcp_logs(self):
+        """MCP_LOGS_WANDB_PROJECT should default to 'wandb-mcp-logs'."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MCP_LOGS_WANDB_PROJECT", None)
+            project = os.environ.get("MCP_LOGS_WANDB_PROJECT", "wandb-mcp-logs")
+            assert project == "wandb-mcp-logs"
+
+    def test_weave_disabled_true_skips_tracing(self):
+        with patch.dict(os.environ, {"WEAVE_DISABLED": "true"}, clear=False):
+            disabled = os.environ.get("WEAVE_DISABLED", "true").lower() == "true"
+            assert disabled is True
+
+    def test_weave_disabled_false_enables_tracing(self):
+        with patch.dict(os.environ, {"WEAVE_DISABLED": "false"}, clear=False):
+            disabled = os.environ.get("WEAVE_DISABLED", "true").lower() == "true"
+            assert disabled is False
+
+    def test_dotenv_loads_from_repo_root(self):
+        from pathlib import Path
+        server_py = Path(__file__).parent.parent / "src" / "wandb_mcp_server" / "server.py"
+        dotenv_path = server_py.parent.parent.parent / ".env"
+        assert dotenv_path.name == ".env"
+
+    def test_mcp_trace_list_operations_normalized(self):
+        with patch.dict(os.environ, {"MCP_TRACE_LIST_OPERATIONS": "True"}, clear=False):
+            val = os.environ.get("MCP_TRACE_LIST_OPERATIONS", "").lower() == "true"
+            assert val is True
+
+    def test_mcp_trace_list_operations_default_disabled(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MCP_TRACE_LIST_OPERATIONS", None)
+            val = os.environ.get("MCP_TRACE_LIST_OPERATIONS", "").lower() == "true"
+            assert val is False

--- a/tests/test_gql_prefix.py
+++ b/tests/test_gql_prefix.py
@@ -1,0 +1,60 @@
+"""Unit tests for _prefix_gql_operation_name() -- GQL operation naming (MCP-9).
+
+Jira MCP-9 acceptance criteria: "Unit test validates prefix on 5 patterns."
+"""
+
+from wandb_mcp_server.mcp_tools.query_wandb_gql import _prefix_gql_operation_name
+
+
+class TestPrefixGqlOperationName:
+
+    def test_named_query_gets_prefix(self):
+        query = "query GetRuns { project { runs { edges { node { name } } } } }"
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_GetRuns" in result
+        assert "query mcp_GetRuns" in result
+
+    def test_named_mutation_gets_prefix(self):
+        query = "mutation CreateReport($input: CreateReportInput!) { createReport(input: $input) { id } }"
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_CreateReport" in result
+
+    def test_already_prefixed_unchanged(self):
+        query = "query mcp_GetRuns { project { runs { edges { node { name } } } } }"
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_mcp_" not in result
+        assert "mcp_GetRuns" in result
+
+    def test_anonymous_query_unchanged(self):
+        query = '{ project(name: "test") { runs { edges { node { name } } } } }'
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_" not in result
+
+    def test_malformed_query_returned_as_is(self):
+        query = "this is not valid graphql {"
+        result = _prefix_gql_operation_name(query)
+        assert result == query
+
+    def test_complex_query_with_variables(self):
+        query = """query FilteredRuns($entity: String!, $project: String!, $limit: Int) {
+            project(name: $project, entityName: $entity) {
+                runs(first: $limit) { edges { node { name displayName state } } }
+            }
+        }"""
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_FilteredRuns" in result
+
+    def test_custom_prefix(self):
+        query = "query MyOp { field }"
+        result = _prefix_gql_operation_name(query, prefix="custom_")
+        assert "custom_MyOp" in result
+        assert "mcp_" not in result
+
+    def test_subscription_gets_prefix(self):
+        query = "subscription WatchRuns { runUpdated { id name } }"
+        result = _prefix_gql_operation_name(query)
+        assert "mcp_WatchRuns" in result
+
+    def test_empty_string_returned_as_is(self):
+        result = _prefix_gql_operation_name("")
+        assert result == ""

--- a/tests/test_semantic_truncation.py
+++ b/tests/test_semantic_truncation.py
@@ -1,0 +1,176 @@
+"""Unit tests for semantic-aware enforce_token_budget() and estimate_tokens() (MCP-6).
+
+Tests the field-priority truncation strategy:
+  L0: under budget (pass-through)
+  L1: truncate LOW_SIGNAL (inputs, output) to 100 chars
+  L2: drop LOW_SIGNAL, truncate MEDIUM_SIGNAL to 200 chars
+  L3: keep only HIGH_SIGNAL fields
+  L4: sample traces, HIGH_SIGNAL only
+"""
+
+import json
+
+from wandb_mcp_server.weave_api.models import QueryResult, TraceMetadata
+from wandb_mcp_server.weave_api.processors import TraceProcessor
+
+
+class TestEstimateTokens:
+    def test_basic_estimate(self):
+        assert TraceProcessor.estimate_tokens("a" * 400) == 100
+
+    def test_minimum_one_token(self):
+        assert TraceProcessor.estimate_tokens("hi") == 1
+
+    def test_empty_string(self):
+        assert TraceProcessor.estimate_tokens("") == 1
+
+
+class TestFieldPriorityConstants:
+    def test_high_signal_contains_key_diagnostic_fields(self):
+        for field in ("id", "op_name", "status", "latency_ms", "exception", "started_at"):
+            assert field in TraceProcessor.HIGH_SIGNAL_FIELDS
+
+    def test_low_signal_contains_large_payloads(self):
+        assert "inputs" in TraceProcessor.LOW_SIGNAL_FIELDS
+        assert "output" in TraceProcessor.LOW_SIGNAL_FIELDS
+
+    def test_no_overlap_between_tiers(self):
+        h = TraceProcessor.HIGH_SIGNAL_FIELDS
+        m = TraceProcessor.MEDIUM_SIGNAL_FIELDS
+        lo = TraceProcessor.LOW_SIGNAL_FIELDS
+        assert not (h & m), "HIGH and MEDIUM overlap"
+        assert not (h & lo), "HIGH and LOW overlap"
+        assert not (m & lo), "MEDIUM and LOW overlap"
+
+
+class TestSemanticTruncation:
+    @staticmethod
+    def _make_traces(n: int, io_size: int = 200) -> list:
+        return [
+            {
+                "id": f"trace-{i}",
+                "op_name": f"weave:///e/p/op/op_{i}:abc",
+                "display_name": f"op_{i}",
+                "trace_id": f"trace-{i}",
+                "parent_id": None,
+                "started_at": "2026-01-01T00:00:00Z",
+                "ended_at": "2026-01-01T00:01:00Z",
+                "status": "success",
+                "latency_ms": 1000 + i,
+                "exception": None,
+                "project_id": "e/p",
+                "inputs": {"text": "x" * io_size},
+                "output": "y" * io_size,
+                "attributes": {"model": "gpt-4", "extra": "z" * 300},
+                "summary": {"tokens": 100},
+                "costs": {},
+                "feedback": {},
+                "wb_run_id": None,
+                "wb_user_id": None,
+            }
+            for i in range(n)
+        ]
+
+    def test_level0_under_budget(self):
+        traces = self._make_traces(2, io_size=10)
+        result_json = json.dumps(traces)
+        budget = TraceProcessor.estimate_tokens(result_json) + 100
+        truncated, warning, level = TraceProcessor.enforce_token_budget(
+            result_json, traces, budget
+        )
+        assert level == 0
+        assert warning is None
+        assert truncated is traces
+
+    def test_level1_truncates_low_signal_only(self):
+        traces = self._make_traces(5, io_size=5000)
+        result_json = json.dumps(traces)
+        l1_json = json.dumps([
+            {
+                k: (TraceProcessor.truncate_value(v, 100) if k in TraceProcessor.LOW_SIGNAL_FIELDS else v)
+                for k, v in t.items()
+            }
+            for t in traces
+        ])
+        budget = TraceProcessor.estimate_tokens(l1_json) + 10
+        truncated, warning, level = TraceProcessor.enforce_token_budget(
+            result_json, traces, budget
+        )
+        assert level == 1
+        assert "high-signal fields preserved" in warning
+        for t in truncated:
+            assert "op_name" in t
+            assert "status" in t
+            if "inputs" in t:
+                assert len(json.dumps(t["inputs"])) < 200
+
+    def test_level2_drops_low_truncates_medium(self):
+        traces = self._make_traces(10, io_size=5000)
+        result_json = json.dumps(traces)
+        truncated, warning, level = TraceProcessor.enforce_token_budget(
+            result_json, traces, 200
+        )
+        assert level >= 2
+        if level == 2:
+            assert "Dropped inputs/output" in warning
+            for t in truncated:
+                assert "inputs" not in t
+                assert "output" not in t
+                assert "op_name" in t
+
+    def test_level3_keeps_high_signal_only(self):
+        traces = self._make_traces(20, io_size=5000)
+        result_json = json.dumps(traces)
+        truncated, warning, level = TraceProcessor.enforce_token_budget(
+            result_json, traces, 50
+        )
+        assert level >= 3
+        if level == 3:
+            assert "high-signal diagnostic fields" in warning
+            for t in truncated:
+                for k in t:
+                    assert k in TraceProcessor.HIGH_SIGNAL_FIELDS
+
+    def test_level4_samples_traces(self):
+        traces = self._make_traces(100, io_size=500)
+        result_json = json.dumps(traces)
+        truncated, warning, level = TraceProcessor.enforce_token_budget(
+            result_json, traces, 1
+        )
+        assert level == 4
+        assert "Sampled" in warning
+        assert len(truncated) < len(traces)
+
+    def test_returns_tuple_of_three(self):
+        traces = self._make_traces(1)
+        result_json = json.dumps(traces)
+        result = TraceProcessor.enforce_token_budget(result_json, traces, 999999)
+        assert isinstance(result, tuple) and len(result) == 3
+
+    def test_high_signal_fields_always_preserved(self):
+        """At every truncation level, HIGH_SIGNAL fields should be present."""
+        traces = self._make_traces(5, io_size=5000)
+        result_json = json.dumps(traces)
+        for budget in [9999, 500, 100, 10, 1]:
+            truncated, _, level = TraceProcessor.enforce_token_budget(
+                result_json, traces, budget
+            )
+            if level == 0:
+                continue
+            for t in truncated:
+                assert "id" in t, f"id missing at level {level}"
+                assert "op_name" in t, f"op_name missing at level {level}"
+
+
+class TestTruncationWarningModel:
+    def test_truncation_warning_defaults_to_none(self):
+        assert TraceMetadata(total_traces=5).truncation_warning is None
+
+    def test_truncation_warning_can_be_set(self):
+        m = TraceMetadata(total_traces=10, truncation_warning="Truncated.")
+        assert m.truncation_warning == "Truncated."
+
+    def test_truncation_warning_in_query_result(self):
+        m = TraceMetadata(total_traces=3, truncation_warning="Level 2.")
+        r = QueryResult(metadata=m)
+        assert r.model_dump()["metadata"]["truncation_warning"] == "Level 2."

--- a/tests/test_semantic_truncation.py
+++ b/tests/test_semantic_truncation.py
@@ -97,7 +97,7 @@ class TestSemanticTruncation:
             result_json, traces, budget
         )
         assert level == 1
-        assert "high-signal fields preserved" in warning
+        assert "inputs/output shortened" in warning
         for t in truncated:
             assert "op_name" in t
             assert "status" in t
@@ -138,7 +138,7 @@ class TestSemanticTruncation:
             result_json, traces, 1
         )
         assert level == 4
-        assert "Sampled" in warning
+        assert "sampled" in warning.lower()
         assert len(truncated) < len(traces)
 
     def test_returns_tuple_of_three(self):

--- a/tests/test_weave_api.py
+++ b/tests/test_weave_api.py
@@ -1,0 +1,285 @@
+"""
+Unit tests for the Weave API client, processors, query builder, and service.
+
+Ported from wandb-mcp-server-internal. All tests use mocks --
+no real API keys or network calls are needed.
+"""
+
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from wandb_mcp_server.weave_api.client import WeaveApiClient
+from wandb_mcp_server.weave_api.models import (
+    FilterOperator,
+    QueryResult,
+)
+from wandb_mcp_server.weave_api.processors import TraceProcessor
+from wandb_mcp_server.weave_api.query_builder import QueryBuilder
+
+
+# ---------------------------------------------------------------------------
+# TraceProcessor tests
+# ---------------------------------------------------------------------------
+
+
+class TestTraceProcessor(unittest.TestCase):
+    """Tests for the TraceProcessor class."""
+
+    def test_truncate_value_with_string(self):
+        value = "a" * 300
+        result = TraceProcessor.truncate_value(value, max_length=100)
+        assert len(result) == 103  # 100 + "..."
+        assert result.endswith("...")
+
+    def test_truncate_value_with_dict(self):
+        value = {"key1": "a" * 300, "key2": "b" * 50}
+        result = TraceProcessor.truncate_value(value, max_length=100)
+        assert len(result["key1"]) == 103
+        assert result["key2"] == "b" * 50
+
+    def test_truncate_value_with_zero_length(self):
+        value = {"key1": "value1", "key2": 123, "key3": ["item1", "item2"]}
+        result = TraceProcessor.truncate_value(value, max_length=0)
+        assert result == {}
+
+    def test_truncate_value_with_none(self):
+        assert TraceProcessor.truncate_value(None) is None
+
+    def test_truncate_value_with_complex_type(self):
+        complex_object = {"__type__": "ComplexObject", "data": "a" * 200}
+        result = TraceProcessor.truncate_value(complex_object, max_length=50)
+        assert result == {"type": "ComplexObject"}
+
+    def test_count_tokens(self):
+        text = "This is a test of the token counter."
+        result = TraceProcessor.count_tokens(text)
+        assert result > 0
+
+    def test_count_tokens_fallback(self):
+        with patch("tiktoken.get_encoding", side_effect=Exception("Tiktoken error")):
+            result = TraceProcessor.count_tokens("This is a test of the token counter.")
+            assert result == 8  # word count fallback
+
+    def test_process_traces(self):
+        now = datetime.now()
+        traces = [
+            {
+                "id": "trace1",
+                "project_id": "entity/project",
+                "op_name": "weave:///entity/project/op/test:123",
+                "trace_id": "trace1",
+                "started_at": now.isoformat(),
+                "inputs": {"text": "a" * 300},
+                "output": "b" * 300,
+                "status": "success",
+            },
+            {
+                "id": "trace2",
+                "project_id": "entity/project",
+                "op_name": "weave:///entity/project/op/other:456",
+                "trace_id": "trace2",
+                "started_at": now.isoformat(),
+                "inputs": {"text": "c" * 300},
+                "output": "d" * 300,
+                "status": "error",
+            },
+        ]
+
+        result = TraceProcessor.process_traces(traces, truncate_length=100)
+        assert isinstance(result, QueryResult)
+        assert result.metadata.total_traces == 2
+        assert result.metadata.status_summary == {"success": 1, "error": 1, "other": 0}
+        assert len(result.traces) == 2
+
+    def test_process_traces_metadata_only(self):
+        traces = [
+            {
+                "id": "t1",
+                "project_id": "e/p",
+                "op_name": "weave:///e/p/op/x:1",
+                "trace_id": "t1",
+                "started_at": datetime.now().isoformat(),
+                "status": "success",
+            }
+        ]
+        result = TraceProcessor.process_traces(traces, metadata_only=True)
+        assert result.metadata.total_traces == 1
+        assert result.traces is None
+
+    def test_extract_op_name_distribution(self):
+        traces = [
+            {"op_name": "weave:///entity/project/op/test:123"},
+            {"op_name": "weave:///entity/project/op/test:456"},
+            {"op_name": "weave:///entity/project/op/other:789"},
+            {"op_name": "invalid_op_name"},
+        ]
+        distribution = TraceProcessor.extract_op_name_distribution(traces)
+        assert distribution == {"test": 2, "other": 1}
+
+    def test_get_time_range(self):
+        now = datetime.now()
+        earlier = now - timedelta(hours=1)
+        later = now + timedelta(hours=1)
+        traces = [
+            {"started_at": earlier.isoformat(), "ended_at": now.isoformat()},
+            {"started_at": now.isoformat(), "ended_at": later.isoformat()},
+        ]
+        time_range = TraceProcessor.get_time_range(traces)
+        assert time_range["earliest"] == earlier.isoformat()
+        assert time_range["latest"] == later.isoformat()
+        assert TraceProcessor.get_time_range([]) == {"earliest": None, "latest": None}
+
+    def test_get_cost(self):
+        trace = {
+            "costs": {
+                "gpt-4": {"prompt_tokens_total_cost": 0.5, "completion_tokens_total_cost": 1.0, "total_cost": 1.5},
+                "gpt-3.5-turbo": {
+                    "prompt_tokens_total_cost": 0.1,
+                    "completion_tokens_total_cost": 0.2,
+                    "total_cost": 0.3,
+                },
+            }
+        }
+        assert TraceProcessor.get_cost(trace, "total_cost") == 1.8
+        assert TraceProcessor.get_cost(trace, "completion_cost") == 1.2
+        assert TraceProcessor.get_cost(trace, "prompt_cost") == 0.6
+        assert TraceProcessor.get_cost(trace, "invalid_cost") == 0.0
+        assert TraceProcessor.get_cost({}, "total_cost") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# QueryBuilder tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryBuilder(unittest.TestCase):
+    """Tests for the QueryBuilder class."""
+
+    def test_datetime_to_timestamp(self):
+        assert QueryBuilder.datetime_to_timestamp("2021-01-01T00:00:00Z") == 1609459200
+        assert QueryBuilder.datetime_to_timestamp("2021-01-01T00:00:00+00:00") == 1609459200
+        assert QueryBuilder.datetime_to_timestamp("invalid_datetime") == 0
+        assert QueryBuilder.datetime_to_timestamp("") == 0
+
+    def test_separate_filters(self):
+        filters = {"trace_roots_only": True, "op_name": "test_op", "status": "success", "latency": {"$gt": 1000}}
+        direct, complex_f = QueryBuilder.separate_filters(filters)
+        assert direct == {"trace_roots_only": True, "op_names": ["test_op"]}
+        assert complex_f == {"status": "success", "latency": {"$gt": 1000}}
+
+    def test_separate_filters_with_trace_id(self):
+        direct, complex_f = QueryBuilder.separate_filters({"trace_id": "123"})
+        assert direct == {"trace_ids": ["123"]}
+
+    def test_separate_filters_with_call_ids_list(self):
+        direct, _ = QueryBuilder.separate_filters({"call_ids": ["123", "456"]})
+        assert direct == {"call_ids": ["123", "456"]}
+
+    def test_separate_filters_with_call_ids_string(self):
+        direct, _ = QueryBuilder.separate_filters({"call_ids": "123"})
+        assert direct == {"call_ids": ["123"]}
+
+    def test_prepare_query_params(self):
+        params = {
+            "entity_name": "test_entity",
+            "project_name": "test_project",
+            "filters": {"trace_roots_only": True, "op_name": "test_op", "status": "success"},
+            "sort_by": "started_at",
+            "sort_direction": "desc",
+            "limit": 10,
+            "offset": 0,
+            "include_costs": True,
+            "include_feedback": True,
+            "columns": ["id", "op_name", "status"],
+        }
+        result = QueryBuilder.prepare_query_params(params)
+        assert result["project_id"] == "test_entity/test_project"
+        assert result["filter"] == {"trace_roots_only": True, "op_names": ["test_op"]}
+        assert "query" in result
+        assert result["sort_by"] == [{"field": "started_at", "direction": "desc"}]
+        assert result["limit"] == 10
+
+    def test_create_contains_operation(self):
+        op = QueryBuilder.create_contains_operation("op_name", "test")
+        d = op.model_dump(by_alias=True)
+        assert d["$contains"]["substr"]["$literal"] == "test"
+        assert d["$contains"]["input"]["$getField"] == "op_name"
+
+    def test_create_comparison_operation(self):
+        eq_op = QueryBuilder.create_comparison_operation("field", FilterOperator.EQUALS, "value")
+        assert eq_op.model_dump(by_alias=True)["$eq"][0]["$getField"] == "field"
+
+        gt_op = QueryBuilder.create_comparison_operation("field", FilterOperator.GREATER_THAN, 100)
+        assert gt_op.model_dump(by_alias=True)["$gt"][1]["$literal"] == 100
+
+        lt_op = QueryBuilder.create_comparison_operation("field", FilterOperator.LESS_THAN, 100)
+        assert "$not" in lt_op.model_dump(by_alias=True)
+
+        assert QueryBuilder.create_comparison_operation("field", "invalid_operator", "v") is None
+
+
+# ---------------------------------------------------------------------------
+# WeaveApiClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestWeaveApiClient(unittest.TestCase):
+    """Tests for the WeaveApiClient class."""
+
+    def test_init_with_explicit_key(self):
+        client = WeaveApiClient(api_key="test_key_12345")
+        assert client.api_key == "test_key_12345"
+        assert client.retries == 3
+        assert client.timeout == 10
+
+    def test_init_without_key_raises(self):
+        with pytest.raises(ValueError, match="API key not provided"):
+            WeaveApiClient(api_key=None)
+
+    def test_get_auth_headers(self):
+        client = WeaveApiClient(api_key="test_key")
+        headers = client._get_auth_headers()
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Accept"] == "application/jsonl"
+        assert "Basic " in headers["Authorization"]
+
+    @patch("requests.Session.post")
+    def test_query_traces_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.iter_lines.return_value = [
+            b'{"id": "1", "op_name": "test"}',
+            b'{"id": "2", "op_name": "test2"}',
+        ]
+        mock_post.return_value = mock_response
+
+        client = WeaveApiClient(api_key="test_key")
+        results = list(client.query_traces({"project_id": "entity/project"}))
+        assert len(results) == 2
+        assert results[0]["id"] == "1"
+
+    @patch("requests.Session.post")
+    def test_query_traces_error_response(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad request"
+        mock_post.return_value = mock_response
+
+        client = WeaveApiClient(api_key="test_key")
+        with pytest.raises(Exception, match="Error 400"):
+            list(client.query_traces({"project_id": "entity/project"}))
+
+    @patch("requests.Session.post")
+    def test_query_traces_network_error(self, mock_post):
+        mock_post.side_effect = requests.RequestException("Network error")
+        client = WeaveApiClient(api_key="test_key")
+        with pytest.raises(Exception, match="Failed to query Weave traces"):
+            list(client.query_traces({"project_id": "entity/project"}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Tool hardening for the Mistral Hackathon. Consolidates:

1. **Endpoint fixes** (MCP-5, MCP-9): Auto-detect dedicated/on-prem trace server URLs, add `mcp_` prefix to all GQL operations
2. **Semantic truncation** (MCP-6): 5-level progressive truncation based on field signal density (HIGH/MEDIUM/LOW), prevents context flooding
3. **Improved warnings**: Truncation messages now include per-field token estimates and actionable tips

## Why This Matters for Hackathon

- NVIDIA flagged the GQL endpoint issue -- dedicated/on-prem users couldn't query traces
- Large projects (like hackathon participants will create) need truncation to avoid context flooding
- GQL operation prefixing enables analytics tracking of MCP-originated queries

## Security Note

No `wandb.login()` or `wandb.init()` introduced. All changes are in tool logic and response processing, not auth pathways.

## Test Plan

- [ ] `pytest tests/test_config.py tests/test_gql_prefix.py tests/test_semantic_truncation.py -v`
- [ ] Verify truncation levels L0-L4 in test output
- [ ] Verify endpoint resolution for SaaS, dedicated, and explicit env var

## Jira

MCP-5 (endpoints), MCP-6 (truncation), MCP-9 (GQL prefix)

@nicolasremerscheid -- the GQL prompt improvement from the NVIDIA GitHub issue should be added on top of this. This PR has the structural fixes.

Made with [Cursor](https://cursor.com)