### PR TITLE
release: staging/v0.3.2 (entity discovery + trace content search)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,8 +1,7 @@
 name: Eval
 
-# Nightly + manual eval benchmark against staging.
-# Runs both SDK-only (baseline) and MCP agents via WandBAgentFactory,
-# then updates README badges with pass rates.
+# Nightly MCP server evaluation against staging via WandBAgentFactory.
+# Results are uploaded as artifacts for review.
 
 on:
   schedule:
@@ -12,9 +11,14 @@ on:
   workflow_dispatch:
     inputs:
       agents:
-        description: 'JSON array of agent variants, e.g. ["wandb-primary","mcp-v3-lazy"]'
+        description: 'JSON array of agent configs, e.g. ["claude-mcp","claude-mcp-qa"]'
         required: false
         default: ""
+        type: string
+      eval_config:
+        description: "Eval config file in WandBAgentFactory (e.g. data/evals/mcp-nightly.yaml)"
+        required: false
+        default: "data/evals/mcp-nightly.yaml"
         type: string
       parallelism:
         description: "Weave parallelism (concurrent tasks)"
@@ -30,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJson(inputs.agents || '["wandb-primary", "mcp-v3-lazy"]') }}
+        variant: ${{ fromJson(inputs.agents || '["claude-mcp"]') }}
 
     env:
       WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
@@ -70,10 +74,13 @@ jobs:
         working-directory: wbaf
         run: |
           PARALLELISM="${{ inputs.parallelism || '15' }}"
-          AGENT="claude-code-${{ matrix.variant }}"
-          echo "Agent: $AGENT, parallelism: $PARALLELISM"
-          uv run python -W ignore -m core.run_eval \
-            data/evals/mcp-ci.yaml \
+          AGENT="${{ matrix.variant }}"
+          EVAL_CONFIG="${{ inputs.eval_config || 'data/evals/mcp-nightly.yaml' }}"
+          echo "Agent: $AGENT"
+          echo "Config: $EVAL_CONFIG"
+          echo "Parallelism: $PARALLELISM"
+          uv run python -W ignore -m factory.run_eval \
+            "$EVAL_CONFIG" \
             --agent "$AGENT" \
             --weave-parallelism "$PARALLELISM" \
             2>&1 | tee eval-output.log
@@ -124,104 +131,3 @@ jobs:
           name: results-${{ matrix.variant }}
           path: wbaf/results-summary.json
           retention-days: 90
-
-  update-badges:
-    name: Update README & Badges
-    needs: eval
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.WBAF_PAT }}
-
-      - name: Download all result summaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: results-*
-          path: results/
-
-      - name: Update badges and README
-        run: |
-          python3 -c "
-          import json, re
-          from pathlib import Path
-
-          agents = {}
-          for result_dir in sorted(Path('results').iterdir()):
-              if not result_dir.is_dir():
-                  continue
-              variant = result_dir.name.replace('results-', '')
-              summary_file = result_dir / 'results-summary.json'
-              if summary_file.exists():
-                  agents[variant] = json.loads(summary_file.read_text())
-
-          badge_names = {
-              'wandb-primary': 'sdk',
-              'mcp-v3-lazy': 'mcp',
-          }
-
-          badges_dir = Path('.badges')
-          badges_dir.mkdir(exist_ok=True)
-
-          for variant, data in agents.items():
-              passed = data.get('passed', 0)
-              total = data.get('total', 0)
-              badge_key = badge_names.get(variant, variant)
-
-              if total > 0:
-                  pct = passed / total
-                  label = f'{passed}/{total} ({pct:.0%})'
-                  color = 'brightgreen' if pct >= 0.8 else 'yellow' if pct >= 0.5 else 'red'
-              else:
-                  label = 'no data'
-                  color = 'lightgrey'
-
-              badge = {
-                  'schemaVersion': 1,
-                  'label': badge_key.upper(),
-                  'message': label,
-                  'color': color,
-              }
-              (badges_dir / f'{badge_key}.json').write_text(
-                  json.dumps(badge, indent=2) + '\n'
-              )
-              print(f'{badge_key}: {label} ({color})')
-
-          readme = Path('README.md')
-          content = readme.read_text()
-
-          parts = []
-          for variant, data in sorted(agents.items()):
-              passed = data.get('passed', 0)
-              total = data.get('total', 0)
-              badge_key = badge_names.get(variant, variant)
-              if total > 0:
-                  parts.append(f'{badge_key.upper()}: {passed}/{total} ({passed/total:.0%})')
-          status = ' | '.join(parts) if parts else 'pending'
-
-          pattern = r'<!-- BEGIN EVAL BADGES -->.*?<!-- END EVAL BADGES -->'
-          if re.search(pattern, content, re.DOTALL):
-              sdk_badge = '[![SDK](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wandb/wandb-mcp-server/main/.badges/sdk.json)](https://wandb.ai/wandb/mcp-server-ci/weave)'
-              mcp_badge = '[![MCP](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/wandb/wandb-mcp-server/main/.badges/mcp.json)](https://wandb.ai/wandb/mcp-server-ci/weave)'
-              replacement = f'<!-- BEGIN EVAL BADGES -->\n{sdk_badge}\n{mcp_badge}\n<!-- END EVAL BADGES -->'
-              content = re.sub(pattern, replacement, content, flags=re.DOTALL)
-              readme.write_text(content)
-              print(f'Updated README badges: {status}')
-          else:
-              print('No badge markers found in README, skipping update')
-          "
-
-      - name: Commit results
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md .badges/
-          if git diff --cached --quiet; then
-            echo "No changes"
-          else
-            git commit -m "chore: update eval badges [skip ci]"
-            git push
-          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.0"
+version = "0.3.2"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.2"
 
 # Import the functions we want to expose
 from .server import cli

--- a/src/wandb_mcp_server/mcp_tools/compare_runs.py
+++ b/src/wandb_mcp_server/mcp_tools/compare_runs.py
@@ -1,0 +1,191 @@
+"""Compare two W&B runs: config diff, summary metric diff, optional history overlap."""
+
+import json
+import math
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+COMPARE_RUNS_TOOL_DESCRIPTION = """Compare two W&B runs side-by-side.
+
+Returns config differences, summary metric deltas, and metadata comparison.
+
+<when_to_use>
+Call when the user asks "what changed between run A and B?", "which run is better?",
+or wants to understand why two runs have different performance.
+
+Typical workflow:
+1. query_wandb_tool or get_run_history_tool to identify the two runs
+2. compare_runs_tool to see what differs
+3. create_wandb_report_tool to visualize the comparison
+</when_to_use>
+
+Parameters
+----------
+entity_name : str
+    W&B entity (username or team).
+project_name : str
+    W&B project name.
+run_id_a : str
+    First run ID.
+run_id_b : str
+    Second run ID.
+include_history_overlap : bool, optional
+    If True, sample both runs' history and return aligned rows. Default: False.
+history_keys : list of str, optional
+    Specific metric keys to compare in history. If None, uses common keys.
+history_samples : int, optional
+    Number of history samples per run. Default: 50.
+
+Returns
+-------
+JSON with config_diff, summary_diff, metadata_diff, and optional history_comparison.
+"""
+
+DEFAULT_HISTORY_SAMPLES = 50
+
+
+def _safe_val(v: Any) -> Any:
+    """Make values JSON-serializable."""
+    if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+        return str(v)
+    return v
+
+
+def _diff_dicts(a: Dict, b: Dict) -> Dict[str, Any]:
+    """Compute structured diff between two dicts."""
+    all_keys = sorted(set(list(a.keys()) + list(b.keys())))
+    only_a = {}
+    only_b = {}
+    changed = {}
+    same = {}
+
+    for k in all_keys:
+        in_a = k in a
+        in_b = k in b
+        if in_a and not in_b:
+            only_a[k] = _safe_val(a[k])
+        elif in_b and not in_a:
+            only_b[k] = _safe_val(b[k])
+        elif a[k] != b[k]:
+            entry: Dict[str, Any] = {"run_a": _safe_val(a[k]), "run_b": _safe_val(b[k])}
+            if isinstance(a[k], (int, float)) and isinstance(b[k], (int, float)):
+                try:
+                    entry["delta"] = round(b[k] - a[k], 6)
+                except (TypeError, ValueError):
+                    pass
+            changed[k] = entry
+        else:
+            same[k] = _safe_val(a[k])
+
+    return {
+        "only_in_run_a": only_a,
+        "only_in_run_b": only_b,
+        "changed": changed,
+        "identical_count": len(same),
+    }
+
+
+def compare_runs(
+    entity_name: str,
+    project_name: str,
+    run_id_a: str,
+    run_id_b: str,
+    include_history_overlap: bool = False,
+    history_keys: Optional[List[str]] = None,
+    history_samples: int = DEFAULT_HISTORY_SAMPLES,
+) -> str:
+    """Compare two W&B runs."""
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "compare_runs",
+        api.viewer,
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "run_id_a": run_id_a,
+            "run_id_b": run_id_b,
+        },
+    ) as ctx:
+        try:
+            path = f"{entity_name}/{project_name}"
+            run_a = api.run(f"{path}/{run_id_a}")
+            run_b = api.run(f"{path}/{run_id_b}")
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
+
+        config_a = dict(run_a.config) if run_a.config else {}
+        config_b = dict(run_b.config) if run_b.config else {}
+        summary_a = dict(run_a.summary) if run_a.summary else {}
+        summary_b = dict(run_b.summary) if run_b.summary else {}
+
+        # Filter out internal keys from summary
+        skip_prefixes = ("_", "wandb/")
+        summary_a = {k: v for k, v in summary_a.items() if not any(k.startswith(p) for p in skip_prefixes)}
+        summary_b = {k: v for k, v in summary_b.items() if not any(k.startswith(p) for p in skip_prefixes)}
+
+        result: Dict[str, Any] = {
+            "run_a": {
+                "id": run_id_a,
+                "name": getattr(run_a, "name", run_id_a),
+                "state": getattr(run_a, "state", "unknown"),
+            },
+            "run_b": {
+                "id": run_id_b,
+                "name": getattr(run_b, "name", run_id_b),
+                "state": getattr(run_b, "state", "unknown"),
+            },
+            "config_diff": _diff_dicts(config_a, config_b),
+            "summary_diff": _diff_dicts(summary_a, summary_b),
+            "metadata_diff": {
+                "run_a": {
+                    "created_at": str(getattr(run_a, "created_at", "")),
+                    "heartbeat_at": str(getattr(run_a, "heartbeat_at", "")),
+                    "tags": getattr(run_a, "tags", []),
+                    "group": getattr(run_a, "group", None),
+                },
+                "run_b": {
+                    "created_at": str(getattr(run_b, "created_at", "")),
+                    "heartbeat_at": str(getattr(run_b, "heartbeat_at", "")),
+                    "tags": getattr(run_b, "tags", []),
+                    "group": getattr(run_b, "group", None),
+                },
+            },
+        }
+
+        if include_history_overlap:
+            try:
+                hist_a = list(run_a.scan_history(keys=history_keys, page_size=history_samples))[:history_samples]
+                hist_b = list(run_b.scan_history(keys=history_keys, page_size=history_samples))[:history_samples]
+
+                if history_keys is None:
+                    keys_a = set()
+                    keys_b = set()
+                    for row in hist_a[:5]:
+                        keys_a.update(k for k in row.keys() if not k.startswith("_"))
+                    for row in hist_b[:5]:
+                        keys_b.update(k for k in row.keys() if not k.startswith("_"))
+                    common_keys = sorted(keys_a & keys_b)
+                else:
+                    common_keys = history_keys
+
+                result["history_comparison"] = {
+                    "keys": common_keys,
+                    "run_a_rows": len(hist_a),
+                    "run_b_rows": len(hist_b),
+                    "run_a_sample": [
+                        {k: _safe_val(r.get(k)) for k in ["_step"] + common_keys[:5]} for r in hist_a[:10]
+                    ],
+                    "run_b_sample": [
+                        {k: _safe_val(r.get(k)) for k in ["_step"] + common_keys[:5]} for r in hist_b[:10]
+                    ],
+                }
+            except Exception as e:
+                result["history_comparison"] = {"error": str(e)[:300]}
+
+        return json.dumps(result, default=str)

