### PR TITLE
chore: add CONTRIBUTING.md, RELEASING.md, update README (14 tools + on-prem)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -73,7 +73,7 @@ jobs:
           AGENT="claude-code-${{ matrix.variant }}"
           echo "Agent: $AGENT, parallelism: $PARALLELISM"
           uv run python -W ignore -m core.run_eval \
-            evals/mcp-v030-staging.yaml \
+            data/evals/mcp-ci.yaml \
             --agent "$AGENT" \
             --weave-parallelism "$PARALLELISM" \
             2>&1 | tee eval-output.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to the W&B MCP Server
+
+## Development Setup
+
+```bash
+git clone https://github.com/wandb/wandb-mcp-server
+cd wandb-mcp-server
+
+# Create virtual environment
+uv venv .venv --python 3.12
+uv pip install -e ".[test,http]"
+
+# Install pre-commit hooks (ruff check + format on staged files)
+pre-commit install
+```
+
+## Running Tests
+
+All unit tests are mock-based -- no API keys or network calls required.
+
+```bash
+# Run all tests
+uv run pytest tests/ -v --tb=short
+
+# Run a specific test file
+uv run pytest tests/test_weave_api.py -v
+
+# Run with coverage
+uv run pytest tests/ --cov=src/wandb_mcp_server
+```
+
+## Linting
+
+Ruff config is in `pyproject.toml`. Do not pass `--select` or `--ignore` on the CLI.
+
+```bash
+# Check
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+
+# Auto-fix
+uv run ruff check src/ tests/ --fix
+uv run ruff format src/ tests/
+```
+
+Pre-commit hooks run these automatically on staged files.
+
+## Running Locally
+
+### STDIO mode (for desktop clients)
+
+```bash
+export WANDB_API_KEY=your-key
+uv run wandb_mcp_server
+```
+
+### HTTP mode (for testing)
+
+```bash
+export WANDB_API_KEY=your-key
+uv run wandb_mcp_server --transport http --port 8080
+```
+
+Then test with curl:
+
+```bash
+curl -s http://localhost:8080/health | python3 -m json.tool
+```
+
+## Branch Naming
+
+- `feat/mcp{N}-{short-name}` for features linked to Jira tickets
+- `fix/{description}` for bug fixes
+- `chore/{description}` for maintenance
+- Always branch from `main`
+
+## PR Process
+
+1. Create a branch from `main`
+2. Make changes, ensure tests pass locally
+3. Push and create a PR targeting `main`
+4. CI runs automatically (ruff + pytest on Python 3.11 + 3.12)
+5. Get review from `@NiWaRe` or another team member
+6. Merge via squash merge
+
+### PR Title Format
+
+```
+feat(MCP-{N}): short description
+fix(MCP-{N}): short description
+chore(MCP-{N}): short description
+```
+
+### PR Body
+
+Include: summary, changes, Jira link, test plan.
+
+## Architecture
+
+```
+src/wandb_mcp_server/
+├── server.py              # FastMCP app, tool registration, CLI
+├── auth.py                # Bearer token validation, session binding
+├── api_client.py          # WandBApiManager (per-request API keys)
+├── session_manager.py     # Multi-tenant session management
+├── analytics.py           # Cloud Logging + Segment events
+├── config.py              # WANDB_BASE_URL, token budgets
+├── mcp_tools/             # 14 MCP tool implementations
+│   ├── query_weave.py     # Trace querying with token budget
+│   ├── query_wandb_gql.py # GraphQL with auto-pagination
+│   ├── create_report.py   # W&B Reports with panels
+│   ├── query_artifacts.py # Artifact list/get/compare
+│   ├── query_registry.py  # Registry + collection listing
+│   └── ...
+└── weave_api/             # HTTP client for Weave trace server
+    ├── service.py         # TraceService orchestrator
+    ├── processors.py      # Token estimation + truncation
+    ├── query_builder.py   # Filter -> trace server query
+    └── client.py          # HTTP client (Basic auth)
+```
+
+## Adding a New Tool
+
+1. Create `src/wandb_mcp_server/mcp_tools/your_tool.py`
+2. Define the tool function with a descriptive docstring
+3. Create a `TOOL_DESCRIPTION` constant with proactive guidance
+4. Register it in `server.py` via `register_tools()`
+5. Add unit tests in `tests/test_your_tool.py`
+6. Update the tool count in `README.md`
+
+## Environment Variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `WANDB_API_KEY` | W&B authentication (STDIO mode) | From netrc |
+| `WANDB_BASE_URL` | W&B API endpoint | `https://api.wandb.ai` |
+| `WF_TRACE_SERVER_URL` | Weave trace server | `https://trace.wandb.ai` |
+| `MAX_RESPONSE_TOKENS` | Token budget for truncation | `30000` |
+| `MCP_SERVER_LOG_LEVEL` | Log level | `WARNING` |
+
+## Deployment
+
+This repo contains only the MCP server logic. Deployment (Docker, Cloud Run, Helm) lives in the private `wandb/wandb-mcp-server-test` repo. See [RELEASING.md](RELEASING.md) for the release process.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Query and analyze your Weights & Biases data using natural language through the 
 </details>
 
 <details>
