### PR TITLE
fix: point nightly eval at existing mcp-ci.yaml config

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -73,7 +73,7 @@ jobs:
           AGENT="claude-code-${{ matrix.variant }}"
           echo "Agent: $AGENT, parallelism: $PARALLELISM"
           uv run python -W ignore -m core.run_eval \
-            evals/mcp-v030-staging.yaml \
+            data/evals/mcp-ci.yaml \
             --agent "$AGENT" \
             --weave-parallelism "$PARALLELISM" \
             2>&1 | tee eval-output.log


### PR DESCRIPTION
## Summary

The nightly eval workflow has been failing daily since April 6+ because it references `evals/mcp-v030-staging.yaml` which doesn't exist in WandBAgentFactory.

## Change

One line: `evals/mcp-v030-staging.yaml` -> `data/evals/mcp-ci.yaml`

`mcp-ci.yaml` is the CI smoke test (7 tasks, ~10 min) and exists on the WandBAgentFactory main branch.

## Also Fixed

Set the 5 required GitHub Actions secrets that were missing:
- `WBAF_PAT` (checkout WandBAgentFactory private repo)
- `WANDB_API_KEY` (eval task authentication)
- `ANTHROPIC_API_KEY` (Claude agent)
- `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` (Modal execution)

The eval workflow should pass after this PR merges.

Made with [Cursor](https://cursor.com)