--- a/src/wandb_mcp_server/mcp_tools/diagnose_run.py
+++ b/src/wandb_mcp_server/mcp_tools/diagnose_run.py
@@ -1,0 +1,248 @@
+"""Diagnose a W&B run: convergence, overfitting, NaN detection, tail statistics."""
+
+import json
+import math
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+DIAGNOSE_RUN_TOOL_DESCRIPTION = """Diagnose a W&B run's training health.
+
+Automatically detects convergence, overfitting, NaN values, and provides
+tail statistics. Returns actionable recommendations.
+
+<when_to_use>
+Call when the user asks "is my run okay?", "has it converged?", "is it
+overfitting?", or wants a health check on a training run.
+
+This tool samples the run's history and applies standard ML diagnostic
+heuristics. Use get_run_history_tool for raw metric data instead.
+</when_to_use>
+
+Parameters
+----------
+entity_name : str
+    W&B entity (username or team).
+project_name : str
+    W&B project name.
+run_id : str
+    The run to diagnose.
+loss_key : str, optional
+    Name of the loss metric. Auto-detected if not provided.
+val_loss_key : str, optional
+    Name of the validation loss metric. Auto-detected if not provided.
+
+Returns
+-------
+JSON with diagnosis (converged/diverging/plateaued/insufficient_data),
+overfit_signal, nan_warnings, tail_stats, and recommendations.
+"""
+
+DIAGNOSIS_SAMPLES = 500
+
+
+def _auto_detect_key(keys: List[str], patterns: List[str]) -> Optional[str]:
+    """Find a key matching any of the patterns (case-insensitive)."""
+    for pattern in patterns:
+        for k in keys:
+            if pattern in k.lower():
+                return k
+    return None
+
+
+def _compute_trend(values: List[float]) -> str:
+    """Classify the trend of a metric series."""
+    if len(values) < 10:
+        return "insufficient_data"
+
+    half = len(values) // 2
+    first_half_mean = sum(values[:half]) / half
+    second_half_mean = sum(values[half:]) / (len(values) - half)
+
+    tail_10 = values[-max(1, len(values) // 10) :]
+    tail_mean = sum(tail_10) / len(tail_10)
+
+    if second_half_mean < first_half_mean * 0.95:
+        if abs(tail_mean - second_half_mean) / max(abs(second_half_mean), 1e-8) < 0.05:
+            return "plateaued"
+        return "decreasing"
+    elif second_half_mean > first_half_mean * 1.05:
+        return "increasing"
+    else:
+        return "plateaued"
+
+
+def _detect_overfit(train_vals: List[float], val_vals: List[float]) -> Dict[str, Any]:
+    """Detect overfitting by comparing train and val loss trends."""
+    if len(train_vals) < 10 or len(val_vals) < 10:
+        return {"detected": False, "reason": "insufficient_data"}
+
+    min_len = min(len(train_vals), len(val_vals))
+    train_vals = train_vals[:min_len]
+    val_vals = val_vals[:min_len]
+
+    half = min_len // 2
+    train_gap_early = sum(abs(v - t) for t, v in zip(train_vals[:half], val_vals[:half])) / half
+    train_gap_late = sum(abs(v - t) for t, v in zip(train_vals[half:], val_vals[half:])) / (min_len - half)
+
+    train_trend = _compute_trend(train_vals)
+    val_trend = _compute_trend(val_vals)
+
+    overfit = train_trend == "decreasing" and val_trend in ("increasing", "plateaued")
+    gap_growing = train_gap_late > train_gap_early * 1.3
+
+    return {
+        "detected": overfit or gap_growing,
+        "train_loss_trend": train_trend,
+        "val_loss_trend": val_trend,
+        "gap_early": round(train_gap_early, 6),
+        "gap_late": round(train_gap_late, 6),
+        "gap_ratio": round(train_gap_late / max(train_gap_early, 1e-8), 3),
+    }
+
+
+def diagnose_run(
+    entity_name: str,
+    project_name: str,
+    run_id: str,
+    loss_key: Optional[str] = None,
+    val_loss_key: Optional[str] = None,
+) -> str:
+    """Diagnose a W&B run's training health."""
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "diagnose_run",
+        api.viewer,
+        {"entity_name": entity_name, "project_name": project_name, "run_id": run_id},
+    ) as ctx:
+        try:
+            run = api.run(f"{entity_name}/{project_name}/{run_id}")
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
+
+        try:
+            history_rows = list(run.scan_history(page_size=DIAGNOSIS_SAMPLES))[:DIAGNOSIS_SAMPLES]
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "history_fetch_failed", "message": str(e)[:500]})
+
+        if not history_rows:
+            return json.dumps(
+                {
+                    "diagnosis": "no_history",
+                    "message": "Run has no logged history steps.",
+                    "run_id": run_id,
+                    "run_name": getattr(run, "name", run_id),
+                }
+            )
+
+        all_keys = set()
+        for row in history_rows[:10]:
+            all_keys.update(k for k in row.keys() if not k.startswith("_"))
+        all_keys = sorted(all_keys)
+
+        if loss_key is None:
+            loss_key = _auto_detect_key(all_keys, ["train_loss", "train/loss", "loss"])
+        if val_loss_key is None:
+            val_loss_key = _auto_detect_key(
+                all_keys, ["val_loss", "val/loss", "eval_loss", "eval/loss", "validation_loss"]
+            )
+
+        # NaN detection
+        nan_warnings = {}
+        for key in all_keys:
+            vals = [row.get(key) for row in history_rows if row.get(key) is not None]
+            nan_count = sum(1 for v in vals if isinstance(v, float) and (math.isnan(v) or math.isinf(v)))
+            if nan_count > 0:
+                nan_warnings[key] = {
+                    "nan_count": nan_count,
+                    "total": len(vals),
+                    "fraction": round(nan_count / max(len(vals), 1), 4),
+                }
+
+        # Loss analysis
+        diagnosis = "unknown"
+        loss_stats = None
+        if loss_key:
+            loss_vals = [
+                row.get(loss_key)
+                for row in history_rows
+                if isinstance(row.get(loss_key), (int, float)) and not math.isnan(row.get(loss_key, float("nan")))
+            ]
+            if len(loss_vals) >= 10:
+                trend = _compute_trend(loss_vals)
+                tail_n = max(1, len(loss_vals) // 10)
+                loss_stats = {
+                    "key": loss_key,
+                    "first_value": round(loss_vals[0], 6),
+                    "last_value": round(loss_vals[-1], 6),
+                    "min_value": round(min(loss_vals), 6),
+                    "tail_mean": round(sum(loss_vals[-tail_n:]) / tail_n, 6),
+                    "overall_mean": round(sum(loss_vals) / len(loss_vals), 6),
+                    "trend": trend,
+                    "total_steps": len(loss_vals),
+                }
+
+                if trend == "decreasing":
+                    diagnosis = "training"
+                elif trend == "plateaued":
+                    diagnosis = "converged"
+                elif trend == "increasing":
+                    diagnosis = "diverging"
+            else:
+                diagnosis = "insufficient_data"
+        else:
+            diagnosis = "no_loss_key"
+
+        # Overfit detection
+        overfit = {"detected": False, "reason": "no_val_loss_key"}
+        if loss_key and val_loss_key:
+            train_vals = [
+                row.get(loss_key)
+                for row in history_rows
+                if isinstance(row.get(loss_key), (int, float)) and not math.isnan(row.get(loss_key, float("nan")))
+            ]
+            val_vals = [
+                row.get(val_loss_key)
+                for row in history_rows
+                if isinstance(row.get(val_loss_key), (int, float))
+                and not math.isnan(row.get(val_loss_key, float("nan")))
+            ]
+            overfit = _detect_overfit(train_vals, val_vals)
+
+        # Recommendations
+        recommendations = []
+        if diagnosis == "diverging":
+            recommendations.append("Loss is increasing -- consider reducing learning rate or checking data pipeline.")
+        if diagnosis == "converged":
+            recommendations.append("Training appears converged -- run can likely be stopped to save compute.")
+        if overfit.get("detected"):
+            recommendations.append(
+                "Overfitting detected -- consider adding regularization, dropout, or early stopping."
+            )
+        if nan_warnings:
+            recommendations.append(
+                f"NaN/Inf values found in {len(nan_warnings)} metric(s) -- check for numerical instability."
+            )
+
+        return json.dumps(
+            {
+                "run_id": run_id,
+                "run_name": getattr(run, "name", run_id),
+                "run_state": getattr(run, "state", "unknown"),
+                "diagnosis": diagnosis,
+                "loss_stats": loss_stats,
+                "overfit_signal": overfit,
+                "nan_warnings": nan_warnings if nan_warnings else None,
+                "available_keys": all_keys[:30],
+                "detected_keys": {"loss": loss_key, "val_loss": val_loss_key},
+                "total_history_rows": len(history_rows),
+                "recommendations": recommendations,
+            },
+            default=str,
+        )

--- a/src/wandb_mcp_server/mcp_tools/list_entities.py
+++ b/src/wandb_mcp_server/mcp_tools/list_entities.py
@@ -1,0 +1,53 @@
+"""Lightweight entity discovery tool.
+
+Returns the authenticated user's personal entity and team memberships
+without enumerating projects. Agents use this to discover which entity
+name to pass to other tools (query_traces, list_entity_projects, etc.).
+"""
+
+import json
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+LIST_ENTITIES_TOOL_DESCRIPTION = """List W&B entities (username + teams) the current API key has access to.
+
+Returns entity names and types WITHOUT listing projects (fast, lightweight).
+
+<when_to_use>
+Call this FIRST when:
+- The user hasn't specified which entity (username or team) to use
+- You need to discover available entities before querying projects or data
+- The user asks "what teams do I have?" or "what's my entity?"
+
+After getting entity names, call list_entity_projects with a SPECIFIC entity
+to get that entity's projects.
+</when_to_use>
+
+<critical_info>
+This is a discovery-only tool. It does NOT list projects.
+Use list_entity_projects(entity="<name>") to get projects for a specific entity.
+</critical_info>
+
+Returns
+-------
+JSON with:
+  - entities: list of {name, type} where type is "user" or "team"
+  - count: total number of entities
+"""
+
+
+def list_entities() -> str:
+    """List W&B entities (user + teams) accessible with the current API key."""
+    api = WandBApiManager.get_api()
+    viewer = api.viewer
+
+    with track_tool_execution("list_entities", viewer, {}):
+        entities = [{"name": viewer.entity, "type": "user"}]
+        for team in getattr(viewer, "teams", []):
+            entities.append({"name": team, "type": "team"})
+
+        return json.dumps({"entities": entities, "count": len(entities)})

--- a/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
+++ b/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
@@ -1,117 +1,107 @@
-from typing import Any
+"""List projects for a specific W&B entity."""
 
-from wandb_mcp_server.utils import get_rich_logger
+import json
+from typing import Optional
+
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
-
-
-LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION = """
-Fetch all projects for a specific wandb or weave entity. Useful to use when
-the user hasn't specified a project name or queries are failing due to a
-missing or incorrect Weights & Biases project name.
-
-If no entity is provided, the tool will fetch all projects for the current user
-as well as all the project in the teams they are part of.
-
-<when_to_use>
-Call this tool FIRST when the user mentions a W&B entity but has not specified a
-project name, or when queries fail due to "project not found" errors. This
-resolves entity/project discovery before any data query.
-</when_to_use>
-
-<critical_info>
-
-**Important:**
-
-Do not use this tool if the user has not specified a W&BB entity name. Instead ask
-the user to provide either their W&B username or W&B team name.
-</critical_info>
-
-<debugging_tips>
-
-**Error Handling:**
-
-If this function throws an error, it's likely because the W&B entity name is incorrect.
-If this is the case, ask the user to double check the W&B entity name given by the user,
-either their personal user or their W&B Team name.
-
-**Expected Project Name Not Found:**
-
-If the user doesn't see the project they're looking for in the list of projects,
-ask them to double check the W&B entity name, either their personal W&B username or their
-W&B Team name.
-</debugging_tips>
-
-Args:
-    entity (str): The wandb entity (username or team name)
-
-Returns:
-    List[Dict[str, Any]]: List of project dictionaries containing:
-        - name: Project name
-        - entity: Entity name
-        - description: Project description
-        - visibility: Project visibility (public/private)
-        - created_at: Creation timestamp
-        - updated_at: Last update timestamp
-        - tags: List of project tags
-"""
-
+from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
 
+DEFAULT_MAX_PROJECTS = 50
+MAX_PROJECTS_CEILING = 200
+MAX_ENTITIES_WHEN_NONE = 5
 
-def list_entity_projects(entity: str | None = None) -> dict[str, list[dict[str, Any]]]:
-    """
-    Fetch all projects for a specific wandb entity. If no entity is provided,
-    fetches projects for the current user and their teams.
+LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION = """List projects for a W&B entity (username or team).
 
-    Args:
-        entity (str, optional): The wandb entity (username or team name). If None,
-                               fetches projects for the current user and their teams.
+<when_to_use>
+Call this when the user has specified an entity but needs to find a project name,
+or when queries fail due to "project not found" errors.
 
-    Returns:
-        Dict[str, List[Dict[str, Any]]]: Dictionary mapping entity names to lists of project dictionaries.
-            Each project dictionary contains:
-            - name: Project name
-            - entity: Entity name
-            - description: Project description
-            - visibility: Project visibility (public/private)
-            - created_at: Creation timestamp
-            - updated_at: Last update timestamp
-            - tags: List of project tags
-    """
+Preferred workflow:
+1. Call list_entities first to discover available entity names
+2. Call this tool with entity="<specific name>" to list that entity's projects
+</when_to_use>
+
+<critical_info>
+Always pass a specific entity name when possible. If entity is omitted, only
+the first 5 entities are listed with up to max_projects each to avoid
+overwhelming the response. Use list_entities for full entity discovery.
+</critical_info>
+
+Parameters
+----------
+entity : str, optional
+    W&B entity (username or team name). If omitted, lists projects for
+    the current user + up to 5 teams (bounded).
+max_projects : int, optional
+    Maximum projects to return per entity. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - projects: dict mapping entity name -> list of project objects
+  - truncated: whether any entity's project list was capped
+"""
+
+
+def list_entity_projects(
+    entity: Optional[str] = None,
+    max_projects: int = DEFAULT_MAX_PROJECTS,
+) -> str:
+    """List projects for a W&B entity with bounded results."""
     from wandb_mcp_server.api_client import get_wandb_api
 
     api = get_wandb_api()
+    max_projects = min(max(1, max_projects), MAX_PROJECTS_CEILING)
 
     viewer = None
     if entity is None:
         viewer = api.viewer
-        entities = [viewer.entity] + viewer.teams
+        all_entities = [viewer.entity] + getattr(viewer, "teams", [])
+        entities = all_entities[:MAX_ENTITIES_WHEN_NONE]
+        entities_truncated = len(all_entities) > MAX_ENTITIES_WHEN_NONE
     else:
         entities = [entity]
+        entities_truncated = False
 
     with track_tool_execution(
         "list_entity_projects",
-        viewer,
-        {"entity": entity},
-    ):
+        viewer or entity,
+        {"entity": entity, "max_projects": max_projects},
+    ) as ctx:
         entities_projects = {}