-<summary><strong>Available Tools</strong> (9 tools)</summary>
+<summary><strong>Available Tools</strong> (14 tools)</summary>
 
 | Tool | Description | Example Query |
 |------|-------------|---------------|
@@ -42,10 +42,15 @@ Query and analyze your Weights & Biases data using natural language through the 
 | **count_weave_traces_tool** | Count traces and get storage metrics | *"How many traces failed?"* |
 | **query_wandb_tool** | Query W&B runs, metrics, and experiments | *"Show me runs with loss < 0.1"* |
 | **get_run_history_tool** | Sampled time-series metric data | *"Show loss curve for run abc123"* |
-| **create_wandb_report_tool** | Create reports with markdown and charts | *"Create a report with loss plots"* |
+| **create_wandb_report_tool** | Create reports with markdown, charts, and panels | *"Create a report with loss plots"* |
+| **log_analysis_to_wandb** | Log analysis metrics to W&B as a run | *"Log these latency stats to W&B"* |
 | **search_wandb_docs_tool** | Search official W&B documentation | *"How do I create a Weave scorer?"* |
 | **query_wandb_entity_projects** | List projects for an entity | *"What projects exist?"* |
-| **query_wandb_support_bot** | ~~Get help from W&B support bot~~ (deprecated) | Use `search_wandb_docs_tool` instead |
+| **list_registries_tool** | List model registries in an organization | *"What registries are available?"* |
+| **list_registry_collections_tool** | List collections within a registry | *"What models are in the prod registry?"* |
+| **list_artifact_versions_tool** | List versions of an artifact collection | *"Show versions of my model artifact"* |
+| **get_artifact_details_tool** | Get full details of an artifact version | *"What's in model-v2 artifact?"* |
+| **compare_artifact_versions_tool** | Diff two artifact versions | *"Compare model v1 vs v2"* |
 
 **Schema-first workflow:** Call `infer_trace_schema_tool` first to discover fields, then `query_weave_traces_tool` with precise columns and `detail_level`:
 - `"schema"` -- structural fields only (fast browsing)
@@ -422,6 +427,41 @@ uvx wandb_mcp_server \
 **Note**: Clients must continue to provide their own W&B API key via Bearer token per the MCP spec.
 </details>
 
