### PR TITLE
feat: add read-only MCP tools for Registry and Artifacts

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -1,0 +1,576 @@
+"""List, inspect, and compare W&B artifact versions.
+
+Provides three read-only tools for artifact discovery, inspection, and
+comparison via the ``wandb.Api`` public interface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import log_tool_call
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+DEFAULT_MAX_ITEMS = 50
+MAX_ITEMS_CEILING = 200
+MAX_USED_BY = 20
+
+
+# ---------------------------------------------------------------------------
+# Tool 1 – list_artifact_versions
+# ---------------------------------------------------------------------------
+
+LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION = """List versions of an artifact collection from a project or registry.
+
+Returns version numbers, aliases, tags, sizes, and state for each version.
+
+<when_to_use>
+Call this when the user wants to see available versions of a model, dataset, or
+other artifact collection. Works with both project-level artifacts and registry
+collections. Use the version identifiers in get_artifact_details_tool or
+compare_artifact_versions_tool.
+
+Typical workflow:
+1. list_registries_tool → list_registry_collections_tool → list_artifact_versions_tool
+   (for registry artifacts)
+2. query_wandb_entity_projects → list_artifact_versions_tool
+   (for project-level artifacts)
+</when_to_use>
+
+<critical_info>
+The collection_name format depends on the source parameter:
+- source="project": fully qualified as "entity/project/artifact-name", requires type_name
+- source="registry": just the collection name (e.g., "sentiment-classifier"),
+  the registry is specified separately via registry_name
+</critical_info>
+
+Parameters
+----------
+collection_name : str
+    For project source: fully qualified "entity/project/artifact-name".
+    For registry source: unqualified collection name (e.g., "sentiment-classifier").
+registry_name : str, optional
+    Registry name. Required when source="registry".
+organization : str, optional
+    W&B organization name. Only used when source="registry".
+type_name : str, optional
+    Artifact type (e.g., "model", "dataset"). Required for project source.
+source : str, optional
+    "project" (default) or "registry". Determines the API path.
+max_items : int, optional
+    Maximum versions to return. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - collection: the queried collection name
+  - source: "project" or "registry"
+  - versions: list of version objects with version, aliases, tags, size, etc.
+  - count: number of versions returned
+  - truncated: whether more versions exist beyond max_items
+"""
+
+
+def list_artifact_versions(
+    collection_name: str,
+    registry_name: Optional[str] = None,
+    organization: Optional[str] = None,
+    type_name: Optional[str] = None,
+    source: str = "project",
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> str:
+    """List versions of an artifact collection."""
+
+    try:
+        api = WandBApiManager.get_api()
+        log_tool_call(
+            "list_artifact_versions",
+            api.viewer,
+            {
+                "collection_name": collection_name,
+                "registry_name": registry_name,
+                "type_name": type_name,
+                "source": source,
+                "max_items": max_items,
+            },
+        )
+    except Exception:
+        logger.debug("analytics emit failed", exc_info=True)
+
+    max_items = min(max_items, MAX_ITEMS_CEILING)
+
+    try:
+        api = WandBApiManager.get_api()
+
+        if source == "registry":
+            if not registry_name:
+                return json.dumps(
+                    {
+                        "error": "invalid_input",
+                        "message": "registry_name is required when source='registry'",
+                    }
+                )
+            reg_kwargs: Dict[str, Any] = {}
+            if organization is not None:
+                reg_kwargs["organization"] = organization
+            registry = api.registry(registry_name, **reg_kwargs)
+            versions_iter = registry.collections(
+                filter={"name": collection_name},
+                per_page=min(max_items, 100),
+            ).versions()
+        else:
+            if not type_name:
+                return json.dumps(
+                    {
+                        "error": "invalid_input",
+                        "message": "type_name is required when source='project'",
+                    }
+                )
+            versions_iter = api.artifacts(
+                type_name=type_name,
+                name=collection_name,
+                per_page=min(max_items, 100),
+            )
+
+        versions: List[Dict[str, Any]] = []
+        truncated = False
+        for art in versions_iter:
+            if len(versions) >= max_items:
+                truncated = True
+                break
+            versions.append(_serialize_artifact_summary(art))
+
+        return json.dumps(
+            {
+                "collection": collection_name,
+                "source": source,
+                "versions": versions,
+                "count": len(versions),
+                "truncated": truncated,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
+        return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Tool 2 – get_artifact_details
+# ---------------------------------------------------------------------------
+
+GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION = """Get full details for a specific artifact version including metadata and lineage.
+
+Returns metadata, aliases, tags, and lineage (which run created it, which runs
+consumed it, linked artifacts) for a specific artifact version.
+
+<when_to_use>
+Call this when the user wants to inspect a specific artifact version: its metadata,
+who created it, what depends on it, or its file contents.
+
+For comparing two versions side-by-side, use compare_artifact_versions_tool instead.
+</when_to_use>
+
+<critical_info>
+artifact_name must include a version or alias qualifier:
+  - "entity/project/name:v3" (by version number)
+  - "entity/project/name:latest" (by alias)
+Without a qualifier, the API will default to "latest".
+Lineage calls (logged_by, used_by) make additional network requests and may
+return null if the source run has been deleted.
+</critical_info>
+
+Parameters
+----------
+artifact_name : str
+    Fully qualified artifact name with version or alias
+    (e.g., "my-team/my-project/my-model:v3").
+type_name : str, optional
+    Artifact type hint for disambiguation.
+include_files : bool, optional
+    Whether to include the file manifest. Default: False.
+max_files : int, optional
+    Maximum files to include when include_files is True. Default: 50.
+
+Returns
+-------
+JSON with:
+  - artifact: core properties (name, type, version, state, metadata, etc.)
+  - lineage: logged_by run, used_by runs, source_artifact, linked_artifacts
+  - files: (only when include_files=True) list of {name, size, digest}
+"""
+
+
+def get_artifact_details(
+    artifact_name: str,
+    type_name: Optional[str] = None,
+    include_files: bool = False,
+    max_files: int = 50,
+) -> str:
+    """Get full details for a specific artifact version."""
+
+    try:
+        api = WandBApiManager.get_api()
+        log_tool_call(
+            "get_artifact_details",
+            api.viewer,
+            {
+                "artifact_name": artifact_name,
+                "type_name": type_name,
+                "include_files": include_files,
+            },
+        )
+    except Exception:
+        logger.debug("analytics emit failed", exc_info=True)
+
+    try:
+        api = WandBApiManager.get_api()
+        artifact = api.artifact(artifact_name, type=type_name)
+
+        result: Dict[str, Any] = {
+            "artifact": {
+                "id": getattr(artifact, "id", None),
+                "name": getattr(artifact, "name", None),
+                "type": getattr(artifact, "type", None),
+                "version": getattr(artifact, "version", None),
+                "state": getattr(artifact, "state", None),
+                "description": getattr(artifact, "description", None),
+                "size": getattr(artifact, "size", None),
+                "file_count": getattr(artifact, "file_count", None),
+                "tags": getattr(artifact, "tags", []),
+                "aliases": getattr(artifact, "aliases", []),
+                "metadata": getattr(artifact, "metadata", {}),
+                "created_at": str(getattr(artifact, "created_at", "")),
+                "digest": getattr(artifact, "digest", None),
+                "commit_hash": getattr(artifact, "commit_hash", None),
+            },
+            "lineage": _build_lineage(artifact),
+        }
+
+        if include_files:
+            result["files"] = _list_files(artifact, max_files)
+
+        return json.dumps(result)
+
+    except Exception as e:
+        logger.error(f"Error in get_artifact_details: {e}", exc_info=True)
+        return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Tool 3 – compare_artifact_versions
+# ---------------------------------------------------------------------------
+
+COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION = """Compare two artifact versions side-by-side.
+
+Shows metadata diff, alias/tag changes, size delta, file changes, and lineage
+differences between two artifact versions.
+
+<when_to_use>
+Call this when the user asks "what changed between version X and version Y" of
+a model, dataset, or any artifact. Both versions can be from the same collection
+or from different collections/projects.
+</when_to_use>
+
+<critical_info>
+Both artifact names must include version or alias qualifiers.
+The diff is directional: artifact_name_a is the "before" and artifact_name_b is
+the "after".
+File-level diff compares file names and digests. Set include_file_diff=False to
+skip file comparison for large artifacts with many files.
+For artifacts with more than 1000 files, only the first 1000 files per artifact
+are scanned — files beyond that limit will not appear in the diff. The
+"truncated" flag in file_diff is set when this occurs.
+</critical_info>
+
+Parameters
+----------
+artifact_name_a : str
+    Fully qualified name of the "before" artifact (e.g., "team/proj/model:v3").
+artifact_name_b : str
+    Fully qualified name of the "after" artifact (e.g., "team/proj/model:v7").
+type_name : str, optional
+    Artifact type hint for disambiguation.
+include_file_diff : bool, optional
+    Whether to compute file-level diff. Default: True.
+max_file_diff_entries : int, optional
+    Maximum file diff entries to report. Default: 50.
+
+Returns
+-------
+JSON with:
+  - metadata_diff: keys added, removed, changed between versions
+  - tags_diff / aliases_diff: set differences
+  - size_diff / file_count_diff: numeric deltas with percent change
+  - file_diff: files added, removed, modified (by digest), unchanged count
+  - lineage_diff: which runs created each version
+  - digest_match: whether the two versions have identical content digests
+"""
+
+
+def compare_artifact_versions(
+    artifact_name_a: str,
+    artifact_name_b: str,
+    type_name: Optional[str] = None,
+    include_file_diff: bool = True,
+    max_file_diff_entries: int = 50,
+) -> str:
+    """Compare two artifact versions side-by-side."""
+
+    try:
+        api = WandBApiManager.get_api()
+        log_tool_call(
+            "compare_artifact_versions",
+            api.viewer,
+            {
+                "artifact_name_a": artifact_name_a,
+                "artifact_name_b": artifact_name_b,
+                "type_name": type_name,
+            },
+        )
+    except Exception:
+        logger.debug("analytics emit failed", exc_info=True)
+
+    try:
+        api = WandBApiManager.get_api()
+        art_a = api.artifact(artifact_name_a, type=type_name)
+        art_b = api.artifact(artifact_name_b, type=type_name)
+
+        meta_a = getattr(art_a, "metadata", {}) or {}
+        meta_b = getattr(art_b, "metadata", {}) or {}
+
+        tags_a = set(getattr(art_a, "tags", []) or [])
+        tags_b = set(getattr(art_b, "tags", []) or [])
+
+        aliases_a = set(getattr(art_a, "aliases", []) or [])
+        aliases_b = set(getattr(art_b, "aliases", []) or [])
+
+        size_a = getattr(art_a, "size", 0) or 0
+        size_b = getattr(art_b, "size", 0) or 0
+
+        fc_a = getattr(art_a, "file_count", 0) or 0
+        fc_b = getattr(art_b, "file_count", 0) or 0
+
+        logged_by_a = _get_logged_by(art_a)
+        logged_by_b = _get_logged_by(art_b)
+
+        result: Dict[str, Any] = {
+            "artifact_a": artifact_name_a,
+            "artifact_b": artifact_name_b,
+            "metadata_diff": _compute_metadata_diff(meta_a, meta_b),
+            "tags_diff": {
+                "added": sorted(tags_b - tags_a),
+                "removed": sorted(tags_a - tags_b),
+            },
+            "aliases_diff": {
+                "added": sorted(aliases_b - aliases_a),
+                "removed": sorted(aliases_a - aliases_b),
+            },
+            "size_diff": {
+                "a": size_a,
+                "b": size_b,
+                "delta": size_b - size_a,
+                "percent_change": round((size_b - size_a) / size_a * 100, 2) if size_a else None,
+            },
+            "file_count_diff": {
+                "a": fc_a,
+                "b": fc_b,
+                "delta": fc_b - fc_a,
+            },
+            "lineage_diff": {
+                "logged_by_a": logged_by_a,
+                "logged_by_b": logged_by_b,
+                "same_source_run": logged_by_a is not None
+                and logged_by_b is not None
+                and (logged_by_a or {}).get("run_id") == (logged_by_b or {}).get("run_id"),
+            },
+            "digest_match": getattr(art_a, "digest", None) == getattr(art_b, "digest", None),
+        }
+
+        if include_file_diff:
+            result["file_diff"] = _compute_file_diff(art_a, art_b, max_file_diff_entries)
+
+        return json.dumps(result)
+
+    except Exception as e:
+        logger.error(f"Error in compare_artifact_versions: {e}", exc_info=True)
+        return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize_artifact_summary(artifact: Any) -> Dict[str, Any]:
+    """Extract core properties from an Artifact into a plain dict."""
+    return {
+        "version": getattr(artifact, "version", None),
+        "name": getattr(artifact, "name", None),
+        "aliases": getattr(artifact, "aliases", []),
+        "tags": getattr(artifact, "tags", []),
+        "state": getattr(artifact, "state", None),
+        "size": getattr(artifact, "size", None),
+        "file_count": getattr(artifact, "file_count", None),
+        "description": getattr(artifact, "description", None),
+        "created_at": str(getattr(artifact, "created_at", "")),
+        "digest": getattr(artifact, "digest", None),
+    }
+
+
+def _serialize_run_info(run: Any) -> Optional[Dict[str, Any]]:
+    """Extract run identity, or None."""
+    if run is None:
+        return None
+    return {
+        "run_id": getattr(run, "id", None),
+        "run_name": getattr(run, "name", None),
+        "project": getattr(run, "project", None),
+        "entity": getattr(run, "entity", None),
+    }
+
+
+def _get_logged_by(artifact: Any) -> Optional[Dict[str, Any]]:
+    """Safely call artifact.logged_by()."""
+    try:
+        run = artifact.logged_by()
+        return _serialize_run_info(run)
+    except Exception:
+        logger.debug("logged_by() failed", exc_info=True)
+        return None
+
+
+def _build_lineage(artifact: Any) -> Dict[str, Any]:
+    """Build the lineage section for get_artifact_details."""
+    logged_by = _get_logged_by(artifact)
+
+    used_by: Optional[List[Dict[str, Any]]] = None
+    used_by_truncated = False
+    try:
+        runs = artifact.used_by()
+        if runs is not None:
+            used_by = []
+            for run in runs:
+                if len(used_by) >= MAX_USED_BY:
+                    used_by_truncated = True
+                    break
+                used_by.append(_serialize_run_info(run))
+    except Exception:
+        logger.debug("used_by() failed", exc_info=True)
+
+    source_artifact = None
+    try:
+        src = artifact.source_artifact
+        if src is not None and src is not artifact:
+            source_artifact = getattr(src, "source_qualified_name", None) or getattr(src, "name", None)
+    except Exception:
+        logger.debug("source_artifact failed", exc_info=True)
+
+    linked: Optional[List[str]] = None
+    try:
+        linked_arts = artifact.linked_artifacts
+        if linked_arts is not None:
+            linked = []
+            for la in linked_arts:
+                name = getattr(la, "source_qualified_name", None) or getattr(la, "name", None)
+                if name:
+                    linked.append(name)
+    except Exception:
+        logger.debug("linked_artifacts failed", exc_info=True)
+
+    lineage: Dict[str, Any] = {
+        "logged_by": logged_by,
+        "used_by": used_by,
+        "source_artifact": source_artifact,
+        "linked_artifacts": linked,
+    }
+    if used_by_truncated:
+        lineage["used_by_truncated"] = True
+    return lineage
+
+
+def _list_files(artifact: Any, max_files: int) -> List[Dict[str, Any]]:
+    """List files in an artifact, capped at max_files."""
+    files: List[Dict[str, Any]] = []
+    try:
+        for f in artifact.files():
+            if len(files) >= max_files:
+                break
+            files.append(
+                {
+                    "name": getattr(f, "name", None),
+                    "size": getattr(f, "size", None),
+                    "digest": getattr(f, "digest", None),
+                }
+            )
+    except Exception:
+        logger.debug("files() failed", exc_info=True)
+    return files
+
+
+def _compute_metadata_diff(meta_a: Dict, meta_b: Dict) -> Dict[str, Any]:
+    """Key-by-key diff between two metadata dicts."""
+    keys_a, keys_b = set(meta_a.keys()), set(meta_b.keys())
+    added = {k: meta_b[k] for k in sorted(keys_b - keys_a)}
+    removed = {k: meta_a[k] for k in sorted(keys_a - keys_b)}
+    changed = {}
+    for k in sorted(keys_a & keys_b):
+        if meta_a[k] != meta_b[k]:
+            changed[k] = {"a": meta_a[k], "b": meta_b[k]}
+    return {"added": added, "removed": removed, "changed": changed}
+
+
+MAX_FILES_FOR_DIFF = 1000
+
+
+def _compute_file_diff(art_a: Any, art_b: Any, max_entries: int) -> Dict[str, Any]:
+    """Compute file-level diff between two artifacts by name + digest."""
+    files_a: Dict[str, str] = {}
+    files_b: Dict[str, str] = {}
+    scan_truncated = False
+
+    try:
+        for f in art_a.files():
+            if len(files_a) >= MAX_FILES_FOR_DIFF:
+                scan_truncated = True
+                break
+            files_a[getattr(f, "name", "")] = getattr(f, "digest", "")
+    except Exception:
+        logger.debug("files() failed for artifact_a", exc_info=True)
+
+    try:
+        for f in art_b.files():
+            if len(files_b) >= MAX_FILES_FOR_DIFF:
+                scan_truncated = True
+                break
+            files_b[getattr(f, "name", "")] = getattr(f, "digest", "")
+    except Exception:
+        logger.debug("files() failed for artifact_b", exc_info=True)
+
+    names_a, names_b = set(files_a.keys()), set(files_b.keys())
+    added = sorted(names_b - names_a)
+    removed = sorted(names_a - names_b)
+    modified = sorted(n for n in (names_a & names_b) if files_a[n] != files_b[n])
+    unchanged_count = len(names_a & names_b) - len(modified)
+
+    total_entries = len(added) + len(removed) + len(modified)
+    truncated = scan_truncated or total_entries > max_entries
+
+    if truncated:
+        added = added[:max_entries]
+        remaining = max_entries - len(added)
+        removed = removed[: max(remaining, 0)]
+        remaining -= len(removed)
+        modified = modified[: max(remaining, 0)]
+
+    return {
+        "added": added,
+        "removed": removed,
+        "modified": modified,
+        "unchanged_count": unchanged_count,
+        "truncated": truncated,
+    }

--- a/src/wandb_mcp_server/mcp_tools/query_registry.py
+++ b/src/wandb_mcp_server/mcp_tools/query_registry.py
@@ -1,0 +1,229 @@
+"""List W&B registries and registry collections.
+
+Provides two read-only tools for discovering registries and their
+collections via the ``wandb.Api`` public interface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import log_tool_call
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+DEFAULT_MAX_ITEMS = 50
+MAX_ITEMS_CEILING = 200
+
+
+# ---------------------------------------------------------------------------
+# Tool 1 – list_registries
+# ---------------------------------------------------------------------------
+
+LIST_REGISTRIES_TOOL_DESCRIPTION = """List W&B registries for an organization.
+
+Returns registry names, descriptions, visibility, and allowed artifact types.
+
+<when_to_use>
+Call this tool FIRST when the user asks about model registries, registered
+models, or registered datasets. Use the output to identify which registry to
+drill into with list_registry_collections_tool.
+
+Typical workflow:
+1. list_registries_tool → discover available registries
+2. list_registry_collections_tool → browse collections in a registry
+3. list_artifact_versions_tool → see versions of a specific collection
+4. get_artifact_details_tool → inspect a single version
+</when_to_use>
+
+<critical_info>
+Requires the user's API key to have access to the organization. If no
+organization is specified, uses the default organization for the
+authenticated user.
+Supports MongoDB-style filters on name, description, etc.
+(e.g., {"name": {"$regex": "model.*"}}).
+</critical_info>
+
+Parameters
+----------
+organization : str, optional
+    W&B organization name. Omit to use the authenticated user's default org.
+filter : dict, optional
+    MongoDB-style filter dict (e.g., {"name": {"$regex": "model.*"}}).
+max_items : int, optional
+    Maximum registries to return. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - registries: list of registry objects with name, description, visibility, etc.
+  - count: number of registries returned
+  - truncated: whether more registries exist beyond max_items
+"""
+
+
+def list_registries(
+    organization: Optional[str] = None,
+    filter: Optional[Dict[str, Any]] = None,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> str:
+    """List W&B registries for an organization."""
+
+    try:
+        api = WandBApiManager.get_api()
+        log_tool_call(
+            "list_registries",
+            api.viewer,
+            {"organization": organization, "filter": filter, "max_items": max_items},
+        )
+    except Exception:
+        logger.debug("analytics emit failed", exc_info=True)
+
+    max_items = min(max_items, MAX_ITEMS_CEILING)
+
+    try:
+        api = WandBApiManager.get_api()
+        kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+        if organization is not None:
+            kwargs["organization"] = organization
+        if filter is not None:
+            kwargs["filter"] = filter
+
+        registries: List[Dict[str, Any]] = []
+        truncated = False
+        for reg in api.registries(**kwargs):
+            if len(registries) >= max_items:
+                truncated = True
+                break
+            registries.append(
+                {
+                    "name": getattr(reg, "name", None),
+                    "full_name": getattr(reg, "full_name", None),
+                    "organization": getattr(reg, "organization", None),
+                    "entity": getattr(reg, "entity", None),
+                    "description": getattr(reg, "description", None),
+                    "visibility": getattr(reg, "visibility", None),
+                    "artifact_types": list(getattr(reg, "artifact_types", [])),
+                    "created_at": str(getattr(reg, "created_at", "")),
+                    "updated_at": str(getattr(reg, "updated_at", "")),
+                }
+            )
+
+        return json.dumps({"registries": registries, "count": len(registries), "truncated": truncated})
+
+    except Exception as e:
+        logger.error(f"Error in list_registries: {e}", exc_info=True)
+        return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Tool 2 – list_registry_collections
+# ---------------------------------------------------------------------------
+
+LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION = """List collections within a W&B registry.
+
+Collections are named groups of artifact versions (e.g., a model with v0..v12).
+
+<when_to_use>
+Call this when the user wants to see what models or datasets exist within a
+specific registry. Use the collection name to then call
+list_artifact_versions_tool or get_artifact_details_tool.
+</when_to_use>
+
+<critical_info>
+The registry_name is the short name (e.g., "model"), NOT the full name with
+the "wandb-registry-" prefix.
+Supports MongoDB-style filters on name, description, tags, etc.
+</critical_info>
+
+Parameters
+----------
+registry_name : str
+    The registry short name (e.g., "model", "dataset", "my-registry").
+organization : str, optional
+    W&B organization name. Omit to use default.
+filter : dict, optional
+    MongoDB-style filter (e.g., {"tag": "production"}).
+max_items : int, optional
+    Maximum collections to return. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - registry: the queried registry name
+  - collections: list of collection objects with name, type, tags, aliases, etc.
+  - count: number of collections returned
+  - truncated: whether more collections exist beyond max_items
+"""
+
+
+def list_registry_collections(
+    registry_name: str,
+    organization: Optional[str] = None,
+    filter: Optional[Dict[str, Any]] = None,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> str:
+    """List collections within a W&B registry."""
+
+    try:
+        api = WandBApiManager.get_api()
+        log_tool_call(
+            "list_registry_collections",
+            api.viewer,
+            {
+                "registry_name": registry_name,
+                "organization": organization,
+                "filter": filter,
+                "max_items": max_items,
+            },
+        )
+    except Exception:
+        logger.debug("analytics emit failed", exc_info=True)
+
+    max_items = min(max_items, MAX_ITEMS_CEILING)
+
+    try:
+        api = WandBApiManager.get_api()
+        reg_kwargs: Dict[str, Any] = {}
+        if organization is not None:
+            reg_kwargs["organization"] = organization
+        registry = api.registry(registry_name, **reg_kwargs)
+
+        coll_kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+        if filter is not None:
+            coll_kwargs["filter"] = filter
+
+        collections: List[Dict[str, Any]] = []
+        truncated = False
+        for coll in registry.collections(**coll_kwargs):
+            if len(collections) >= max_items:
+                truncated = True
+                break
+            collections.append(
+                {
+                    "name": getattr(coll, "name", None),
+                    "type": getattr(coll, "type", None),
+                    "description": getattr(coll, "description", None),
+                    "tags": getattr(coll, "tags", []),
+                    "aliases": getattr(coll, "aliases", []),
+                    "created_at": str(getattr(coll, "created_at", "")),
+                    "updated_at": str(getattr(coll, "updated_at", "")),
+                    "is_sequence": coll.is_sequence() if hasattr(coll, "is_sequence") else None,
+                }
+            )
+
+        return json.dumps(
+            {
+                "registry": registry_name,
+                "collections": collections,
+                "count": len(collections),
+                "truncated": truncated,
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error in list_registry_collections: {e}", exc_info=True)
+        return json.dumps({"error": "api_error", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -50,6 +50,21 @@ from wandb_mcp_server.mcp_tools.query_wandb_gql import (
     query_paginated_wandb_gql,
 )
 
+from wandb_mcp_server.mcp_tools.query_registry import (
+    LIST_REGISTRIES_TOOL_DESCRIPTION,
+    list_registries,
+    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+    list_registry_collections,
+)
+from wandb_mcp_server.mcp_tools.query_artifacts import (
+    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    list_artifact_versions,
+    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    get_artifact_details,
+    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    compare_artifact_versions,
+)
+
 # wandbot removed -- zero usage across 400+ benchmark runs, superseded by search_wandb_docs_tool
 from wandb_mcp_server.mcp_tools.query_weave import (
     QUERY_WEAVE_TRACES_TOOL_DESCRIPTION,
@@ -580,6 +595,87 @@ def register_tools(mcp_instance: FastMCP) -> None:
         except Exception as e:
             logger.error(f"Error in get_run_history_tool: {e}")
             return json.dumps({"error": str(e)})
+
+    # --- Registry & Artifact tools ---
+
+    @mcp_instance.tool(description=LIST_REGISTRIES_TOOL_DESCRIPTION)
+    def list_registries_tool(
+        organization: Optional[str] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        max_items: int = 50,
+    ) -> str:
+        """List W&B registries for an organization."""
+        return list_registries(
+            organization=organization,
+            filter=filter,
+            max_items=max_items,
+        )
+
+    @mcp_instance.tool(description=LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION)
+    def list_registry_collections_tool(
+        registry_name: str,
+        organization: Optional[str] = None,
+        filter: Optional[Dict[str, Any]] = None,
+        max_items: int = 50,
+    ) -> str:
+        """List collections within a W&B registry."""
+        return list_registry_collections(
+            registry_name=registry_name,
+            organization=organization,
+            filter=filter,
+            max_items=max_items,
+        )
+
+    @mcp_instance.tool(description=LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION)
+    def list_artifact_versions_tool(
+        collection_name: str,
+        registry_name: Optional[str] = None,
+        organization: Optional[str] = None,
+        type_name: Optional[str] = None,
+        source: str = "project",
+        max_items: int = 50,
+    ) -> str:
+        """List versions of an artifact collection."""
+        return list_artifact_versions(
+            collection_name=collection_name,
+            registry_name=registry_name,
+            organization=organization,
+            type_name=type_name,
+            source=source,
+            max_items=max_items,
+        )
+
+    @mcp_instance.tool(description=GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION)
+    def get_artifact_details_tool(
+        artifact_name: str,
+        type_name: Optional[str] = None,
+        include_files: bool = False,
+        max_files: int = 50,
+    ) -> str:
+        """Get full details for a specific artifact version."""
+        return get_artifact_details(
+            artifact_name=artifact_name,
+            type_name=type_name,
+            include_files=include_files,
+            max_files=max_files,
+        )
+
+    @mcp_instance.tool(description=COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION)
+    def compare_artifact_versions_tool(
+        artifact_name_a: str,
+        artifact_name_b: str,
+        type_name: Optional[str] = None,
+        include_file_diff: bool = True,
+        max_file_diff_entries: int = 50,
+    ) -> str:
+        """Compare two artifact versions side-by-side."""
+        return compare_artifact_versions(
+            artifact_name_a=artifact_name_a,
+            artifact_name_b=artifact_name_b,
+            type_name=type_name,
+            include_file_diff=include_file_diff,
+            max_file_diff_entries=max_file_diff_entries,
+        )
 
 
 # ===============================================================================

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -1,0 +1,306 @@
+"""Tests for artifact tools (list_artifact_versions, get_artifact_details, compare_artifact_versions)."""
+
+import json
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from wandb_mcp_server.mcp_tools.query_artifacts import (
+    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    compare_artifact_versions,
+    get_artifact_details,
+    list_artifact_versions,
+)
+
+
+def _make_artifact(**overrides):
+    art = MagicMock()
+    art.id = overrides.get("id", "abc123")
+    art.name = overrides.get("name", "my-model:v1")
+    art.type = overrides.get("type", "model")
+    art.version = overrides.get("version", "v1")
+    art.state = overrides.get("state", "COMMITTED")
+    art.description = overrides.get("description", "A test artifact")
+    art.size = overrides.get("size", 1048576)
+    art.file_count = overrides.get("file_count", 3)
+    art.tags = overrides.get("tags", ["production"])
+    art.aliases = overrides.get("aliases", ["latest"])
+    art.metadata = overrides.get("metadata", {"framework": "pytorch"})
+    art.created_at = overrides.get("created_at", "2025-01-01T00:00:00")
+    art.digest = overrides.get("digest", "abc123def456")
+    art.commit_hash = overrides.get("commit_hash", None)
+    art.source_qualified_name = overrides.get("source_qualified_name", None)
+
+    logged_by_run = overrides.get("logged_by_run", None)
+    art.logged_by.return_value = logged_by_run
+
+    used_by_runs = overrides.get("used_by_runs", [])
+    art.used_by.return_value = used_by_runs
+
+    source = overrides.get("source_artifact", art)
+    type(art).source_artifact = PropertyMock(return_value=source)
+
+    type(art).linked_artifacts = PropertyMock(return_value=overrides.get("linked_artifacts", []))
+
+    files = overrides.get("files", [])
+    art.files.return_value = iter(files)
+    return art
+
+
+def _make_run(run_id="run1", name="train-v1", project="my-project", entity="my-team"):
+    run = MagicMock()
+    run.id = run_id
+    run.name = name
+    run.project = project
+    run.entity = entity
+    return run
+
+
+def _make_file(name="model.pt", size=1000000, digest="aaa111"):
+    f = MagicMock()
+    f.name = name
+    f.size = size
+    f.digest = digest
+    return f
+
+
+class TestListArtifactVersions:
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_project_source(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.artifacts.return_value = iter(
+            [
+                _make_artifact(version="v1"),
+                _make_artifact(version="v2"),
+            ]
+        )
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("team/project/my-model", type_name="model", source="project"))
+
+        assert result["count"] == 2
+        assert result["source"] == "project"
+        assert result["versions"][0]["version"] == "v1"
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_registry_source(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_registry = MagicMock()
+        mock_collections = MagicMock()
+        mock_collections.versions.return_value = iter(
+            [
+                _make_artifact(version="v3"),
+            ]
+        )
+        mock_registry.collections.return_value = mock_collections
+        mock_api.registry.return_value = mock_registry
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("my-model", registry_name="model-registry", source="registry"))
+
+        assert result["count"] == 1
+        assert result["source"] == "registry"
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_project_source_requires_type_name(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("team/project/my-model", source="project"))
+
+        assert result["error"] == "invalid_input"
+        assert "type_name" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_registry_source_requires_registry_name(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("my-model", source="registry"))
+
+        assert result["error"] == "invalid_input"
+        assert "registry_name" in result["message"]
+
+
+class TestGetArtifactDetails:
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_basic(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        run = _make_run()
+        art = _make_artifact(
+            metadata={"accuracy": 0.95, "framework": "pytorch"},
+            logged_by_run=run,
+        )
+        mock_api.artifact.return_value = art
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model:v1"))
+
+        assert result["artifact"]["version"] == "v1"
+        assert result["artifact"]["metadata"]["accuracy"] == 0.95
+        assert result["lineage"]["logged_by"]["run_id"] == "run1"
+        assert "files" not in result
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_with_files(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        files = [_make_file("model.pt", 1000), _make_file("config.json", 500)]
+        art = _make_artifact(files=files)
+        mock_api.artifact.return_value = art
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model:v1", include_files=True))
+
+        assert len(result["files"]) == 2
+        assert result["files"][0]["name"] == "model.pt"
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_lineage_failure_graceful(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        art = _make_artifact()
+        art.logged_by.side_effect = Exception("Run deleted")
+        art.used_by.side_effect = Exception("Run deleted")
+        mock_api.artifact.return_value = art
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model:v1"))
+
+        assert result["lineage"]["logged_by"] is None
+        assert result["lineage"]["used_by"] is None
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_api_error_returns_json(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.artifact.side_effect = Exception("Artifact not found")
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model:v99"))
+
+        assert "error" in result
+        assert "Artifact not found" in result["message"]
+
+
+class TestCompareArtifactVersions:
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_basic(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+
+        art_a = _make_artifact(
+            version="v1",
+            size=1000,
+            tags=["staging"],
+            aliases=["old"],
+            metadata={"accuracy": 0.90},
+            digest="aaa",
+            files=[_make_file("model.pt", 1000, "d1")],
+        )
+        art_b = _make_artifact(
+            version="v2",
+            size=2000,
+            tags=["production"],
+            aliases=["latest"],
+            metadata={"accuracy": 0.95},
+            digest="bbb",
+            files=[_make_file("model.pt", 2000, "d2"), _make_file("vocab.json", 100, "d3")],
+        )
+        mock_api.artifact.side_effect = [art_a, art_b]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(compare_artifact_versions("t/p/m:v1", "t/p/m:v2"))
+
+        assert result["digest_match"] is False
+        assert result["size_diff"]["delta"] == 1000
+        assert result["metadata_diff"]["changed"]["accuracy"] == {"a": 0.90, "b": 0.95}
+        assert "production" in result["tags_diff"]["added"]
+        assert "staging" in result["tags_diff"]["removed"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_identical(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+
+        art = _make_artifact(digest="same_digest")
+        mock_api.artifact.side_effect = [art, art]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(compare_artifact_versions("t/p/m:v1", "t/p/m:v1"))
+
+        assert result["digest_match"] is True
+        assert result["metadata_diff"]["added"] == {}
+        assert result["metadata_diff"]["removed"] == {}
+        assert result["metadata_diff"]["changed"] == {}
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_metadata_diff(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+
+        art_a = _make_artifact(metadata={"a": 1, "b": 2, "c": 3})
+        art_b = _make_artifact(metadata={"b": 2, "c": 99, "d": 4})
+        mock_api.artifact.side_effect = [art_a, art_b]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(compare_artifact_versions("t/p/m:v1", "t/p/m:v2"))
+
+        diff = result["metadata_diff"]
+        assert diff["added"] == {"d": 4}
+        assert diff["removed"] == {"a": 1}
+        assert diff["changed"] == {"c": {"a": 3, "b": 99}}
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_file_diff(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+
+        art_a = _make_artifact(
+            files=[_make_file("a.pt", 100, "d1"), _make_file("b.pt", 100, "d2")],
+        )
+        art_b = _make_artifact(
+            files=[_make_file("b.pt", 100, "d2_changed"), _make_file("c.pt", 100, "d3")],
+        )
+        mock_api.artifact.side_effect = [art_a, art_b]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(compare_artifact_versions("t/p/m:v1", "t/p/m:v2"))
+
+        fd = result["file_diff"]
+        assert "c.pt" in fd["added"]
+        assert "a.pt" in fd["removed"]
+        assert "b.pt" in fd["modified"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_no_file_diff_when_disabled(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+
+        art_a = _make_artifact()
+        art_b = _make_artifact()
+        mock_api.artifact.side_effect = [art_a, art_b]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(compare_artifact_versions("t/p/m:v1", "t/p/m:v2", include_file_diff=False))
+
+        assert "file_diff" not in result
+
+
+class TestToolDescriptions:
+    def test_list_artifact_versions_has_when_to_use(self):
+        assert "<when_to_use>" in LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION
+        assert "</when_to_use>" in LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION
+
+    def test_get_artifact_details_has_when_to_use(self):
+        assert "<when_to_use>" in GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION
+        assert "</when_to_use>" in GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION
+
+    def test_compare_artifact_versions_has_when_to_use(self):
+        assert "<when_to_use>" in COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION
+        assert "</when_to_use>" in COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION

--- a/tests/test_query_registry.py
+++ b/tests/test_query_registry.py
@@ -1,0 +1,186 @@
+"""Tests for registry discovery tools (list_registries, list_registry_collections)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from wandb_mcp_server.mcp_tools.query_registry import (
+    LIST_REGISTRIES_TOOL_DESCRIPTION,
+    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+    list_registries,
+    list_registry_collections,
+)
+
+
+def _make_registry(name="my-registry", **overrides):
+    reg = MagicMock()
+    reg.name = name
+    reg.full_name = f"wandb-registry-{name}"
+    reg.organization = overrides.get("organization", "my-org")
+    reg.entity = overrides.get("entity", "my-org")
+    reg.description = overrides.get("description", "A test registry")
+    reg.visibility = overrides.get("visibility", "organization")
+    reg.artifact_types = overrides.get("artifact_types", ["model"])
+    reg.created_at = overrides.get("created_at", "2025-01-01T00:00:00")
+    reg.updated_at = overrides.get("updated_at", "2025-06-01T00:00:00")
+    return reg
+
+
+def _make_collection(name="my-model", **overrides):
+    coll = MagicMock()
+    coll.name = name
+    coll.type = overrides.get("type", "model")
+    coll.description = overrides.get("description", "A test collection")
+    coll.tags = overrides.get("tags", ["production"])
+    coll.aliases = overrides.get("aliases", ["latest"])
+    coll.created_at = overrides.get("created_at", "2025-01-01T00:00:00")
+    coll.updated_at = overrides.get("updated_at", "2025-06-01T00:00:00")
+    coll.is_sequence.return_value = overrides.get("is_sequence", True)
+    return coll
+
+
+class TestListRegistries:
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_basic(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.registries.return_value = iter(
+            [
+                _make_registry("models"),
+                _make_registry("datasets"),
+            ]
+        )
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registries())
+
+        assert result["count"] == 2
+        assert result["truncated"] is False
+        assert result["registries"][0]["name"] == "models"
+        assert result["registries"][1]["name"] == "datasets"
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_filter_passed_through(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.registries.return_value = iter([_make_registry("models")])
+        mock_api_mgr.get_api.return_value = mock_api
+
+        filt = {"name": {"$regex": "model.*"}}
+        list_registries(filter=filt)
+
+        call_kwargs = mock_api.registries.call_args[1]
+        assert call_kwargs["filter"] == filt
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_max_items_ceiling(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        regs = [_make_registry(f"reg-{i}") for i in range(250)]
+        mock_api.registries.return_value = iter(regs)
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registries(max_items=999))
+
+        assert result["count"] == 200
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_api_error_returns_json(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.registries.side_effect = Exception("Connection refused")
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registries())
+
+        assert "error" in result
+        assert "Connection refused" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_empty_result(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.registries.return_value = iter([])
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registries())
+
+        assert result["count"] == 0
+        assert result["registries"] == []
+        assert result["truncated"] is False
+
+
+class TestListRegistryCollections:
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_basic(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.collections.return_value = iter(
+            [
+                _make_collection("model-a"),
+                _make_collection("model-b"),
+            ]
+        )
+        mock_api.registry.return_value = mock_registry
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registry_collections("my-registry"))
+
+        assert result["registry"] == "my-registry"
+        assert result["count"] == 2
+        assert result["collections"][0]["name"] == "model-a"
+        assert result["collections"][1]["name"] == "model-b"
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_empty(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_registry = MagicMock()
+        mock_registry.collections.return_value = iter([])
+        mock_api.registry.return_value = mock_registry
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registry_collections("my-registry"))
+
+        assert result["count"] == 0
+        assert result["collections"] == []
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_collection_properties(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_registry = MagicMock()
+        coll = _make_collection("prod-model", tags=["production", "v2"], is_sequence=True)
+        mock_registry.collections.return_value = iter([coll])
+        mock_api.registry.return_value = mock_registry
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registry_collections("my-registry"))
+        c = result["collections"][0]
+
+        assert c["name"] == "prod-model"
+        assert c["tags"] == ["production", "v2"]
+        assert c["is_sequence"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    def test_api_error_returns_json(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.registry.side_effect = Exception("Registry not found")
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_registry_collections("nonexistent"))
+
+        assert "error" in result
+        assert "Registry not found" in result["message"]
+
+
+class TestToolDescriptions:
+    def test_list_registries_has_when_to_use(self):
+        assert "<when_to_use>" in LIST_REGISTRIES_TOOL_DESCRIPTION
+        assert "</when_to_use>" in LIST_REGISTRIES_TOOL_DESCRIPTION
+
+    def test_list_registry_collections_has_when_to_use(self):
+        assert "<when_to_use>" in LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION
+        assert "</when_to_use>" in LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -11,6 +11,15 @@ from wandb_mcp_server.mcp_tools.query_wandbot import WANDBOT_TOOL_DESCRIPTION
 from wandb_mcp_server.mcp_tools.infer_schema import INFER_TRACE_SCHEMA_TOOL_DESCRIPTION
 from wandb_mcp_server.mcp_tools.run_history import GET_RUN_HISTORY_TOOL_DESCRIPTION
 from wandb_mcp_server.mcp_tools.docs_search import SEARCH_WANDB_DOCS_TOOL_DESCRIPTION
+from wandb_mcp_server.mcp_tools.query_registry import (
+    LIST_REGISTRIES_TOOL_DESCRIPTION,
+    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+)
+from wandb_mcp_server.mcp_tools.query_artifacts import (
+    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+)
 
 
 ALL_DESCRIPTIONS = {
@@ -23,6 +32,11 @@ ALL_DESCRIPTIONS = {
     "infer_trace_schema": INFER_TRACE_SCHEMA_TOOL_DESCRIPTION,
     "get_run_history": GET_RUN_HISTORY_TOOL_DESCRIPTION,
     "search_wandb_docs": SEARCH_WANDB_DOCS_TOOL_DESCRIPTION,
+    "list_registries": LIST_REGISTRIES_TOOL_DESCRIPTION,
+    "list_registry_collections": LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+    "list_artifact_versions": LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    "get_artifact_details": GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    "compare_artifact_versions": COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "wandb-mcp-server"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
PRD: https://www.notion.so/wandbai/MCP-Support-for-Registry-31be2f5c7ef38073a980fdd2a1dbc8d1

Add 5 new tools for artifacts and registries:

- list_registries: list registries for an org with optional filters
- list_registry_collections: list collections within a registry
- list_artifact_versions: list versions from project or registry source
- get_artifact_details: inspect metadata, lineage, and files
- compare_artifact_versions: side-by-side diff of two versions

I setup a stress test locally using claude to test all of these MCP tools. Here are the results with the sample outputs:
```
MCP Registry & Artifact Tools — Stress Test Results
====================================================
Date: 2026-04-07
Data: 100 registries, 500 pagination-model versions (artifacts with many versions) , 50 rich-model versions (artifacts with a lot of metadata/files)

================================================================================
TEST 1: list_registries — max_items=200 (pagination across 104 registries)
================================================================================
RESULT: ✅ PASS
  count: 104
  truncated: false
  Returned all 104 registries (100 stress-reg-* + test-reg + test-reg-1 + model + dataset)
  Registries ordered by created_at desc (stress-reg-099 first, model/dataset last)

OUTPUT (first 2 of 104):
  {
    "count": 104,
    "truncated": false,
    "registries": [
      {
        "name": "stress-reg-099",
        "full_name": "wandb-registry-stress-reg-099",
        "organization": "vbhat-wand-org",
        "description": "Stress test registry 99 — pipelines",
        "visibility": "organization",
        "artifact_types": [],
        "created_at": "2026-04-07T17:45:05Z"
      },
      {
        "name": "stress-reg-098",
        "full_name": "wandb-registry-stress-reg-098",
        "organization": "vbhat-wand-org",
        "description": "Stress test registry 98 — pipelines",
        "visibility": "organization",
        "artifact_types": [],
        "created_at": "2026-04-07T17:45:05Z"
      },
      "... (102 more registries) ..."
    ]
  }

================================================================================
TEST 2: list_registries — regex filter + max_items=5 (truncation)
================================================================================
RESULT: ✅ PASS
  filter: {"name": {"$regex": "stress.*"}}
  count: 5
  truncated: true
  Correctly returned only 5 stress-reg registries and flagged truncation

OUTPUT:
  {
    "count": 5,
    "truncated": true,
    "registries": [
      { "name": "stress-reg-099", "description": "Stress test registry 99 — pipelines" },
      { "name": "stress-reg-098", "description": "Stress test registry 98 — pipelines" },
      "... (3 more) ..."
    ]
  }

================================================================================
TEST 3: list_registry_collections — registry with linked artifacts
================================================================================
RESULT: ✅ PASS
  registry: stress-reg-000
  count: 2
  collections: pagination-model (model), rich-model (model)
  Both linked collections visible

OUTPUT:
  {
    "registry": "stress-reg-000",
    "count": 2,
    "truncated": false,
    "collections": [
      {
        "name": "pagination-model",
        "type": "model",
        "description": null,
        "tags": [],
        "aliases": ["latest"],
        "created_at": "2026-04-07T17:47:20Z",
        "updated_at": "2026-04-07T17:47:20Z",
        "is_sequence": false
      },
      {
        "name": "rich-model",
        "type": "model",
        "description": null,
        "tags": [],
        "aliases": ["latest"],
        "created_at": "2026-04-07T17:47:20Z",
        "updated_at": "2026-04-07T17:47:20Z",
        "is_sequence": false
      }
    ]
  }

================================================================================
TEST 4: list_artifact_versions — 500 versions, max_items=200 (project source)
================================================================================
RESULT: ✅ PASS
  collection: vbhat-wand/mcp-stress-test/pagination-model
  source: project
  count: 200
  truncated: true (500 total, returned 200 at ceiling)
  Response size: 57.6KB (auto-persisted by harness)
  Versions: v499 down to v300, ordered desc

OUTPUT (first 2 of 200):
  {
    "collection": "vbhat-wand/mcp-stress-test/pagination-model",
    "source": "project",
    "count": 200,
    "truncated": true,
    "versions": [
      {
        "version": "v499",
        "name": "pagination-model:v499",
        "aliases": ["latest", "best", "production"],
        "tags": ["production-candidate", "latest-experiment", "approved"],
        "state": "COMMITTED",
        "size": 108,
        "file_count": 2,
        "description": "Pagination test model v499",
        "digest": "12e685fc217cb48f12ea6efe29b0e6f1"
      },
      {
        "version": "v498",
        "name": "pagination-model:v498",
        "aliases": [],
        "tags": [],
        "state": "COMMITTED",
        "size": 152,
        "file_count": 2,
        "description": "Pagination test model v498"
      },
      "... (198 more versions down to v300) ..."
    ]
  }

================================================================================
TEST 5: get_artifact_details — rich-model:v0 (261 files, 2KB metadata)
================================================================================
RESULT: ✅ PASS
  artifact: rich-model:v0
  file_count: 261
  files returned: 50 (capped by max_files=50)
  metadata keys: 40+
  Nested objects preserved: preprocessing, regularization, evaluation_metrics, hardware, environment, custom_metrics

OUTPUT:
  {
    "artifact": {
      "name": "rich-model:v0", "type": "model", "version": "v0",
      "size": 27335, "file_count": 261,
      "metadata": {
        "framework": "pytorch", "architecture": "resnet101", "accuracy": 0.8062,
        "num_parameters": 295627811, "training_time_hours": 148.7,
        "preprocessing": { "tokenizer": "bpe", "vocab_size": 50000, "..." },
        "evaluation_metrics": { "accuracy": 0.708, "f1_macro": 0.8285, "..." },
        "custom_metrics": { "metric_0": 89.703, "...": "19 more" },
        "...": "40+ keys total including nested objects"
      }
    },
    "lineage": {
      "logged_by": { "run_name": "rich-batch-0000-0025", "project": "mcp-stress-test" },
      "used_by": [],
      "linked_artifacts": ["vbhat-wand/mcp-stress-test/rich-model:v0"]
    },
    "files": [
      { "name": "shard_0/file_00000.bin", "size": 112 },
      "... (50 returned, capped from 261 total) ..."
    ]
  }

================================================================================
TEST 6: get_artifact_details — pagination-model:v499 (tagged + aliased)
================================================================================
RESULT: ✅ PASS

OUTPUT:
  {
    "artifact": {
      "name": "pagination-model:v499", "version": "v499",
      "tags": ["production-candidate", "latest-experiment", "approved"],
      "aliases": ["latest", "best", "production"],
      "metadata": { "accuracy": 0.9985, "epoch": 500, "loss": -0.0033 }
    },
    "lineage": { "logged_by": { "run_name": "train-batch-0475-0500" } }
  }

================================================================================
TEST 7: compare_artifact_versions — rich-model:v0 vs v49 (large metadata + many files)
================================================================================
RESULT: ✅ PASS
  metadata_diff.changed: 34 keys changed
  file_diff: 48 removed, 2 modified, truncated=true

OUTPUT (key fields shown):
  {
    "metadata_diff": {
      "changed": {
        "architecture": { "a": "resnet101", "b": "llama-7b" },
        "framework": { "a": "pytorch", "b": "flax" },
        "num_parameters": { "a": 295627811, "b": 6734239089 },
        "task": { "a": "classification", "b": "segmentation" },
        "quantization": { "a": "int8", "b": "awq" },
        "...": "34 changed keys total, including nested diffs for environment, evaluation_metrics, custom_metrics, etc."
      }
    },
    "size_diff": { "a": 27335, "b": 22652, "delta": -4683, "percent_change": -17.13 },
    "file_count_diff": { "a": 261, "b": 213, "delta": -48 },
    "file_diff": {
      "removed": ["shard_2/file_00213.bin", "... (48 removed total)"],
      "modified": ["shard_0/file_00000.bin", "shard_0/file_00001.bin"],
      "truncated": true
    },
    "lineage_diff": { "same_source_run": false },
    "digest_match": false
  }

================================================================================
TEST 8: compare_artifact_versions — pagination-model:v0 vs v499 (first vs last)
================================================================================
RESULT: ✅ PASS

OUTPUT:
  {
    "metadata_diff": {
      "changed": { "accuracy": {"a": 0.5014, "b": 0.9985}, "epoch": {"a": 1, "b": 500}, "loss": {"a": 0.9945, "b": -0.0033} }
    },
    "tags_diff": { "added": ["approved", "latest-experiment", "production-candidate"], "removed": ["baseline", "v1"] },
    "aliases_diff": { "added": ["best", "latest", "production"] },
    "size_diff": { "delta": 21, "percent_change": 24.14 },
    "file_diff": { "modified": ["config.json", "weights.bin"], "truncated": false },
    "digest_match": false
  }

================================================================================
TEST 9: list_artifact_versions — registry source (linked version)
================================================================================
RESULT: ✅ PASS
  collection: rich-model in stress-reg-005

OUTPUT:
  {
    "collection": "rich-model",
    "source": "registry",
    "count": 1,
    "truncated": false,
    "versions": [
      {
        "version": "v0",
        "name": "rich-model:v0",
        "aliases": ["latest"],
        "tags": [],
        "state": "COMMITTED",
        "size": 39416,
        "file_count": 383,
        "description": "Rich model v25 — vit-large for detection",
        "created_at": "2026-04-07T17:46:40Z",
        "digest": "5921150e40cf00c39e2e5580a0ebc5f4"
      }
    ]
  }

================================================================================
TEST 10: list_registry_collections — empty registry (no linked artifacts)
================================================================================
RESULT: ✅ PASS

OUTPUT:
  {
    "registry": "stress-reg-050",
    "count": 0,
    "truncated": false,
    "collections": []
  }

================================================================================
SUMMARY
================================================================================
All 10 tests: ✅ PASS

Stress test coverage:
  - 104 registries paginated in one call (max_items=200)
  - 500 versions paginated with truncation at 200
  - 261-file artifact inspected (file list capped at 50)
  - ~2KB metadata (40+ keys, nested objects) serialized correctly
  - File diff across 261 vs 213 files with truncation flag
  - Metadata diff across 34 changed keys including nested dicts
  - Empty registry handled gracefully
  - Registry-linked versions resolve correctly
  - Tags, aliases, lineage all correct under load
```