-        for entity in entities:
-            projects = api.projects(entity)
+        any_projects_truncated = False
 
-            projects_data = []
-            for project in projects:
-                project_dict = {
-                    "name": project.name,
-                    "entity": project.entity,
-                    "description": getattr(project, "description", None),
-                    "visibility": getattr(project, "visibility", None),
-                    "created_at": getattr(project, "created_at", None),
-                    "updated_at": getattr(project, "updated_at", None),
-                    "tags": getattr(project, "tags", []),
-                }
-                projects_data.append(project_dict)
+        for ent in entities:
+            try:
+                projects = api.projects(ent)
+                projects_data = []
+                for project in projects:
+                    if len(projects_data) >= max_projects:
+                        any_projects_truncated = True
+                        break
+                    projects_data.append(
+                        {
+                            "name": project.name,
+                            "entity": project.entity,
+                            "description": getattr(project, "description", None),
+                            "visibility": getattr(project, "visibility", None),
+                            "created_at": str(getattr(project, "created_at", "")),
+                            "updated_at": str(getattr(project, "updated_at", "")),
+                            "tags": getattr(project, "tags", []),
+                        }
+                    )
+                entities_projects[ent] = projects_data
+            except Exception as e:
+                logger.warning(f"Failed to list projects for entity {ent}: {e}")
+                ctx.mark_error(f"{type(e).__name__}: {e}")
+                entities_projects[ent] = [{"error": str(e)}]
 
-            entities_projects[entity] = projects_data
-
-        return entities_projects
+        return json.dumps(
+            {
+                "projects": entities_projects,
+                "truncated": any_projects_truncated or entities_truncated,
+                "max_projects_per_entity": max_projects,
+            }
+        )

--- a/src/wandb_mcp_server/mcp_tools/probe_project.py
+++ b/src/wandb_mcp_server/mcp_tools/probe_project.py
@@ -1,0 +1,173 @@
+"""Probe a W&B project: discover run structure, metric keys, config keys, and recommended strategies."""
+
+import json
+from typing import Any, Dict, List
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+PROBE_PROJECT_TOOL_DESCRIPTION = """Probe a W&B project to discover its structure before querying.
+
+Samples runs to discover available metric keys, config keys, tags, groups,
+and provides recommended query strategies. This is the run-side equivalent
+of infer_trace_schema_tool (which is for Weave traces).
+
+<when_to_use>
+Call FIRST when working with a new project to understand what data is available
+before making specific queries. Essential for:
+- Discovering which metrics are logged (loss, accuracy, custom metrics)
+- Finding config keys (learning_rate, model, batch_size)
+- Understanding project scale (run count, typical step counts)
+- Getting query strategy recommendations
+
+Typical workflow:
+1. probe_project_tool to discover structure
+2. query_wandb_tool or get_run_history_tool with the discovered keys
+3. create_wandb_report_tool to visualize
+</when_to_use>
+
+Parameters
+----------
+entity_name : str
+    W&B entity (username or team).
+project_name : str
+    W&B project name.
+sample_runs : int, optional
+    Number of runs to sample for key discovery. Default: 5.
+
+Returns
+-------
+JSON with run_count, metric_keys, config_keys, has_history, typical_steps,
+tags, groups, and recommendations.
+"""
+
+DEFAULT_SAMPLE_RUNS = 5
+
+
+def probe_project(
+    entity_name: str,
+    project_name: str,
+    sample_runs: int = DEFAULT_SAMPLE_RUNS,
+) -> str:
+    """Probe a W&B project to discover its structure."""
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "probe_project",
+        api.viewer,
+        {"entity_name": entity_name, "project_name": project_name, "sample_runs": sample_runs},
+    ) as ctx:
+        path = f"{entity_name}/{project_name}"
+
+        try:
+            runs_iter = api.runs(path, per_page=sample_runs)
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "project_not_found", "message": str(e)[:500]})
+
+        run_count = 0
+        metric_keys: Dict[str, str] = {}
+        config_keys: Dict[str, Any] = {}
+        all_tags: List[str] = []
+        all_groups: List[str] = []
+        step_counts: List[int] = []
+        states: Dict[str, int] = {}
+        sampled = 0
+
+        try:
+            for run in runs_iter:
+                run_count += 1
+                if sampled >= sample_runs:
+                    continue
+
+                state = getattr(run, "state", "unknown")
+                states[state] = states.get(state, 0) + 1
+
+                summary = dict(run.summary) if run.summary else {}
+                for k, v in summary.items():
+                    if k.startswith("_") or k.startswith("wandb/"):
+                        continue
+                    if k not in metric_keys:
+                        metric_keys[k] = type(v).__name__
+
+                config = dict(run.config) if run.config else {}
+                for k, v in config.items():
+                    if k.startswith("_") or k.startswith("wandb"):
+                        continue
+                    if k not in config_keys:
+                        config_keys[k] = _safe_sample_value(v)
+
+                tags = getattr(run, "tags", [])
+                if tags:
+                    all_tags.extend(tags)
+
+                group = getattr(run, "group", None)
+                if group and group not in all_groups:
+                    all_groups.append(group)
+
+                last_step = getattr(run, "lastHistoryStep", 0)
+                if last_step and last_step > 0:
+                    step_counts.append(last_step)
+
+                sampled += 1
+        except Exception as e:
+            logger.warning(f"Error iterating runs: {e}")
+
+        unique_tags = sorted(set(all_tags))
+        has_history = len(step_counts) > 0
+        typical_steps = int(sum(step_counts) / len(step_counts)) if step_counts else 0
+
+        recommendations = []
+        if run_count > 100:
+            recommendations.append(
+                f"Large project ({run_count} runs) -- use filters in query_wandb_tool to narrow results."
+            )
+        if typical_steps > 10000:
+            recommendations.append(
+                f"Long runs (~{typical_steps} steps) -- use keys=[...] and samples parameter in get_run_history_tool."
+            )
+        if len(metric_keys) > 20:
+            recommendations.append(f"Many metrics ({len(metric_keys)}) -- specify keys to avoid large responses.")
+        if unique_tags:
+            recommendations.append(
+                f"Tags in use: {unique_tags[:10]}. Filter by tag in query_wandb_tool for focused analysis."
+            )
+        if all_groups:
+            recommendations.append(f"Run groups found: {all_groups[:5]}. Group-based comparison may be useful.")
+        if not recommendations:
+            recommendations.append("Small project -- standard queries should work well.")
+
+        return json.dumps(
+            {
+                "entity": entity_name,
+                "project": project_name,
+                "run_count": run_count,
+                "sampled_runs": sampled,
+                "run_states": states,
+                "metric_keys": metric_keys,
+                "metric_count": len(metric_keys),
+                "config_keys": config_keys,
+                "config_count": len(config_keys),
+                "has_history": has_history,
+                "typical_steps": typical_steps,
+                "tags": unique_tags[:20],
+                "groups": all_groups[:10],
+                "recommendations": recommendations,
+            },
+            default=str,
+        )
+
+
+def _safe_sample_value(v: Any) -> Any:
+    """Return a JSON-safe sample value for display."""
+    if isinstance(v, (str, int, float, bool)):
+        if isinstance(v, str) and len(v) > 100:
+            return v[:100] + "..."
+        return v
+    if isinstance(v, (list, tuple)):
+        return f"[{type(v).__name__}, len={len(v)}]"
+    if isinstance(v, dict):
+        return f"{{dict, keys={len(v)}}}"
+    return str(v)[:50]

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -160,6 +160,21 @@ if given an evaluation trace id or name.
         *   A dictionary with a comparison operator: `$gt`, `$lt`, `$eq`, `$gte`, `$lte` (e.g., `{"token_count": {"$gt": 100}}`)
         *   A dictionary with the `$contains` operator for substring matching on string attributes (e.g., `{"model_name": {"$contains": "gpt-3"}}`)
         **Warning:** The `$contains` operator performs simple substring matching only, full regular expression matching (e.g., via `$regex`) is **not supported** for attributes. Do not attempt to use `$regex`.
+    - inputs : dict, optional
+        Filter on trace input fields using dot-path keys. Supports `$contains` for
+        substring search and comparison operators.
+        Examples:
+        *   `"inputs": {"message": {"$contains": "search phrase"}}` -- find traces where input.message contains text
+        *   `"inputs": {"model": "gpt-4"}` -- find traces where input.model equals "gpt-4"
+        **PERFORMANCE WARNING:** Content search on inputs scans trace data server-side.
+        For projects with >10k traces, ALWAYS combine with other filters (time_range,
+        op_name, trace_roots_only) to narrow the scan.
+    - output : dict, optional
+        Filter on trace output fields. Supports the same operators as inputs.
+        Examples:
+        *   `"output": {"$contains": "error message"}` -- search the full output for a substring
+        *   `"output": {"result": {"$contains": "success"}}` -- search output.result for a substring
+        **PERFORMANCE WARNING:** Same as inputs -- combine with other filters for large projects.
     - has_exception : bool, optional
         Optional[bool] to filter traces by exception status:
         - None (or key not present): Show all traces regardless of exception status

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -231,6 +231,16 @@ detail_level : str, optional
     - "full": Everything untruncated. Use only when drilling into specific trace_ids, never
       for bulk queries as it can overwhelm the context window.
 
+<root_span_resolution>
+If you find child traces and need to know which root session they belong to,
+use resolve_trace_roots_tool with the trace_ids from the results.
+This resolves all roots in a single batched call (O(1), not N separate lookups).
+
+Typical workflow:
+1. query_weave_traces_tool(filters={...}) -> find child traces
+2. resolve_trace_roots_tool(entity_name, project_name, trace_ids=[...]) -> get root context
+</root_span_resolution>
+
 Returns
 -------
 str
@@ -282,6 +292,21 @@ str
         project_name="my-project",
         filters={"call_ids": ["01958ab9-3c68-7c23-8ccd-c135c7037769"]},
         detail_level="full"