+<details>
+<summary><strong>Option 4: Dedicated / On-Prem Deployment</strong></summary>
+
+For W&B Dedicated and On-Prem customers, the MCP server is available as an optional subchart in the `operator-wandb` Helm chart. Enable it with one line in your `WeightsAndBiases` CR:
+
+```yaml
+mcp-server:
+  install: true
+```
+
+The server becomes accessible at `https://<your-instance>/mcp`. It automatically connects to your in-cluster Weave trace server and W&B API.
+
+**Requirements:**
+- `weave-trace` must be installed (`weave-trace.install: true`)
+- Operator chart version >= 0.42.0
+- Image `wandb/mcp-server:0.3.0` or later
+
+**Client configuration** for dedicated instances:
+
+```json
+{
+  "mcpServers": {
+    "wandb": {
+      "url": "https://your-instance.wandb.io/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_WANDB_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Contact your W&B account team to enable MCP on your dedicated deployment.
+</details>
+
 ---
 
 ## More Information
@@ -491,6 +531,11 @@ uvx wandb_mcp_server \
 ```bash
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server --help
 ```
+
+### Contributing & Releasing
+
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** -- Development setup, testing, PR process, architecture overview
+- **[RELEASING.md](RELEASING.md)** -- Version bumping, release checklist, deployment pipeline
 
 ### Key Resources
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,57 @@
+# Releasing the W&B MCP Server
+
+## Overview
+
+This repo contains the MCP server logic (tools, protocol handling, analytics). Deployment infrastructure lives in the private `wandb/wandb-mcp-server-test` repo. See that repo's [RELEASING.md](https://github.com/wandb/wandb-mcp-server-test/blob/main/RELEASING.md) for the full deployment pipeline.
+
+## Version Bumping
+
+Versions are tracked in `pyproject.toml`:
+
+```toml
+[project]
+version = "0.3.0"
+```
+
+To release a new version:
+
+1. Create a PR bumping the version in `pyproject.toml`
+2. Update `__init__.py` `__version__` to match
+3. Ensure all tests pass: `uv run pytest tests/ -v --tb=short`
+4. Ensure lint passes: `uv run ruff check src/ tests/`
+5. Merge to `main`
+
+## What Happens After Merge
+
+1. **Staging auto-deploys**: The test repo's `deploy-staging.yml` triggers on push to its `main`, resolves this repo's `main` to a SHA, and deploys to Cloud Run staging
+2. **Nightly eval runs**: `eval.yml` runs 7 CI smoke tasks via WandBAgentFactory and updates README badges
+3. **Manual promotion**: After staging is verified, a team member promotes to production via `promote-production.yml` in the test repo
+
+## CI Workflows (this repo)
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `ci.yml` | Push to main/staging/*, PR to main | Ruff lint + pytest on Python 3.11 + 3.12 |
+| `eval.yml` | Nightly cron (7 AM UTC) + manual | Run MCP eval suite, update README badges |
+
+## Release Checklist
+
+- [ ] Version bumped in `pyproject.toml`
+- [ ] `__init__.py` `__version__` matches
+- [ ] All 401 unit tests pass
+- [ ] CI green on PR
+- [ ] Staging auto-deployed and healthy (14 tools, `/health` returns 200)
+- [ ] Nightly eval passes (or manual eval triggered)
+- [ ] Production promoted via test repo workflow
+- [ ] On-prem image published via `publish-image.yml` in test repo
+- [ ] Helm chart `values.yaml` image tag updated in helm-charts PR
+- [ ] QA validated on at least one instance (17/17 deployment tests)
+
+## Contacts
+
+| Area | Person |
+|---|---|
+| MCP server code | Anish Shah (@ash0ts) |
+| Code review | Nico (@NiWaRe) |
+| Helm chart | Zachary Blasczyk |
+| Infrastructure | Kevin Chen (@wandb-kc) |


### PR DESCRIPTION
## Summary

Adds developer and release documentation, updates README to reflect current state.

## Changes

- **CONTRIBUTING.md**: Dev setup (`uv venv`, `pre-commit install`), running tests, lint config, local server (STDIO + HTTP), branch naming, PR process, architecture overview, guide for adding new tools, env vars reference
- **RELEASING.md**: Version bumping in `pyproject.toml`, what happens after merge (auto-staging, nightly eval, manual promote), release checklist, contacts
- **README.md**: 
  - Tool count updated from 9 to 14 (added `log_analysis_to_wandb`, `list_registries_tool`, `list_registry_collections_tool`, `list_artifact_versions_tool`, `get_artifact_details_tool`, `compare_artifact_versions_tool`)
  - Removed deprecated `query_wandb_support_bot`
  - Added "Option 4: Dedicated / On-Prem Deployment" section for Helm chart users
  - Added links to CONTRIBUTING.md and RELEASING.md in More Information section

Made with [Cursor](https://cursor.com)