+    )
+
+    # Content search + root resolution (two-step workflow):
+    # Step 1: Find child traces matching content
+    results = query_traces_tool(
+        entity_name="my-team",
+        project_name="my-project",
+        filters={"inputs": {"message": {"$contains": "restaurant rush"}}},
+        detail_level="schema"
+    )
+    # Step 2: Resolve root spans for the found traces
+    resolve_trace_roots_tool(
+        entity_name="my-team",
+        project_name="my-project",
+        trace_ids=["<unique trace_ids from step 1>"]
     )
     ```
 </examples>

--- a/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
+++ b/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
@@ -1,0 +1,107 @@
+"""Batch-resolve root spans for child trace_ids in a single query."""
+
+import json
+from typing import List
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.query_weave import get_trace_service
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+RESOLVE_TRACE_ROOTS_TOOL_DESCRIPTION = """Batch-resolve root spans for a list of child trace_ids.
+
+Given trace_ids from child traces, returns the root span (top-level parent)
+for each in a SINGLE batched query. This eliminates the N+1 problem of
+looking up root spans one at a time.
+
+<when_to_use>
+Call AFTER query_weave_traces_tool when you have found child traces and need
+to know which root session, conversation, or workflow each belongs to.
+
+Typical two-step workflow:
+1. query_weave_traces_tool(filters={...}) -> find matching child traces
+2. resolve_trace_roots_tool(trace_ids=[unique trace_ids from results])
+   -> get root span name/context for each in one call
+
+Common use cases:
+- Content search: find LLM calls containing text, then map to sessions
+- Error triage: find traces with exceptions, then identify root workflows
+- Cost analysis: find expensive child calls, then identify parent pipelines
+</when_to_use>
+
+<critical_info>
+Performance: O(1) API calls regardless of how many trace_ids are passed.
+Each trace_id maps to exactly one root span (the trace's top-level parent).
+Root spans have parent_id=null and share the same trace_id as their children.
+</critical_info>
+
+Parameters
+----------
+entity_name : str
+    W&B entity (username or team).
+project_name : str
+    W&B project name.
+trace_ids : list of str
+    List of trace_id values from child traces to resolve.
+
+Returns
+-------
+JSON with:
+  - roots: dict mapping trace_id -> root span {id, trace_id, op_name, display_name, started_at}
+  - resolved: number of trace_ids successfully resolved
+  - total_requested: number of unique trace_ids requested
+"""
+
+
+def resolve_trace_roots(
+    entity_name: str,
+    project_name: str,
+    trace_ids: List[str],
+) -> str:
+    """Batch-resolve root spans for child trace_ids."""
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "resolve_trace_roots",
+        api.viewer,
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "trace_id_count": len(trace_ids),
+        },
+    ) as ctx:
+        if not trace_ids:
+            return json.dumps({"roots": {}, "resolved": 0, "total_requested": 0})
+
+        try:
+            service = get_trace_service()
+            root_map = service.resolve_trace_roots(
+                entity_name=entity_name,
+                project_name=project_name,
+                trace_ids=trace_ids,
+            )
+
+            roots = {}
+            for tid, root in root_map.items():
+                roots[tid] = {
+                    "id": root.get("id"),
+                    "trace_id": root.get("trace_id"),
+                    "op_name": root.get("op_name"),
+                    "display_name": root.get("display_name"),
+                    "started_at": root.get("started_at"),
+                }
+
+            unique_count = len(set(trace_ids))
+            return json.dumps(
+                {
+                    "roots": roots,
+                    "resolved": len(roots),
+                    "total_requested": unique_count,
+                },
+                default=str,
+            )
+
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "resolve_failed", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
+++ b/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
@@ -1,0 +1,177 @@
+"""Summarize Weave evaluation results with aggregated pass rates and metrics."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.weave_api.service import TraceService
+from wandb_mcp_server.config import WF_TRACE_SERVER_URL
+
+logger = get_rich_logger(__name__)
+
+SUMMARIZE_EVALUATION_TOOL_DESCRIPTION = """Summarize Weave evaluation results with aggregated pass rates and metrics.
+
+Finds Evaluation.evaluate traces in a project and returns aggregated results
+including per-scorer pass rates, error counts, and token usage.
+
+<when_to_use>
+Call when the user asks "how did my eval go?", "what's the pass rate?", "which
+tasks fail most?", or wants a summary of evaluation results without manually
+navigating trace hierarchies.
+
+This tool aggregates the Evaluation.evaluate -> predict_and_score trace hierarchy
+automatically. Use query_weave_traces_tool for raw trace data instead.
+</when_to_use>
+
+Parameters
+----------
+entity_name : str
+    W&B entity (username or team).
+project_name : str
+    W&B project name.
+eval_name : str, optional
+    Filter to a specific evaluation by op_name. If None, summarizes all evals.
+max_evals : int, optional
+    Maximum number of evaluation runs to summarize. Default: 5.
+include_per_task : bool, optional
+    If True, includes per-input-row breakdown. Default: False.
+
+Returns
+-------
+JSON with evaluations (list of eval summaries) and optional comparison.
+"""
+
+
+def _extract_scores(summary: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract scorer results from a trace's summary."""
+    scores = {}
+    weave_summary = summary.get("weave", {})
+    for key, val in weave_summary.items():
+        if isinstance(val, dict) and ("mean" in val or "true_count" in val or "true_fraction" in val):
+            scores[key] = val
+    return scores
+
+
+def _aggregate_eval(eval_trace: Dict[str, Any], children: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate a single evaluation's results."""
+    summary = eval_trace.get("summary", {})
+    scores = _extract_scores(summary)
+
+    total = len(children)
+    errors = sum(
+        1 for c in children if c.get("exception") or c.get("summary", {}).get("weave", {}).get("status") == "error"
+    )
+    successes = total - errors
+
+    usage_total = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    for child in children:
+        child_usage = child.get("summary", {}).get("usage", {})
+        for model_usage in child_usage.values() if isinstance(child_usage, dict) else []:
+            if isinstance(model_usage, dict):
+                for k in usage_total:
+                    usage_total[k] += model_usage.get(k, 0)
+
+    return {
+        "eval_id": eval_trace.get("id", ""),
+        "op_name": eval_trace.get("op_name", ""),
+        "started_at": eval_trace.get("started_at", ""),
+        "total_predictions": total,
+        "successes": successes,
+        "errors": errors,
+        "error_rate": round(errors / max(total, 1), 4),
+        "scores": scores,
+        "token_usage": usage_total,
+    }
+
+
+def summarize_evaluation(
+    entity_name: str,
+    project_name: str,
+    eval_name: Optional[str] = None,
+    max_evals: int = 5,
+    include_per_task: bool = False,
+) -> str:
+    """Summarize Weave evaluation results."""
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "summarize_evaluation",
+        api.viewer,
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "eval_name": eval_name,
+            "max_evals": max_evals,
+        },
+    ) as ctx:
+        try:
+            service = TraceService(
+                api_key=WandBApiManager.get_api_key(),
+                server_url=WF_TRACE_SERVER_URL,
+            )
+
+            filters: Dict[str, Any] = {"op_name_contains": "Evaluation.evaluate"}
+            if eval_name:
+                filters["op_name_contains"] = eval_name
+            filters["trace_roots_only"] = True
+
+            result = service.query_traces(
+                entity_name=entity_name,
+                project_name=project_name,
+                filters=filters,
+                limit=max_evals,
+                sort_by="started_at",
+                sort_direction="desc",
+                return_full_data=True,
+            )
+
+            eval_traces = result.traces if result.traces else []
+            if not eval_traces:
+                return json.dumps(
+                    {
+                        "evaluations": [],
+                        "message": "No Evaluation.evaluate traces found in this project.",
+                    }
+                )
+
+            evaluations = []
+            for eval_trace in eval_traces[:max_evals]:
+                child_result = service.query_traces(
+                    entity_name=entity_name,
+                    project_name=project_name,
+                    filters={"parent_ids": [eval_trace.get("id", "")]},
+                    limit=500,
+                    return_full_data=True,
+                )
+                children = child_result.traces if child_result.traces else []
+                summary = _aggregate_eval(eval_trace, children)
+
+                if include_per_task and children:
+                    per_task = []
+                    for child in children[:50]:
+                        task_entry = {
+                            "id": child.get("id", ""),
+                            "status": child.get("summary", {}).get("weave", {}).get("status", "unknown"),
+                            "has_exception": child.get("exception") is not None,
+                        }
+                        child_scores = _extract_scores(child.get("summary", {}))
+                        if child_scores:
+                            task_entry["scores"] = child_scores
+                        per_task.append(task_entry)
+                    summary["per_task"] = per_task
+
+                evaluations.append(summary)
+
+            return json.dumps(
+                {
+                    "evaluations": evaluations,
+                    "count": len(evaluations),
+                    "project": f"{entity_name}/{project_name}",
+                },
+                default=str,
+            )
+
+        except Exception as e:
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "evaluation_query_failed", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
+++ b/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
@@ -4,10 +4,9 @@ import json
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.query_weave import get_trace_service
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.weave_api.service import TraceService
-from wandb_mcp_server.config import WF_TRACE_SERVER_URL
 
 logger = get_rich_logger(__name__)
 
@@ -106,10 +105,7 @@ def summarize_evaluation(
         },
     ) as ctx:
         try:
-            service = TraceService(
-                api_key=WandBApiManager.get_api_key(),
-                server_url=WF_TRACE_SERVER_URL,
-            )
+            service = get_trace_service()
 
             filters: Dict[str, Any] = {"op_name_contains": "Evaluation.evaluate"}
             if eval_name:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -33,6 +33,10 @@ except ImportError:
     weave = None
     WEAVE_AVAILABLE = False
 
+from wandb_mcp_server.mcp_tools.list_entities import (
+    LIST_ENTITIES_TOOL_DESCRIPTION,
+    list_entities,
+)
 from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import (
     LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION,
     list_entity_projects,
@@ -529,9 +533,18 @@ def register_tools(mcp_instance: FastMCP) -> None:
             logger.error(f"Error in log_analysis_to_wandb: {e}", exc_info=True)
             return json.dumps({"error": "log_failed", "message": str(e)[:500]})
 
+    @mcp_instance.tool(description=LIST_ENTITIES_TOOL_DESCRIPTION)
+    def list_entities_tool() -> str:
+        """List W&B entities (user + teams) accessible with the current API key."""
+        return list_entities()
+
     @mcp_instance.tool(description=LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION)
-    def query_wandb_entity_projects(entity: Optional[str] = None) -> Dict[str, List[Dict[str, Any]]]:
-        return list_entity_projects(entity)
+    def query_wandb_entity_projects(
+        entity: Optional[str] = None,
+        max_projects: int = 50,
+    ) -> str:
+        """List projects for a W&B entity."""
+        return list_entity_projects(entity=entity, max_projects=max_projects)
 
     from wandb_mcp_server.mcp_tools.infer_schema import (
         INFER_TRACE_SCHEMA_TOOL_DESCRIPTION,

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -694,6 +694,96 @@ def register_tools(mcp_instance: FastMCP) -> None:
             max_file_diff_entries=max_file_diff_entries,
         )
 
+    # ----- wb_agent-inspired analysis tools (v0.3.2) -----
+
+    from wandb_mcp_server.mcp_tools.compare_runs import (
+        COMPARE_RUNS_TOOL_DESCRIPTION,
+        compare_runs,
+    )
+
+    @mcp_instance.tool(description=COMPARE_RUNS_TOOL_DESCRIPTION)
+    def compare_runs_tool(
+        entity_name: str,
+        project_name: str,
+        run_id_a: str,
+        run_id_b: str,
+        include_history_overlap: bool = False,
+        history_keys: Optional[List[str]] = None,
+        history_samples: int = 50,
+    ) -> str:
+        """Compare two W&B runs side-by-side."""
+        return compare_runs(
+            entity_name=entity_name,
+            project_name=project_name,
+            run_id_a=run_id_a,
+            run_id_b=run_id_b,
+            include_history_overlap=include_history_overlap,
+            history_keys=history_keys,
+            history_samples=history_samples,
+        )
+
+    from wandb_mcp_server.mcp_tools.summarize_evaluation import (
+        SUMMARIZE_EVALUATION_TOOL_DESCRIPTION,
+        summarize_evaluation,
+    )
+
+    @mcp_instance.tool(description=SUMMARIZE_EVALUATION_TOOL_DESCRIPTION)
+    def summarize_evaluation_tool(
+        entity_name: str,
+        project_name: str,
+        eval_name: Optional[str] = None,
+        max_evals: int = 5,
+        include_per_task: bool = False,
+    ) -> str:
+        """Summarize Weave evaluation results."""
+        return summarize_evaluation(
+            entity_name=entity_name,
+            project_name=project_name,
+            eval_name=eval_name,
+            max_evals=max_evals,
+            include_per_task=include_per_task,
+        )
+
+    from wandb_mcp_server.mcp_tools.diagnose_run import (
+        DIAGNOSE_RUN_TOOL_DESCRIPTION,
+        diagnose_run,
+    )
+
+    @mcp_instance.tool(description=DIAGNOSE_RUN_TOOL_DESCRIPTION)
+    def diagnose_run_tool(
+        entity_name: str,
+        project_name: str,
+        run_id: str,
+        loss_key: Optional[str] = None,
+        val_loss_key: Optional[str] = None,
+    ) -> str:
+        """Diagnose a W&B run's training health."""
+        return diagnose_run(
+            entity_name=entity_name,
+            project_name=project_name,
+            run_id=run_id,
+            loss_key=loss_key,
+            val_loss_key=val_loss_key,
+        )
+
+    from wandb_mcp_server.mcp_tools.probe_project import (
+        PROBE_PROJECT_TOOL_DESCRIPTION,
+        probe_project,
+    )
+
+    @mcp_instance.tool(description=PROBE_PROJECT_TOOL_DESCRIPTION)
+    def probe_project_tool(
+        entity_name: str,
+        project_name: str,
+        sample_runs: int = 5,
+    ) -> str:
+        """Probe a W&B project to discover its structure."""
+        return probe_project(
+            entity_name=entity_name,
+            project_name=project_name,
+            sample_runs=sample_runs,
+        )
+
 
 # ===============================================================================
 # SECTION 4: MCP SERVER SETUP (STDIO & HTTP)

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -265,13 +265,27 @@ def register_tools(mcp_instance: FastMCP) -> None:
     """
     Register all W&B MCP tools on the given FastMCP instance.
 
-    Available tools:
+    Available tools (20):
     - query_weave_traces_tool: Query LLM traces with filtering and pagination
     - count_weave_traces_tool: Efficiently count traces without returning data
+    - resolve_trace_roots_tool: Batch-resolve root spans for child trace_ids
     - query_wandb_tool: Execute GraphQL queries against W&B experiment data
     - create_wandb_report_tool: Create shareable reports with visualizations
-    - query_wandb_entity_projects: List available entities and projects
+    - log_analysis_to_wandb: Log analysis results as W&B runs
+    - list_entities_tool: List W&B entities (user + teams)
+    - query_wandb_entity_projects: List projects for an entity
+    - infer_trace_schema_tool: Discover trace field schema by sampling
     - search_wandb_docs_tool: Search official W&B documentation
+    - get_run_history_tool: Fetch run metric history with sampling
+    - list_registries_tool: List W&B model registries
+    - list_registry_collections_tool: List collections in a registry
+    - list_artifact_versions_tool: List artifact versions
+    - get_artifact_details_tool: Get artifact metadata and files
+    - compare_artifact_versions_tool: Diff two artifact versions
+    - compare_runs_tool: Structured diff between two runs
+    - summarize_evaluation_tool: Aggregate Weave evaluation results
+    - diagnose_run_tool: Automatic training health check
+    - probe_project_tool: Run-side schema and structure discovery
 
     Args:
         mcp_instance: The FastMCP instance to register tools on
@@ -460,6 +474,24 @@ def register_tools(mcp_instance: FastMCP) -> None:
         except Exception as e:
             logger.error(f"Error in count_weave_traces_tool: {e}")
             return json.dumps({"error": f"Error counting traces: {str(e)}"})
+
+    from wandb_mcp_server.mcp_tools.resolve_trace_roots import (
+        RESOLVE_TRACE_ROOTS_TOOL_DESCRIPTION,
+        resolve_trace_roots,
+    )
+
+    @mcp_instance.tool(description=RESOLVE_TRACE_ROOTS_TOOL_DESCRIPTION)
+    def resolve_trace_roots_tool(
+        entity_name: str,
+        project_name: str,
+        trace_ids: List[str],
+    ) -> str:
+        """Batch-resolve root spans for child trace_ids."""
+        return resolve_trace_roots(
+            entity_name=entity_name,
+            project_name=project_name,
+            trace_ids=trace_ids,
+        )
 
     @mcp_instance.tool(description=QUERY_WANDB_GQL_TOOL_DESCRIPTION)
     async def query_wandb_tool(

--- a/src/wandb_mcp_server/weave_api/query_builder.py
+++ b/src/wandb_mcp_server/weave_api/query_builder.py
@@ -328,6 +328,61 @@ class QueryBuilder:
             else:
                 logger.warning(f"Invalid format for 'attributes' filter: {attributes_filters}. Expected a dictionary.")
 
+        # Handle inputs filter (substring search on trace inputs via $contains)
+        if "inputs" in filters:
+            inputs_filters = filters["inputs"]
+            if isinstance(inputs_filters, dict):
+                for input_path, input_condition in inputs_filters.items():
+                    full_path = f"inputs.{input_path}"
+                    if isinstance(input_condition, dict) and "$contains" in input_condition:
+                        if isinstance(input_condition["$contains"], str):
+                            operations.append(cls.create_contains_operation(full_path, input_condition["$contains"]))
+                        else:
+                            logger.warning(f"Invalid $contains value for {full_path}: expected string.")
+                    elif isinstance(input_condition, dict):
+                        for op_key, value in input_condition.items():
+                            try:
+                                op = FilterOperator(op_key)
+                                comp_op = cls.create_comparison_operation(full_path, op, value)
+                                if comp_op:
+                                    operations.append(comp_op)
+                            except (ValueError, KeyError):
+                                logger.warning(f"Invalid operator for inputs filter: {op_key}")
+                    else:
+                        comp_op = cls.create_comparison_operation(full_path, FilterOperator.EQUALS, input_condition)
+                        if comp_op:
+                            operations.append(comp_op)
+
+        # Handle output filter (substring search on trace output via $contains)
+        if "output" in filters:
+            output_filter = filters["output"]
+            if isinstance(output_filter, dict) and "$contains" in output_filter:
+                if isinstance(output_filter["$contains"], str):
+                    operations.append(cls.create_contains_operation("output", output_filter["$contains"]))
+                else:
+                    logger.warning("Invalid $contains value for output: expected string.")
+            elif isinstance(output_filter, dict):
+                for output_path, output_condition in output_filter.items():
+                    full_path = f"output.{output_path}"
+                    if isinstance(output_condition, dict) and "$contains" in output_condition:
+                        if isinstance(output_condition["$contains"], str):
+                            operations.append(cls.create_contains_operation(full_path, output_condition["$contains"]))
+                        else:
+                            logger.warning(f"Invalid $contains value for {full_path}: expected string.")
+                    elif isinstance(output_condition, dict):
+                        for op_key, value in output_condition.items():
+                            try:
+                                op = FilterOperator(op_key)
+                                comp_op = cls.create_comparison_operation(full_path, op, value)
+                                if comp_op:
+                                    operations.append(comp_op)
+                            except (ValueError, KeyError):
+                                logger.warning(f"Invalid operator for output filter: {op_key}")
+                    else:
+                        comp_op = cls.create_comparison_operation(full_path, FilterOperator.EQUALS, output_condition)
+                        if comp_op:
+                            operations.append(comp_op)
+
         # Handle $in filter for multi-value matching (e.g., status $in ["error", "running"])
         if "$in" in filters:
             in_filters = filters["$in"]

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -479,6 +479,47 @@ class TraceService:
 
         return result
 
+    def resolve_trace_roots(
+        self,
+        entity_name: str,
+        project_name: str,
+        trace_ids: List[str],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Batch-resolve root spans for a list of trace_ids in a single query.
+
+        Uses ``trace_ids + trace_roots_only`` to fetch root spans in one
+        API call, eliminating the N+1 problem when child trace searches
+        need parent context.
+
+        Args:
+            entity_name: W&B entity.
+            project_name: W&B project.
+            trace_ids: List of trace_id values to resolve.
+
+        Returns:
+            Dict mapping trace_id -> root span dict. Missing trace_ids
+            (no root found) are omitted.
+        """
+        if not trace_ids:
+            return {}
+
+        unique_ids = list(set(trace_ids))
+
+        result = self.query_traces(
+            entity_name=entity_name,
+            project_name=project_name,
+            filters={
+                "trace_ids": unique_ids,
+                "trace_roots_only": True,
+            },
+            columns=["id", "trace_id", "op_name", "display_name", "started_at", "parent_id"],
+            limit=len(unique_ids),
+            return_full_data=True,
+            metadata_only=False,
+        )
+
+        return {trace.get("trace_id"): trace for trace in (result.traces or []) if trace.get("trace_id")}
+
     def query_paginated_traces(
         self,
         entity_name: str,

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -1,0 +1,195 @@
+"""Tests for the compare_runs tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wandb_mcp_server.mcp_tools.compare_runs import (
+    _diff_dicts,
+    _safe_val,
+    compare_runs,
+)
+
+
+class TestSafeVal:
+    def test_nan_becomes_string(self):
+        assert _safe_val(float("nan")) == "nan"
+
+    def test_inf_becomes_string(self):
+        assert _safe_val(float("inf")) == "inf"
+
+    def test_normal_float_passes_through(self):
+        assert _safe_val(3.14) == 3.14
+
+    def test_string_passes_through(self):
+        assert _safe_val("hello") == "hello"
+
+
+class TestDiffDicts:
+    def test_added_removed_changed_keys(self):
+        a = {"lr": 0.01, "epochs": 10, "model": "resnet"}
+        b = {"lr": 0.001, "epochs": 10, "batch_size": 32}
+        diff = _diff_dicts(a, b)
+
+        assert diff["only_in_run_a"] == {"model": "resnet"}
+        assert diff["only_in_run_b"] == {"batch_size": 32}
+        assert "lr" in diff["changed"]
+        assert diff["changed"]["lr"]["run_a"] == 0.01
+        assert diff["changed"]["lr"]["run_b"] == 0.001
+        assert diff["changed"]["lr"]["delta"] == round(0.001 - 0.01, 6)
+        assert diff["identical_count"] == 1
+
+    def test_identical_dicts(self):
+        d = {"lr": 0.01, "epochs": 10}
+        diff = _diff_dicts(d, d)
+
+        assert diff["only_in_run_a"] == {}
+        assert diff["only_in_run_b"] == {}
+        assert diff["changed"] == {}
+        assert diff["identical_count"] == 2
+
+    def test_empty_dicts(self):
+        diff = _diff_dicts({}, {})
+        assert diff["identical_count"] == 0
+        assert diff["only_in_run_a"] == {}
+
+    def test_numeric_delta_for_ints(self):
+        diff = _diff_dicts({"steps": 100}, {"steps": 200})
+        assert diff["changed"]["steps"]["delta"] == 100
+
+    def test_no_delta_for_strings(self):
+        diff = _diff_dicts({"model": "bert"}, {"model": "gpt2"})
+        assert "delta" not in diff["changed"]["model"]
+
+
+class TestCompareRuns:
+    def _make_mock_run(
+        self,
+        *,
+        config=None,
+        summary=None,
+        name="run",
+        state="finished",
+        tags=None,
+        group=None,
+        created_at="2026-01-01",
+        heartbeat_at="2026-01-02",
+    ):
+        run = MagicMock()
+        run.config = config or {}
+        run.summary = summary or {}
+        run.name = name
+        run.state = state
+        run.tags = tags or []
+        run.group = group
+        run.created_at = created_at
+        run.heartbeat_at = heartbeat_at
+        return run
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_config_diff(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run_a = self._make_mock_run(config={"lr": 0.01, "model": "resnet"})
+        run_b = self._make_mock_run(config={"lr": 0.001, "batch_size": 64})
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "run-a", "run-b"))
+
+        assert result["config_diff"]["only_in_run_a"] == {"model": "resnet"}
+        assert result["config_diff"]["only_in_run_b"] == {"batch_size": 64}
+        assert "lr" in result["config_diff"]["changed"]
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_summary_metric_delta(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run_a = self._make_mock_run(summary={"accuracy": 0.85, "loss": 0.3})
+        run_b = self._make_mock_run(summary={"accuracy": 0.92, "loss": 0.15})
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "a", "b"))
+
+        acc_change = result["summary_diff"]["changed"]["accuracy"]
+        assert acc_change["delta"] == pytest.approx(0.07, abs=1e-5)
+        loss_change = result["summary_diff"]["changed"]["loss"]
+        assert loss_change["delta"] == pytest.approx(-0.15, abs=1e-5)
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_metadata_comparison(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run_a = self._make_mock_run(tags=["baseline"], group="exp1")
+        run_b = self._make_mock_run(tags=["tuned"], group="exp2")
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "a", "b"))
+
+        assert result["metadata_diff"]["run_a"]["tags"] == ["baseline"]
+        assert result["metadata_diff"]["run_b"]["group"] == "exp2"
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_identical_configs(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        shared_config = {"lr": 0.01, "epochs": 10}
+        run_a = self._make_mock_run(config=shared_config)
+        run_b = self._make_mock_run(config=shared_config)
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "a", "b"))
+
+        assert result["config_diff"]["changed"] == {}
+        assert result["config_diff"]["identical_count"] == 2
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_filters_internal_summary_keys(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run_a = self._make_mock_run(summary={"loss": 0.5, "_runtime": 100, "wandb/cpu": 0.8})
+        run_b = self._make_mock_run(summary={"loss": 0.3, "_runtime": 200, "wandb/cpu": 0.9})
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "a", "b"))
+
+        assert "_runtime" not in result["summary_diff"]["changed"]
+        assert "wandb/cpu" not in result["summary_diff"]["changed"]
+        assert "loss" in result["summary_diff"]["changed"]
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_run_not_found_error(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api.return_value.run.side_effect = Exception("Run not found: bad-id")
+
+        result = json.loads(compare_runs("ent", "proj", "bad-id", "other"))
+
+        assert result["error"] == "run_not_found"
+        assert "bad-id" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_run_ids_in_result(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run_a = self._make_mock_run(name="alpha")
+        run_b = self._make_mock_run(name="beta")
+
+        mock_api = mock_api_mgr.get_api.return_value
+        mock_api.run.side_effect = [run_a, run_b]
+
+        result = json.loads(compare_runs("ent", "proj", "id-a", "id-b"))
+
+        assert result["run_a"]["id"] == "id-a"
+        assert result["run_a"]["name"] == "alpha"
+        assert result["run_b"]["id"] == "id-b"
+        assert result["run_b"]["name"] == "beta"

--- a/tests/test_content_search.py
+++ b/tests/test_content_search.py
@@ -1,0 +1,129 @@
+"""Tests for inputs/output content search filters in QueryBuilder."""
+
+from wandb_mcp_server.weave_api.query_builder import QueryBuilder
+
+
+class TestInputsContentSearch:
+    """QueryBuilder.build_query_expression handles inputs filters."""
+
+    def test_inputs_contains_produces_operation(self):
+        filters = {"inputs": {"message": {"$contains": "hello world"}}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        expr = query.expr_
+        assert hasattr(expr, "contains_")
+        spec = expr.contains_
+        assert spec.input.get_field_ == "inputs.message"
+        assert spec.substr.literal_ == "hello world"
+
+    def test_inputs_nested_path(self):
+        filters = {"inputs": {"model.prompt": {"$contains": "summarize"}}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        spec = query.expr_.contains_
+        assert spec.input.get_field_ == "inputs.model.prompt"
+
+    def test_inputs_exact_match(self):
+        filters = {"inputs": {"model": "gpt-4"}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+
+    def test_inputs_comparison_operator(self):
+        filters = {"inputs": {"token_count": {"$gt": 100}}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+
+    def test_inputs_combined_with_other_filters(self):
+        filters = {
+            "inputs": {"message": {"$contains": "search term"}},
+            "op_name_contains": "predict",
+            "status": "success",
+        }
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        assert hasattr(query.expr_, "and_")
+        assert len(query.expr_.and_) == 3
+
+    def test_inputs_multiple_fields(self):
+        filters = {
+            "inputs": {
+                "message": {"$contains": "hello"},
+                "model": "gpt-4",
+            }
+        }
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        assert hasattr(query.expr_, "and_")
+        assert len(query.expr_.and_) == 2
+
+
+class TestOutputContentSearch:
+    """QueryBuilder.build_query_expression handles output filters."""
+
+    def test_output_top_level_contains(self):
+        filters = {"output": {"$contains": "error message"}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        spec = query.expr_.contains_
+        assert spec.input.get_field_ == "output"
+        assert spec.substr.literal_ == "error message"
+
+    def test_output_nested_path(self):
+        filters = {"output": {"result": {"$contains": "success"}}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        spec = query.expr_.contains_
+        assert spec.input.get_field_ == "output.result"
+
+    def test_output_combined_with_inputs(self):
+        filters = {
+            "inputs": {"message": {"$contains": "query"}},
+            "output": {"$contains": "response"},
+        }
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        assert hasattr(query.expr_, "and_")
+        assert len(query.expr_.and_) == 2
+
+    def test_output_combined_with_time_range(self):
+        filters = {
+            "output": {"$contains": "specific text"},
+            "time_range": {
+                "start": "2026-04-01T00:00:00Z",
+                "end": "2026-04-13T00:00:00Z",
+            },
+        }
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        assert hasattr(query.expr_, "and_")
+        assert len(query.expr_.and_) == 3
+
+
+class TestContentSearchEdgeCases:
+    """Edge cases for content search filters."""
+
+    def test_empty_inputs_dict(self):
+        filters = {"inputs": {}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is None
+
+    def test_empty_output_dict(self):
+        filters = {"output": {}}
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is None
+
+    def test_inputs_does_not_conflict_with_attributes(self):
+        filters = {
+            "inputs": {"message": {"$contains": "hello"}},
+            "attributes": {"env": "production"},
+        }
+        query = QueryBuilder.build_query_expression(filters)
+        assert query is not None
+        assert hasattr(query.expr_, "and_")
+        assert len(query.expr_.and_) == 2
+
+    def test_case_insensitive_default(self):
+        filters = {"inputs": {"text": {"$contains": "UPPER"}}}
+        query = QueryBuilder.build_query_expression(filters)
+        spec = query.expr_.contains_
+        assert spec.case_insensitive is True

--- a/tests/test_diagnose_run.py
+++ b/tests/test_diagnose_run.py
@@ -1,0 +1,172 @@
+"""Tests for the diagnose_run tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+from wandb_mcp_server.mcp_tools.diagnose_run import (
+    _auto_detect_key,
+    _compute_trend,
+    _detect_overfit,
+    diagnose_run,
+)
+
+
+class TestComputeTrend:
+    def test_insufficient_data(self):
+        assert _compute_trend([1.0, 2.0, 3.0]) == "insufficient_data"
+
+    def test_decreasing_trend(self):
+        values = [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.9, 0.8]
+        assert _compute_trend(values) == "decreasing"
+
+    def test_increasing_trend(self):
+        values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0]
+        assert _compute_trend(values) == "increasing"
+
+    def test_plateaued_trend(self):
+        values = [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0]
+        assert _compute_trend(values) == "plateaued"
+
+    def test_decreasing_then_plateau(self):
+        values = [10.0, 8.0, 6.0, 4.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+        result = _compute_trend(values)
+        assert result in ("decreasing", "plateaued")
+
+
+class TestDetectOverfit:
+    def test_insufficient_data(self):
+        result = _detect_overfit([1.0, 2.0], [1.0, 2.0])
+        assert result["detected"] is False
+        assert result["reason"] == "insufficient_data"
+
+    def test_overfit_pattern(self):
+        train = [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.9, 0.8]
+        val = [10.0, 9.5, 9.0, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0, 12.5, 13.0]
+        result = _detect_overfit(train, val)
+
+        assert result["detected"] is True
+        assert result["train_loss_trend"] == "decreasing"
+        assert result["val_loss_trend"] == "increasing"
+
+    def test_normal_training(self):
+        train = [10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.9, 0.8]
+        val = [10.5, 9.5, 8.5, 7.5, 6.5, 5.5, 4.5, 3.5, 2.5, 1.5, 1.4, 1.3]
+        result = _detect_overfit(train, val)
+
+        assert result["train_loss_trend"] == "decreasing"
+        assert result["val_loss_trend"] == "decreasing"
+
+    def test_gap_fields_present(self):
+        train = list(range(20, 0, -1))
+        val = list(range(20, 0, -1))
+        result = _detect_overfit(
+            [float(x) for x in train],
+            [float(x) for x in val],
+        )
+        assert "gap_early" in result
+        assert "gap_late" in result
+        assert "gap_ratio" in result
+
+
+class TestAutoDetectKey:
+    def test_finds_loss(self):
+        keys = ["_step", "accuracy", "loss", "lr"]
+        assert _auto_detect_key(keys, ["train_loss", "train/loss", "loss"]) == "loss"
+
+    def test_finds_train_loss_first(self):
+        keys = ["loss", "train_loss", "val_loss"]
+        assert _auto_detect_key(keys, ["train_loss", "loss"]) == "train_loss"
+
+    def test_returns_none_when_no_match(self):
+        keys = ["accuracy", "precision", "recall"]
+        assert _auto_detect_key(keys, ["loss"]) is None
+
+    def test_case_insensitive(self):
+        keys = ["TrainLoss", "ValLoss"]
+        assert _auto_detect_key(keys, ["trainloss"]) == "TrainLoss"
+
+
+class TestDiagnoseRun:
+    def _make_mock_run(self, name="test-run", state="finished", history_rows=None):
+        run = MagicMock()
+        run.name = name
+        run.state = state
+        run.scan_history.return_value = history_rows or []
+        return run
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_run_not_found(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api.return_value.run.side_effect = Exception("Run xyz not found")
+
+        result = json.loads(diagnose_run("ent", "proj", "xyz"))
+
+        assert result["error"] == "run_not_found"
+        assert "xyz" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_no_history(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run = self._make_mock_run(history_rows=[])
+        mock_api_mgr.get_api.return_value.run.return_value = run
+
+        result = json.loads(diagnose_run("ent", "proj", "r1"))
+
+        assert result["diagnosis"] == "no_history"
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_converging_run(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        history = [{"_step": i, "loss": 10.0 / (i + 1)} for i in range(50)]
+        run = self._make_mock_run(history_rows=history)
+        mock_api_mgr.get_api.return_value.run.return_value = run
+
+        result = json.loads(diagnose_run("ent", "proj", "r1"))
+
+        assert result["diagnosis"] in ("training", "converged")
+        assert result["loss_stats"] is not None
+        assert result["loss_stats"]["key"] == "loss"
+        assert result["loss_stats"]["first_value"] > result["loss_stats"]["last_value"]
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_nan_detection(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        history = [{"_step": i, "loss": 1.0, "grad_norm": float("nan") if i % 5 == 0 else 1.0} for i in range(20)]
+        run = self._make_mock_run(history_rows=history)
+        mock_api_mgr.get_api.return_value.run.return_value = run
+
+        result = json.loads(diagnose_run("ent", "proj", "r1"))
+
+        assert result["nan_warnings"] is not None
+        assert "grad_norm" in result["nan_warnings"]
+        assert result["nan_warnings"]["grad_norm"]["nan_count"] == 4
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_detected_keys_returned(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        history = [{"_step": i, "loss": 1.0, "val_loss": 1.1} for i in range(20)]
+        run = self._make_mock_run(history_rows=history)
+        mock_api_mgr.get_api.return_value.run.return_value = run
+
+        result = json.loads(diagnose_run("ent", "proj", "r1"))
+
+        assert result["detected_keys"]["loss"] == "loss"
+        assert result["detected_keys"]["val_loss"] == "val_loss"
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_recommendations_for_diverging(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        history = [{"_step": i, "loss": float(i)} for i in range(50)]
+        run = self._make_mock_run(history_rows=history)
+        mock_api_mgr.get_api.return_value.run.return_value = run
+
+        result = json.loads(diagnose_run("ent", "proj", "r1"))
+
+        assert result["diagnosis"] == "diverging"
+        assert any("learning rate" in r for r in result["recommendations"])

--- a/tests/test_list_entities.py
+++ b/tests/test_list_entities.py
@@ -1,0 +1,139 @@
+"""Tests for list_entities tool and list_entity_projects max_projects bounds."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def mock_viewer():
+    viewer = MagicMock()
+    viewer.entity = "alice"
+    viewer.teams = ["team-a", "team-b", "team-c"]
+    return viewer
+
+
+@pytest.fixture()
+def mock_api(mock_viewer):
+    api = MagicMock()
+    api.viewer = mock_viewer
+    return api
+
+
+def _make_project(name, entity):
+    p = MagicMock()
+    p.name = name
+    p.entity = entity
+    p.description = f"Desc for {name}"
+    p.visibility = "private"
+    p.created_at = "2026-01-01"
+    p.updated_at = "2026-04-01"
+    p.tags = []
+    return p
+
+
+class TestListEntities:
+    """list_entities returns viewer entity + teams without project enumeration."""
+
+    @patch("wandb_mcp_server.mcp_tools.list_entities.WandBApiManager")
+    def test_returns_user_and_teams(self, mock_mgr, mock_api, mock_viewer):
+        mock_mgr.get_api.return_value = mock_api
+        from wandb_mcp_server.mcp_tools.list_entities import list_entities
+
+        result = json.loads(list_entities())
+        assert result["count"] == 4
+        assert result["entities"][0] == {"name": "alice", "type": "user"}
+        assert result["entities"][1] == {"name": "team-a", "type": "team"}
+        assert result["entities"][3] == {"name": "team-c", "type": "team"}
+
+    @patch("wandb_mcp_server.mcp_tools.list_entities.WandBApiManager")
+    def test_no_teams(self, mock_mgr):
+        viewer = MagicMock()
+        viewer.entity = "solo-user"
+        viewer.teams = []
+        api = MagicMock()
+        api.viewer = viewer
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.list_entities import list_entities
+
+        result = json.loads(list_entities())
+        assert result["count"] == 1
+        assert result["entities"][0]["name"] == "solo-user"
+        assert result["entities"][0]["type"] == "user"
+
+    @patch("wandb_mcp_server.mcp_tools.list_entities.WandBApiManager")
+    def test_viewer_without_teams_attr(self, mock_mgr):
+        viewer = MagicMock(spec=[])
+        viewer.entity = "no-attr-user"
+        api = MagicMock()
+        api.viewer = viewer
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.list_entities import list_entities
+
+        result = json.loads(list_entities())
+        assert result["count"] == 1
+
+
+class TestListEntityProjectsBounds:
+    """list_entity_projects respects max_projects and max_entities."""
+
+    def _mock_api_with_projects(self, entity, count):
+        api = MagicMock()
+        api.projects.return_value = iter([_make_project(f"proj-{i}", entity) for i in range(count)])
+        return api
+
+    @patch("wandb_mcp_server.api_client.get_wandb_api")
+    def test_max_projects_caps_results(self, mock_get_api):
+        mock_get_api.return_value = self._mock_api_with_projects("alice", 100)
+        from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import list_entity_projects
+
+        result = json.loads(list_entity_projects(entity="alice", max_projects=5))
+        assert len(result["projects"]["alice"]) == 5
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.api_client.get_wandb_api")
+    def test_max_projects_ceiling(self, mock_get_api):
+        mock_get_api.return_value = self._mock_api_with_projects("alice", 300)
+        from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import list_entity_projects
+
+        result = json.loads(list_entity_projects(entity="alice", max_projects=999))
+        assert len(result["projects"]["alice"]) == 200
+
+    @patch("wandb_mcp_server.api_client.get_wandb_api")
+    def test_entity_none_caps_entities(self, mock_get_api):
+        viewer = MagicMock()
+        viewer.entity = "user"
+        viewer.teams = [f"team-{i}" for i in range(20)]
+        api = MagicMock()
+        api.viewer = viewer
+        api.projects.return_value = iter([_make_project("p1", "user")])
+        mock_get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import list_entity_projects
+
+        result = json.loads(list_entity_projects(entity=None, max_projects=10))
+        assert len(result["projects"]) <= 5
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.api_client.get_wandb_api")
+    def test_specific_entity_no_truncation(self, mock_get_api):
+        mock_get_api.return_value = self._mock_api_with_projects("alice", 3)
+        from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import list_entity_projects
+
+        result = json.loads(list_entity_projects(entity="alice", max_projects=50))
+        assert len(result["projects"]["alice"]) == 3
+        assert result["truncated"] is False
+
+    @patch("wandb_mcp_server.api_client.get_wandb_api")
+    def test_returns_json_string(self, mock_get_api):
+        mock_get_api.return_value = self._mock_api_with_projects("alice", 0)
+        from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import list_entity_projects
+
+        result = list_entity_projects(entity="alice")
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert "projects" in parsed
+        assert "truncated" in parsed

--- a/tests/test_probe_project.py
+++ b/tests/test_probe_project.py
@@ -1,0 +1,181 @@
+"""Tests for the probe_project tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+from wandb_mcp_server.mcp_tools.probe_project import (
+    _safe_sample_value,
+    probe_project,
+)
+
+
+class TestSafeSampleValue:
+    def test_short_string(self):
+        assert _safe_sample_value("hello") == "hello"
+
+    def test_long_string_truncated(self):
+        long = "x" * 200
+        result = _safe_sample_value(long)
+        assert result.endswith("...")
+        assert len(result) == 103
+
+    def test_int_passthrough(self):
+        assert _safe_sample_value(42) == 42
+
+    def test_list_representation(self):
+        result = _safe_sample_value([1, 2, 3])
+        assert "list" in result
+        assert "len=3" in result
+
+    def test_dict_representation(self):
+        result = _safe_sample_value({"a": 1, "b": 2})
+        assert "dict" in result
+        assert "keys=2" in result
+
+
+class TestProbeProject:
+    def _make_mock_run(
+        self, *, config=None, summary=None, state="finished", tags=None, group=None, lastHistoryStep=100
+    ):
+        run = MagicMock()
+        run.config = config or {}
+        run.summary = summary or {}
+        run.state = state
+        run.tags = tags or []
+        run.group = group
+        run.lastHistoryStep = lastHistoryStep
+        return run
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_key_extraction(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run1 = self._make_mock_run(
+            config={"lr": 0.01, "model": "bert"},
+            summary={"loss": 0.5, "accuracy": 0.9},
+        )
+        run2 = self._make_mock_run(
+            config={"lr": 0.001, "batch_size": 32},
+            summary={"loss": 0.3, "f1": 0.85},
+        )
+
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+
+        result = json.loads(probe_project("ent", "proj"))
+
+        assert "lr" in result["config_keys"]
+        assert "model" in result["config_keys"]
+        assert "batch_size" in result["config_keys"]
+        assert "loss" in result["metric_keys"]
+        assert "accuracy" in result["metric_keys"]
+        assert "f1" in result["metric_keys"]
+        assert result["run_count"] == 2
+        assert result["sampled_runs"] == 2
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_empty_project(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([])
+
+        result = json.loads(probe_project("ent", "empty-proj"))
+
+        assert result["run_count"] == 0
+        assert result["metric_keys"] == {}
+        assert result["config_keys"] == {}
+        assert result["has_history"] is False
+        assert any("Small project" in r for r in result["recommendations"])
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_recommendations_for_large_project(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        runs = [
+            self._make_mock_run(
+                config={"lr": 0.01},
+                summary={"loss": 0.5},
+            )
+            for _ in range(150)
+        ]
+        mock_api_mgr.get_api.return_value.runs.return_value = iter(runs)
+
+        result = json.loads(probe_project("ent", "big-proj", sample_runs=5))
+
+        assert result["run_count"] == 150
+        assert result["sampled_runs"] == 5
+        assert any("Large project" in r for r in result["recommendations"])
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_tag_and_group_collection(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run1 = self._make_mock_run(tags=["baseline", "v1"], group="experiment-1")
+        run2 = self._make_mock_run(tags=["tuned", "v1"], group="experiment-2")
+
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+
+        result = json.loads(probe_project("ent", "proj"))
+
+        assert "baseline" in result["tags"]
+        assert "tuned" in result["tags"]
+        assert "v1" in result["tags"]
+        assert "experiment-1" in result["groups"]
+        assert "experiment-2" in result["groups"]
+        assert any("Tags in use" in r for r in result["recommendations"])
+        assert any("Run groups found" in r for r in result["recommendations"])
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_filters_internal_keys(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run = self._make_mock_run(
+            config={"lr": 0.01, "_wandb": {}, "wandb_version": "0.1"},
+            summary={"loss": 0.5, "_runtime": 100, "wandb/cpu": 0.8},
+        )
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([run])
+
+        result = json.loads(probe_project("ent", "proj"))
+
+        assert "_wandb" not in result["config_keys"]
+        assert "wandb_version" not in result["config_keys"]
+        assert "lr" in result["config_keys"]
+        assert "_runtime" not in result["metric_keys"]
+        assert "wandb/cpu" not in result["metric_keys"]
+        assert "loss" in result["metric_keys"]
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_project_not_found_error(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api.return_value.runs.side_effect = Exception("Project not found")
+
+        result = json.loads(probe_project("ent", "no-such-proj"))
+
+        assert result["error"] == "project_not_found"
+        assert "Project not found" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_typical_steps_calculation(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run1 = self._make_mock_run(lastHistoryStep=1000)
+        run2 = self._make_mock_run(lastHistoryStep=2000)
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+
+        result = json.loads(probe_project("ent", "proj"))
+
+        assert result["has_history"] is True
+        assert result["typical_steps"] == 1500
+
+    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
+    def test_run_states_counted(self, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+
+        run1 = self._make_mock_run(state="finished")
+        run2 = self._make_mock_run(state="finished")
+        run3 = self._make_mock_run(state="crashed")
+        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2, run3])
+
+        result = json.loads(probe_project("ent", "proj"))
+
+        assert result["run_states"]["finished"] == 2
+        assert result["run_states"]["crashed"] == 1

--- a/tests/test_resolve_trace_roots.py
+++ b/tests/test_resolve_trace_roots.py
@@ -1,0 +1,244 @@
+"""Tests for resolve_trace_roots: TraceService method and standalone MCP tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from wandb_mcp_server.weave_api.models import QueryResult, TraceMetadata
+
+
+def _make_root_trace(trace_id, op_name, display_name=None):
+    return {
+        "id": f"root-{trace_id}",
+        "trace_id": trace_id,
+        "op_name": op_name,
+        "display_name": display_name,
+        "started_at": "2026-01-01T00:00:00",
+        "parent_id": None,
+    }
+
+
+def _make_query_result(traces):
+    return QueryResult(
+        traces=traces,
+        metadata=TraceMetadata(trace_count=len(traces)),
+    )
+
+
+class TestResolveTraceRoots:
+    """resolve_trace_roots batches trace_id -> root span in one query."""
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_returns_root_map(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        service.query_traces = MagicMock(
+            return_value=_make_query_result(
+                [
+                    _make_root_trace("t1", "session_a", "Session A"),
+                    _make_root_trace("t2", "session_b", "Session B"),
+                ]
+            )
+        )
+
+        result = service.resolve_trace_roots("entity", "project", ["t1", "t2"])
+
+        assert "t1" in result
+        assert "t2" in result
+        assert result["t1"]["op_name"] == "session_a"
+        assert result["t2"]["display_name"] == "Session B"
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_empty_trace_ids(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        result = service.resolve_trace_roots("entity", "project", [])
+        assert result == {}
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_deduplicates_trace_ids(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        service.query_traces = MagicMock(
+            return_value=_make_query_result(
+                [
+                    _make_root_trace("t1", "session"),
+                ]
+            )
+        )
+
+        result = service.resolve_trace_roots("entity", "project", ["t1", "t1", "t1"])
+
+        assert len(result) == 1
+        assert "t1" in result
+        service.query_traces.assert_called_once()
+        call_kwargs = service.query_traces.call_args[1]
+        assert len(call_kwargs["filters"]["trace_ids"]) == 1
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_missing_root_omitted(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        service.query_traces = MagicMock(
+            return_value=_make_query_result(
+                [
+                    _make_root_trace("t1", "session"),
+                ]
+            )
+        )
+
+        result = service.resolve_trace_roots("entity", "project", ["t1", "t2", "t3"])
+
+        assert "t1" in result
+        assert "t2" not in result
+        assert "t3" not in result
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_passes_trace_roots_only(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        service.query_traces = MagicMock(return_value=_make_query_result([]))
+
+        service.resolve_trace_roots("entity", "project", ["t1"])
+
+        call_kwargs = service.query_traces.call_args[1]
+        assert call_kwargs["filters"]["trace_roots_only"] is True
+        assert call_kwargs["filters"]["trace_ids"] == ["t1"]
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_query_params(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        service.query_traces = MagicMock(return_value=_make_query_result([]))
+
+        service.resolve_trace_roots("entity", "project", ["t1"])
+
+        call_kwargs = service.query_traces.call_args[1]
+        assert call_kwargs["metadata_only"] is False
+        assert call_kwargs["return_full_data"] is True
+        assert "op_name" in call_kwargs["columns"]
+        assert "trace_id" in call_kwargs["columns"]
+        assert "display_name" in call_kwargs["columns"]
+        assert "parent_id" in call_kwargs["columns"]
+
+    @patch("wandb_mcp_server.weave_api.service.WeaveApiClient")
+    def test_large_batch(self, mock_client_cls):
+        from wandb_mcp_server.weave_api.service import TraceService
+
+        service = TraceService(api_key="test", server_url="http://test")
+        trace_ids = [f"t{i}" for i in range(200)]
+        roots = [_make_root_trace(f"t{i}", f"session_{i}") for i in range(200)]
+        service.query_traces = MagicMock(return_value=_make_query_result(roots))
+
+        result = service.resolve_trace_roots("entity", "project", trace_ids)
+
+        assert len(result) == 200
+        call_kwargs = service.query_traces.call_args[1]
+        assert call_kwargs["limit"] == 200
+
+
+class TestResolveTraceRootsTool:
+    """Tests for the standalone resolve_trace_roots MCP tool wrapper."""
+
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.WandBApiManager")
+    def test_tool_returns_json_with_roots(self, mock_mgr, mock_get_svc):
+        from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
+
+        mock_api = MagicMock()
+        mock_api.viewer = {"username": "testuser"}
+        mock_mgr.get_api.return_value = mock_api
+
+        mock_svc = MagicMock()
+        mock_svc.resolve_trace_roots.return_value = {
+            "t1": _make_root_trace("t1", "chat_session", "Chat Session"),
+            "t2": _make_root_trace("t2", "pipeline", "Pipeline Run"),
+        }
+        mock_get_svc.return_value = mock_svc
+
+        result = json.loads(resolve_trace_roots("entity", "project", ["t1", "t2"]))
+
+        assert result["resolved"] == 2
+        assert result["total_requested"] == 2
+        assert result["roots"]["t1"]["op_name"] == "chat_session"
+        assert result["roots"]["t2"]["display_name"] == "Pipeline Run"
+
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.WandBApiManager")
+    def test_tool_empty_trace_ids(self, mock_mgr, mock_get_svc):
+        from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
+
+        mock_api = MagicMock()
+        mock_api.viewer = {"username": "testuser"}
+        mock_mgr.get_api.return_value = mock_api
+
+        result = json.loads(resolve_trace_roots("entity", "project", []))
+
+        assert result["roots"] == {}
+        assert result["resolved"] == 0
+        assert result["total_requested"] == 0
+        mock_get_svc.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.WandBApiManager")
+    def test_tool_handles_service_error(self, mock_mgr, mock_get_svc):
+        from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
+
+        mock_api = MagicMock()
+        mock_api.viewer = {"username": "testuser"}
+        mock_mgr.get_api.return_value = mock_api
+
+        mock_svc = MagicMock()
+        mock_svc.resolve_trace_roots.side_effect = ValueError("connection failed")
+        mock_get_svc.return_value = mock_svc
+
+        result = json.loads(resolve_trace_roots("entity", "project", ["t1"]))
+
+        assert result["error"] == "resolve_failed"
+        assert "connection failed" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.WandBApiManager")
+    def test_tool_deduplicates_in_response(self, mock_mgr, mock_get_svc):
+        from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
+
+        mock_api = MagicMock()
+        mock_api.viewer = {"username": "testuser"}
+        mock_mgr.get_api.return_value = mock_api
+
+        mock_svc = MagicMock()
+        mock_svc.resolve_trace_roots.return_value = {
+            "t1": _make_root_trace("t1", "session"),
+        }
+        mock_get_svc.return_value = mock_svc
+
+        result = json.loads(resolve_trace_roots("entity", "project", ["t1", "t1", "t1"]))
+
+        assert result["resolved"] == 1
+        assert result["total_requested"] == 1
+
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
+    @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.WandBApiManager")
+    def test_tool_response_shape(self, mock_mgr, mock_get_svc):
+        """Verify the tool output contains only the expected root span fields."""
+        from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
+
+        mock_api = MagicMock()
+        mock_api.viewer = {"username": "testuser"}
+        mock_mgr.get_api.return_value = mock_api
+
+        full_root = _make_root_trace("t1", "chat", "Chat")
+        full_root["extra_field"] = "should_not_appear"
+        mock_svc = MagicMock()
+        mock_svc.resolve_trace_roots.return_value = {"t1": full_root}
+        mock_get_svc.return_value = mock_svc
+
+        result = json.loads(resolve_trace_roots("entity", "project", ["t1"]))
+
+        root_fields = set(result["roots"]["t1"].keys())
+        assert root_fields == {"id", "trace_id", "op_name", "display_name", "started_at"}

--- a/tests/test_summarize_evaluation.py
+++ b/tests/test_summarize_evaluation.py
@@ -1,0 +1,204 @@
+"""Tests for the summarize_evaluation tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+from wandb_mcp_server.mcp_tools.summarize_evaluation import (
+    _aggregate_eval,
+    _extract_scores,
+    summarize_evaluation,
+)
+
+
+class TestExtractScores:
+    def test_extracts_mean_scores(self):
+        summary = {
+            "weave": {
+                "correctness": {"true_count": 8, "true_fraction": 0.8},
+                "latency": {"mean": 1.23},
+            }
+        }
+        scores = _extract_scores(summary)
+
+        assert "correctness" in scores
+        assert scores["correctness"]["true_fraction"] == 0.8
+        assert scores["latency"]["mean"] == 1.23
+
+    def test_ignores_non_scorer_keys(self):
+        summary = {
+            "weave": {
+                "status": "success",
+                "some_string": "not a score",
+                "count": 42,
+            }
+        }
+        scores = _extract_scores(summary)
+        assert scores == {}
+
+    def test_empty_summary(self):
+        assert _extract_scores({}) == {}
+
+    def test_missing_weave_key(self):
+        assert _extract_scores({"other": {"mean": 1.0}}) == {}
+
+
+class TestAggregateEval:
+    def test_success_and_error_counts(self):
+        eval_trace = {
+            "id": "eval-1",
+            "op_name": "Evaluation.evaluate",
+            "started_at": "2026-01-01T00:00:00Z",
+            "summary": {"weave": {"accuracy": {"mean": 0.9}}},
+        }
+        children = [
+            {"summary": {"weave": {"status": "success"}}},
+            {"summary": {"weave": {"status": "success"}}},
+            {"exception": "ValueError: bad input"},
+            {"summary": {"weave": {"status": "error"}}},
+        ]
+
+        result = _aggregate_eval(eval_trace, children)
+
+        assert result["total_predictions"] == 4
+        assert result["errors"] == 2
+        assert result["successes"] == 2
+        assert result["error_rate"] == 0.5
+
+    def test_all_successes(self):
+        eval_trace = {"id": "e1", "op_name": "eval", "started_at": "", "summary": {}}
+        children = [
+            {"summary": {"weave": {"status": "success"}}},
+            {"summary": {"weave": {"status": "success"}}},
+        ]
+
+        result = _aggregate_eval(eval_trace, children)
+        assert result["errors"] == 0
+        assert result["error_rate"] == 0.0
+
+    def test_empty_children(self):
+        eval_trace = {"id": "e1", "op_name": "eval", "started_at": "", "summary": {}}
+        result = _aggregate_eval(eval_trace, [])
+
+        assert result["total_predictions"] == 0
+        assert result["error_rate"] == 0.0
+
+    def test_token_usage_aggregation(self):
+        eval_trace = {"id": "e1", "op_name": "eval", "started_at": "", "summary": {}}
+        children = [
+            {"summary": {"usage": {"gpt-4": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}}}},
+            {"summary": {"usage": {"gpt-4": {"prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300}}}},
+        ]
+
+        result = _aggregate_eval(eval_trace, children)
+        assert result["token_usage"]["prompt_tokens"] == 300
+        assert result["token_usage"]["completion_tokens"] == 150
+        assert result["token_usage"]["total_tokens"] == 450
+
+    def test_scores_extracted_from_eval_summary(self):
+        eval_trace = {
+            "id": "e1",
+            "op_name": "eval",
+            "started_at": "",
+            "summary": {"weave": {"relevance": {"true_fraction": 0.75}}},
+        }
+        result = _aggregate_eval(eval_trace, [])
+        assert result["scores"]["relevance"]["true_fraction"] == 0.75
+
+
+class TestSummarizeEvaluation:
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
+    def test_no_evals_found(self, mock_trace_svc_cls, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api_key.return_value = "fake-key"
+
+        mock_service = MagicMock()
+        mock_trace_svc_cls.return_value = mock_service
+
+        mock_query_result = MagicMock()
+        mock_query_result.traces = []
+        mock_service.query_traces.return_value = mock_query_result
+
+        result = json.loads(summarize_evaluation("ent", "proj"))
+
+        assert result["evaluations"] == []
+        assert "No Evaluation.evaluate" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
+    def test_with_eval_traces(self, mock_trace_svc_cls, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api_key.return_value = "fake-key"
+
+        mock_service = MagicMock()
+        mock_trace_svc_cls.return_value = mock_service
+
+        eval_trace = {
+            "id": "eval-abc",
+            "trace_id": "trace-123",
+            "op_name": "Evaluation.evaluate",
+            "started_at": "2026-01-01T00:00:00Z",
+            "summary": {"weave": {"correctness": {"true_fraction": 0.9}}},
+        }
+        child_1 = {"summary": {"weave": {"status": "success"}}}
+        child_2 = {"exception": "TimeoutError"}
+
+        eval_result = MagicMock()
+        eval_result.traces = [eval_trace]
+
+        child_result = MagicMock()
+        child_result.traces = [child_1, child_2]
+
+        mock_service.query_traces.side_effect = [eval_result, child_result]
+
+        result = json.loads(summarize_evaluation("ent", "proj"))
+
+        assert result["count"] == 1
+        ev = result["evaluations"][0]
+        assert ev["eval_id"] == "eval-abc"
+        assert ev["total_predictions"] == 2
+        assert ev["errors"] == 1
+        assert ev["successes"] == 1
+        assert ev["scores"]["correctness"]["true_fraction"] == 0.9
+
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
+    def test_query_failure_returns_error(self, mock_trace_svc_cls, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api_key.return_value = "fake-key"
+
+        mock_service = MagicMock()
+        mock_trace_svc_cls.return_value = mock_service
+        mock_service.query_traces.side_effect = Exception("Connection refused")
+
+        result = json.loads(summarize_evaluation("ent", "proj"))
+
+        assert result["error"] == "evaluation_query_failed"
+        assert "Connection refused" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
+    def test_project_path_in_response(self, mock_trace_svc_cls, mock_api_mgr):
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        mock_api_mgr.get_api_key.return_value = "fake-key"
+
+        mock_service = MagicMock()
+        mock_trace_svc_cls.return_value = mock_service
+
+        eval_trace = {
+            "id": "e1",
+            "trace_id": "t1",
+            "op_name": "Evaluation.evaluate",
+            "started_at": "",
+            "summary": {},
+        }
+        eval_result = MagicMock()
+        eval_result.traces = [eval_trace]
+        child_result = MagicMock()
+        child_result.traces = []
+        mock_service.query_traces.side_effect = [eval_result, child_result]
+
+        result = json.loads(summarize_evaluation("my-team", "my-project"))
+
+        assert result["project"] == "my-team/my-project"

--- a/tests/test_summarize_evaluation.py
+++ b/tests/test_summarize_evaluation.py
@@ -108,13 +108,12 @@ class TestAggregateEval:
 
 class TestSummarizeEvaluation:
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
-    def test_no_evals_found(self, mock_trace_svc_cls, mock_api_mgr):
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
+    def test_no_evals_found(self, mock_get_svc, mock_api_mgr):
         mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api_key.return_value = "fake-key"
 
         mock_service = MagicMock()
-        mock_trace_svc_cls.return_value = mock_service
+        mock_get_svc.return_value = mock_service
 
         mock_query_result = MagicMock()
         mock_query_result.traces = []
@@ -126,13 +125,12 @@ class TestSummarizeEvaluation:
         assert "No Evaluation.evaluate" in result["message"]
 
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
-    def test_with_eval_traces(self, mock_trace_svc_cls, mock_api_mgr):
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
+    def test_with_eval_traces(self, mock_get_svc, mock_api_mgr):
         mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api_key.return_value = "fake-key"
 
         mock_service = MagicMock()
-        mock_trace_svc_cls.return_value = mock_service
+        mock_get_svc.return_value = mock_service
 
         eval_trace = {
             "id": "eval-abc",
@@ -163,13 +161,12 @@ class TestSummarizeEvaluation:
         assert ev["scores"]["correctness"]["true_fraction"] == 0.9
 
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
-    def test_query_failure_returns_error(self, mock_trace_svc_cls, mock_api_mgr):
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
+    def test_query_failure_returns_error(self, mock_get_svc, mock_api_mgr):
         mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api_key.return_value = "fake-key"
 
         mock_service = MagicMock()
-        mock_trace_svc_cls.return_value = mock_service
+        mock_get_svc.return_value = mock_service
         mock_service.query_traces.side_effect = Exception("Connection refused")
 
         result = json.loads(summarize_evaluation("ent", "proj"))
@@ -178,13 +175,12 @@ class TestSummarizeEvaluation:
         assert "Connection refused" in result["message"]
 
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.TraceService")
-    def test_project_path_in_response(self, mock_trace_svc_cls, mock_api_mgr):
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
+    def test_project_path_in_response(self, mock_get_svc, mock_api_mgr):
         mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api_key.return_value = "fake-key"
 
         mock_service = MagicMock()
-        mock_trace_svc_cls.return_value = mock_service
+        mock_get_svc.return_value = mock_service
 
         eval_trace = {
             "id": "e1",


### PR DESCRIPTION
## Summary

v0.3.2 staging branch with 8 new features addressing customer feedback and wb_agent-inspired analysis tools. **19 tools total**, up from 14 in v0.3.1.

## What's New

### Customer Feedback Fixes

**1. Entity Discovery (list_entities_tool)** -- New lightweight tool returns user + team entity names without enumerating projects. Single GQL call. Addresses customer report that `query_wandb_entity_projects(entity=None)` floods the LLM context with 2000+ project objects on enterprise accounts.

**2. Bounded Project Listing** -- `query_wandb_entity_projects` now has `max_projects` param (default 50, ceiling 200) and caps to 5 entities when entity=None. Returns `truncated` flag. Fixes the context overflow.

**3. Trace Content Search** -- `query_weave_traces_tool` filters now support `inputs` and `output` keys with `$contains` for substring search on trace content. Uses the Weave trace server's existing `positionCaseInsensitive` + `tokenbf_v1` skip indexes. Addresses customer need to search 100k+ traces by message text.

### wb_agent-Inspired Analysis Tools

Inspired by production skill helpers in `core/services/wb_agent`:

**4. compare_runs_tool** -- Structured config diff, summary metric deltas, metadata comparison between two runs. Optional history overlap. (Inspired by wb_agent's `compare_configs`)

**5. summarize_evaluation_tool** -- Aggregates Weave `Evaluation.evaluate` traces into pass rates, error counts, token usage, optional per-task breakdown. Replaces manual trace hierarchy navigation. (Inspired by wb_agent's `eval_results_to_dicts` + `pivot_solve_rate`)

**6. diagnose_run_tool** -- Automatic training health check: convergence detection, overfit signal (train vs val gap), NaN/Inf warnings, tail statistics, actionable recommendations. (Inspired by wb_agent's `diagnose_run`)

**7. probe_project_tool** -- Run-side schema/structure discovery: metric keys, config keys, run count, step counts, tags, groups, and recommended query strategies. The runs equivalent of `infer_trace_schema_tool`. (Inspired by wb_agent's `probe_project`)

### CI Fixes

**8. Fixed eval.yml** -- The nightly eval has been broken for 10+ days:
- `core.run_eval` -> `factory.run_eval` (correct module path)
- Agent variants `["wandb-primary","mcp-v3-lazy"]` -> `["claude-mcp"]` (actual config names)
- Nightly eval config `mcp-ci.yaml` (7 tasks) -> `mcp-nightly.yaml` (18 tasks covering all 19 tools)
- Removed `update-badges` job (blocked by branch protection GH013)

## Tests

- **559 unit tests** passed (83 new), lint clean
- **17/17 deployment tests** on staging (existing tools)
- **7/7 new tool tests** on staging (list_entities, probe_project, diagnose_run, compare_runs, summarize_evaluation, content search, bounded projects)
- Analytics: all tool calls show in Cloud Logging with correct `success`, `error`, `duration_ms`

## Commits

| Commit | What |
|---|---|
| `1b2f25b` | Entity discovery + content search + max_projects bounds (22 new tests) |
| `32f6b31` | compare_runs, summarize_evaluation, diagnose_run, probe_project (61 new tests) |
| `4f944e4` | Fix eval.yml (module path, agent names, nightly config, remove badges) |

## Companion PR

- [WandBAgentFactory#105](https://github.com/wandb/WandBAgentFactory/pull/105) -- 30 MCP eval tasks, mcp-nightly.yaml, 19-tool agent configs, production URL

## Tool Inventory (19 total)

| # | Tool | Category | New? |
|---|---|---|---|
| 1 | query_weave_traces_tool | Trace queries | |
| 2 | count_weave_traces_tool | Trace queries | |
| 3 | query_wandb_tool | W&B GQL | |
| 4 | create_wandb_report_tool | Reports | |
| 5 | log_analysis_to_wandb | Reports | |
| 6 | query_wandb_entity_projects | Discovery | Updated (max_projects) |
| 7 | infer_trace_schema_tool | Discovery | |
| 8 | search_wandb_docs_tool | Docs | |
| 9 | get_run_history_tool | Run analysis | |
| 10 | list_registries_tool | Registry | |
| 11 | list_registry_collections_tool | Registry | |
| 12 | list_artifact_versions_tool | Artifacts | |
| 13 | get_artifact_details_tool | Artifacts | |
| 14 | compare_artifact_versions_tool | Artifacts | |
| 15 | **list_entities_tool** | Discovery | v0.3.2 |
| 16 | **compare_runs_tool** | Run analysis | v0.3.2 |
| 17 | **summarize_evaluation_tool** | Eval analysis | v0.3.2 |
| 18 | **diagnose_run_tool** | Run analysis | v0.3.2 |
| 19 | **probe_project_tool** | Discovery | v0.3.2 |