### PR TITLE
fix(observability): JSON log format for containerized deploys; gate forwarder warning behind agent presence

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -104,6 +104,25 @@ rich formatter's ANSI codes and level placement. Setting `MCP_LOG_FORMAT=json` e
 Datadog extracts the `level`, `timestamp`, `logger`, and `message` fields automatically;
 `status:error` misclassification disappears.
 
+### Scope of JSON mode: root + third-party loggers
+
+When `MCP_LOG_FORMAT=json` is set, the server calls `configure_process_logging()` at
+startup. This installs the JSON handler on:
+
+- the Python **root logger**,
+- `uvicorn`, `uvicorn.access`, `uvicorn.error`,
+- `mcp` (the MCP SDK; covers `mcp.server.streamable_http.*`).
+
+As a result, **every log line emitted by the process is structured JSON**, not just
+the ones from `wandb_mcp_server.*` modules that go through `get_rich_logger()`. This
+is what makes uvicorn's `GET /mcp/health 200` access lines parse cleanly in Datadog
+instead of being auto-classified as `status:error` due to rich-formatter text shape.
+
+One explicit exclusion: `wandb_mcp_server.analytics` is intentionally NOT reconfigured.
+It already uses its own `_StructuredJsonFormatter` ([`src/wandb_mcp_server/analytics.py`](../src/wandb_mcp_server/analytics.py))
+whose schema downstream GCP Cloud Logging -> BigQuery pipelines depend on. Touching
+it would silently break analytics ingestion.
+
 ## What about Cloud Run today?
 
 Cloud Run production (see [`deploy.sh`](https://github.com/wandb/wandb-mcp-server-test/blob/main/deploy.sh))

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,115 @@
+# Observability
+
+The MCP server emits product analytics (Segment) and operational telemetry (Datadog).
+This document covers the two supported Datadog collection modes, the environment
+variables that control them, and when to pick each.
+
+## TL;DR
+
+| Deployment target | Recommended mode | What to set |
+|---|---|---|
+| Managed Kubernetes (dedicated cloud, self-managed) | **Agent mode** | Install DD Agent DaemonSet once per cluster; set `MCP_LOG_FORMAT=json` on the pod. No DD credentials on the workload. |
+| Serverless (Cloud Run, Lambda) | **Forwarder mode** | `MCP_DATADOG_FORWARD=true` + `DD_API_KEY` (env or GCP Secret Manager) |
+| Local dev | No Datadog | Leave `MCP_DATADOG_FORWARD` unset; `MCP_LOG_FORMAT` defaults to `rich` |
+
+## Two collection modes
+
+### Agent mode (preferred on Kubernetes)
+
+A Datadog Agent DaemonSet on every node:
+
+- **Logs**: tails `/var/log/pods/**` (container stdout/stderr) via kubelet and forwards with
+  `containerCollectAll: true`. Per-pod Unified Service Tagging labels
+  (`tags.datadoghq.com/{service,env,version}`) auto-join logs to APM traces.
+- **APM traces**: the MCP server's `ddtrace` library sends spans to `$DD_AGENT_HOST:8126`
+  (node IP, via downward API). No app code change required.
+- **Metrics**: DogStatsD on `$DD_AGENT_HOST:8125`; system/container metrics via kubelet.
+
+The agent holds the single DD API key (typically from a `datadog-secrets` Secret in the
+`datadog` namespace, managed once by cluster infra). Workloads hold no DD credentials.
+
+Configure via the helm chart (see
+[wandb/helm-charts operator-wandb 0.42.2+](https://github.com/wandb/helm-charts/tree/main/charts/operator-wandb)):
+
+```yaml
+mcp-server:
+  datadog:
+    enabled: true              # injects DD_SERVICE/ENV/VERSION + DD_AGENT_HOST + MCP_LOG_FORMAT=json
+    # mode: agent              # default; no MCP_DATADOG_FORWARD env, no workload DD_API_KEY
+    deploymentType: dedicated-cloud
+    customer: acme
+    extraTags: ["team:ml-platform", "region:us-west1"]
+```
+
+### Forwarder mode (serverless only)
+
+The MCP server itself POSTs analytics events to
+`https://http-intake.logs.$DD_SITE/api/v2/logs` using the
+[Datadog HTTP Logs Intake API](https://docs.datadoghq.com/api/latest/logs/#send-logs),
+mapping each internal event to a structured log entry (`@duration`, `@http.status_code`,
+`@error.kind`, `@usr.id`, etc).
+
+Use this on Cloud Run, Lambda, or any environment where you cannot run a node-local agent.
+It is **not recommended on Kubernetes** because it duplicates what the agent already does
+and requires a `DD_API_KEY` on the workload.
+
+Required environment variables:
+
+| Var | Purpose |
+|---|---|
+| `MCP_DATADOG_FORWARD=true` | Enables the in-app HTTP forwarder. |
+| `DD_API_KEY` | API key. Read from env first, then GCP Secret Manager if `MCP_SERVER_SECRETS_PROVIDER=gcp` is set. |
+| `DD_SITE` | Datadog site (default `datadoghq.com`; W&B uses `us5.datadoghq.com`). |
+| `DD_SERVICE`, `DD_ENV`, `DD_VERSION` | Unified Service Tagging on every forwarded event. |
+| `MCP_SERVER_SECRETS_PROVIDER=gcp` | Optional: if set, `DD_API_KEY` is fetched from `mcp-server-datadog-api-key` in GCP Secret Manager instead of env. |
+| `MCP_SERVER_SECRETS_PROJECT` | Required when `MCP_SERVER_SECRETS_PROVIDER=gcp`. |
+
+If `MCP_DATADOG_FORWARD=true` but `DD_API_KEY` resolves empty, the forwarder disables
+itself. When `DD_AGENT_HOST` is also set (agent mode is active) this is logged at
+`DEBUG` because a local agent is already handling observability; otherwise it's a
+`WARNING` since it indicates misconfiguration.
+
+## Environment variables (cross-reference)
+
+| Variable | Default | Modes | Purpose |
+|---|---|---|---|
+| `MCP_LOG_FORMAT` | `rich` | both | `json` for structured one-line-per-record output (preferred in containers / behind DD Agent). `rich` for pretty local dev. Chart 0.42.2+ sets `json` when `datadog.enabled=true`. |
+| `MCP_DATADOG_ENABLED` | `false` | informational | Marker emitted by the chart; doesn't gate behavior today. |
+| `MCP_DATADOG_FORWARD` | `false` | forwarder | Enable the in-app HTTP intake forwarder. |
+| `DD_AGENT_HOST` | unset | agent | Node IP where the DD Agent runs; used by `ddtrace` and DogStatsD. Chart sets from `status.hostIP`. |
+| `DD_TRACE_AGENT_HOSTNAME` | unset | agent | Same as `DD_AGENT_HOST`, for trace-agent clients that read this name. |
+| `DD_SERVICE` | `wandb-mcp-server` | both | UST service name. Chart and Cloud Run deploy both set this. |
+| `DD_ENV` | `production` | both | UST environment tag. |
+| `DD_VERSION` | image tag | both | UST version tag. |
+| `DD_SITE` | `datadoghq.com` | forwarder | Datadog site; controls the intake URL. |
+| `DD_API_KEY` | unset | forwarder | DD API key. Workload must not hold this in agent mode. |
+| `MCP_SERVER_SECRETS_PROVIDER` | unset | forwarder | Set to `gcp` to resolve `DD_API_KEY` (and other secrets) from GCP Secret Manager. |
+| `MCP_SERVER_SECRETS_PROJECT` | unset | forwarder | GCP project id for Secret Manager when provider is `gcp`. |
+
+## Log format: `MCP_LOG_FORMAT=json`
+
+The default `rich` format produces human-readable lines like:
+
+```
+[2026-04-24 15:00:40] INFO     GET / -> 200 (0.001s)
+```
+
+Datadog's auto-detection misclassifies many of these as `status:error` due to the
+rich formatter's ANSI codes and level placement. Setting `MCP_LOG_FORMAT=json` emits:
+
+```json
+{"timestamp":"2026-04-24T15:00:40Z","level":"info","logger":"wandb_mcp_server.server","message":"GET / -> 200 (0.001s)"}
+```
+
+Datadog extracts the `level`, `timestamp`, `logger`, and `message` fields automatically;
+`status:error` misclassification disappears.
+
+## What about Cloud Run today?
+
+Cloud Run production (see [`deploy.sh`](https://github.com/wandb/wandb-mcp-server-test/blob/main/deploy.sh))
+sets `MCP_DATADOG_FORWARD=true`, `DD_SITE=us5.datadoghq.com`, `DD_SERVICE=wandb-mcp-server`,
+and pulls `DD_API_KEY` via `MCP_SERVER_SECRETS_PROVIDER=gcp` from the
+`mcp-server-datadog-api-key` secret in `wandb-mcp-production`. That configuration is
+unchanged by this PR: the forwarder path is preserved, `DD_AGENT_HOST` is not set
+(so the WARN behavior for a misconfigured forwarder-without-key stays on Cloud Run),
+and `MCP_LOG_FORMAT` defaults to `rich` until Cloud Run explicitly opts in.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -139,6 +139,56 @@ third-party logger reconfiguration loop. This guard runs only in JSON mode (rich
 mode returns early), so Cloud Run today is unaffected. Behavior was observed live
 on Cloud Run staging revision `wandb-mcp-server-staging-00084-p8s`.
 
+## Privacy levels: `MCP_LOG_PRIVACY_LEVEL`
+
+`MCP_LOG_PRIVACY_LEVEL` controls how aggressively customer-supplied content
+is redacted before it reaches any log sink (Cloud Logging, Segment, Datadog
+forwarder). Applied uniformly by `AnalyticsTracker._sanitise_params`, by the
+identity-hashing helper in `analytics.py`, and by verbose-log-site gates in
+`tools_utils.py` and `weave_api/client.py`.
+
+| Level | Free-text params (`query`, `prompt`, `description`, ...) | Identifiers (`entity_name`, `project_name`, `run_id`, `user_id`, `email_domain`) | Verbose `ToolCall` / raw-body logs |
+|---|---|---|---|
+| `off` (default) | pass-through | pass-through | INFO |
+| `standard` | redacted -> `<redacted: text len=N>` | pass-through | demoted to DEBUG |
+| `strict` | redacted -> `<redacted: text len=N>` | hashed -> `<h:sha256_prefix>` | demoted to DEBUG |
+
+Sensitive key-name redaction (`api_key`, `token`, `secret`, `password`,
+`credential`, `auth`) runs at every level. Truncation of strings >200 chars
+runs at every level.
+
+### Recommended defaults per deployment target
+
+| Deployment | Recommended level | How it's set |
+|---|---|---|
+| Local dev | `off` (unset) | env-var default |
+| Cloud Run (W&B-managed, feeds BigQuery analytics) | `off` explicit | `deploy.sh` passes `MCP_LOG_PRIVACY_LEVEL=off` |
+| Customer K8s via helm chart | `standard` | chart injects from `mcp-server.privacy.logLevel` (default `standard`) |
+| Regulated / privacy-sensitive K8s | `strict` | override chart value to `strict` |
+
+### Why the split
+
+Cloud Run's analytics logger emits directly to GCP Cloud Logging, which pipes
+to BigQuery for product analytics. That pipeline depends on plaintext
+`user_id`, `email_domain`, and `params` fields for cohort analysis. `off`
+preserves this byte-for-byte.
+
+Customer K8s installs do NOT feed W&B's BigQuery; their analytics logger goes
+to stdout for the local Datadog Agent to collect into the customer's own
+Datadog tenant. There's no business need to retain plaintext free-text
+params there, and redaction reduces legal exposure if customer logs are
+subpoenaed, exported, or retained longer than needed. `standard` is the safe
+default. `strict` goes one step further for regulated customers.
+
+### Identifier hashing at `strict`
+
+`<h:sha256_prefix>` uses the first 12 hex chars of `sha256(value)`.
+Deterministic (the same entity name always hashes to the same digest), so
+cohort analytics (tool adoption by entity, error rates by project) still
+work. Not reversible without a rainbow table over known W&B entity names,
+which is out of scope for legal defensibility (the retained data is no
+longer plaintext customer identifiers).
+
 ## What about Cloud Run today?
 
 Cloud Run production (see [`deploy.sh`](https://github.com/wandb/wandb-mcp-server-test/blob/main/deploy.sh))

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -123,6 +123,22 @@ It already uses its own `_StructuredJsonFormatter` ([`src/wandb_mcp_server/analy
 whose schema downstream GCP Cloud Logging -> BigQuery pipelines depend on. Touching
 it would silently break analytics ingestion.
 
+### Defensive analytics propagation lock
+
+`analytics.py` sets `analytics_logger.propagate = False` at module import time so that
+the analytics record is emitted only by its own `_StructuredJsonFormatter` handler
+(stdout) and never reaches the root logger. However, when the server boots under
+`uvicorn`, `logging.config.dictConfig` can reset propagation on existing loggers,
+silently re-enabling propagation. In that case every analytics event is emitted
+twice: once via the rich `_StructuredJsonFormatter` payload on stdout, and a
+minimal duplicate via the root `_JsonLogFormatter` on stderr.
+
+To prevent this, `configure_process_logging()` re-asserts
+`logging.getLogger("wandb_mcp_server.analytics").propagate = False` after the
+third-party logger reconfiguration loop. This guard runs only in JSON mode (rich
+mode returns early), so Cloud Run today is unaffected. Behavior was observed live
+on Cloud Run staging revision `wandb-mcp-server-staging-00084-p8s`.
+
 ## What about Cloud Run today?
 
 Cloud Run production (see [`deploy.sh`](https://github.com/wandb/wandb-mcp-server-test/blob/main/deploy.sh))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.2"
+version = "0.3.3"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -92,6 +92,7 @@ _IDENTIFIER_KEYS_FOR_HASHING: frozenset = frozenset(
         "project_name",
         "entity",
         "project",
+        "organization",
         "registry_name",
         "collection_name",
         "artifact_name",
@@ -103,17 +104,35 @@ _IDENTIFIER_KEYS_FOR_HASHING: frozenset = frozenset(
     }
 )
 
+# Once-per-process latch so an invalid MCP_LOG_PRIVACY_LEVEL doesn't spam logs
+# on every analytics emit. Operators see one WARNING in their first scrape.
+_warned_invalid_privacy_level = False
+
 
 def _resolve_privacy_level() -> str:
     """Return the active privacy level, defaulting to ``off``.
 
     Read lazily (not cached) so tests and runtime env-var toggles work
     without reloading the module.
+
+    Invalid values fall back to ``off`` (most permissive -- preserves
+    availability) but emit a single WARNING so a typo like ``stict`` is
+    visible to operators rather than silently downgrading their privacy
+    posture.
     """
     raw = os.environ.get("MCP_LOG_PRIVACY_LEVEL", _PRIVACY_LEVEL_OFF).strip().lower()
-    if raw not in _VALID_PRIVACY_LEVELS:
+    if raw and raw not in _VALID_PRIVACY_LEVELS:
+        global _warned_invalid_privacy_level
+        if not _warned_invalid_privacy_level:
+            _warned_invalid_privacy_level = True
+            logger.warning(
+                "MCP_LOG_PRIVACY_LEVEL=%r is not one of %s; falling back to 'off'. "
+                "Set a valid level to silence this warning.",
+                raw,
+                sorted(_VALID_PRIVACY_LEVELS),
+            )
         return _PRIVACY_LEVEL_OFF
-    return raw
+    return raw or _PRIVACY_LEVEL_OFF
 
 
 def _hash_identifier(value: Any) -> str:
@@ -167,6 +186,12 @@ _handler.setFormatter(_StructuredJsonFormatter())
 analytics_logger.addHandler(_handler)
 
 _REQUIRED_BASE_FIELDS = frozenset({"schema_version", "event_type", "timestamp"})
+
+# Surface the active privacy level once at module import so operators can
+# verify their config by grepping pod logs (instead of needing kubectl describe).
+# Triggers _resolve_privacy_level()'s WARNING for invalid values, so an env-var
+# typo also lights up here at startup.
+logger.info("Analytics ready: MCP_LOG_PRIVACY_LEVEL=%s", _resolve_privacy_level())
 
 
 def _utcnow_iso() -> str:

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -13,6 +13,7 @@ Based on prior art by @NiWaRe (PR #2), rewritten for improved
 datetime handling, cleaner auth integration, and structured event schema.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -36,6 +37,105 @@ _SENSITIVE_PARAM_PATTERNS: List[str] = [
 ]
 
 _MAX_PARAM_VALUE_LENGTH = 200
+
+# ---------------------------------------------------------------------------
+# Privacy levels
+#
+# MCP_LOG_PRIVACY_LEVEL controls how aggressively we redact customer-supplied
+# content before it lands in any log sink (Cloud Logging, Segment, Datadog
+# forwarder). Consumed here by _sanitise_params and the identifier-hashing
+# helpers; also consumed by tools_utils/weave_api to demote verbose log sites
+# at standard+ levels.
+#
+#   off       -- today's behavior. Redact sensitive-looking keys, truncate long
+#                strings. Free-text values pass through. Cloud Run uses this
+#                to preserve the BigQuery analytics contract.
+#   standard  -- additionally redact free-text value keys (query, prompt,
+#                description, etc). Customer K8s chart default.
+#   strict    -- additionally hash entity/project/user identifiers. For
+#                regulated / privacy-sensitive deployments.
+#
+# Default is "off" so the image behaves identically when run outside the chart.
+# Customer K8s installs flip to "standard" via the helm chart's env injection.
+# ---------------------------------------------------------------------------
+
+_PRIVACY_LEVEL_OFF = "off"
+_PRIVACY_LEVEL_STANDARD = "standard"
+_PRIVACY_LEVEL_STRICT = "strict"
+_VALID_PRIVACY_LEVELS = frozenset({_PRIVACY_LEVEL_OFF, _PRIVACY_LEVEL_STANDARD, _PRIVACY_LEVEL_STRICT})
+
+# Keys whose values are free-form customer text. At standard+ levels the
+# value is replaced with "<redacted: text len=N>" so we can still analyse
+# call-volume / length distributions without logging the content itself.
+_FREE_TEXT_KEYS: frozenset = frozenset(
+    {
+        "query",
+        "question",
+        "prompt",
+        "description",
+        "title",
+        "text",
+        "content",
+        "body",
+        "eval_name",
+        "analysis_name",
+        "message",
+    }
+)
+
+# Keys whose values identify a specific customer entity/project/artifact.
+# At strict level we hash these to a 12-char sha256 prefix so cardinality
+# for cohort analytics is preserved while plaintext is not retained.
+_IDENTIFIER_KEYS_FOR_HASHING: frozenset = frozenset(
+    {
+        "entity_name",
+        "project_name",
+        "entity",
+        "project",
+        "registry_name",
+        "collection_name",
+        "artifact_name",
+        "artifact_name_a",
+        "artifact_name_b",
+        "run_id",
+        "run_id_a",
+        "run_id_b",
+    }
+)
+
+
+def _resolve_privacy_level() -> str:
+    """Return the active privacy level, defaulting to ``off``.
+
+    Read lazily (not cached) so tests and runtime env-var toggles work
+    without reloading the module.
+    """
+    raw = os.environ.get("MCP_LOG_PRIVACY_LEVEL", _PRIVACY_LEVEL_OFF).strip().lower()
+    if raw not in _VALID_PRIVACY_LEVELS:
+        return _PRIVACY_LEVEL_OFF
+    return raw
+
+
+def _hash_identifier(value: Any) -> str:
+    """Hash an identifier to a short sha256 prefix for strict-mode analytics.
+
+    Non-string inputs are coerced via ``str()``. Empty/None values return
+    ``"<empty>"`` so downstream consumers can distinguish "no value" from
+    "hashed value".
+    """
+    if value is None or value == "":
+        return "<empty>"
+    digest = hashlib.sha256(str(value).encode("utf-8", errors="replace")).hexdigest()
+    return f"<h:{digest[:12]}>"
+
+
+def is_verbose_log_site_gated() -> bool:
+    """True when standard+ privacy levels demote verbose log sites to DEBUG.
+
+    Exported so external emit sites (tools_utils, weave_api/client) can gate
+    their INFO-level logs without importing the private level constants.
+    """
+    return _resolve_privacy_level() in (_PRIVACY_LEVEL_STANDARD, _PRIVACY_LEVEL_STRICT)
 
 
 class _StructuredJsonFormatter(logging.Formatter):
@@ -141,21 +241,44 @@ class AnalyticsTracker:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _sanitise_params(cls, params: Optional[Dict[str, Any]], *, _depth: int = 0) -> Dict[str, Any]:
+    def _sanitise_params(
+        cls,
+        params: Optional[Dict[str, Any]],
+        *,
+        _depth: int = 0,
+        level: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Strip sensitive keys and truncate large values.
 
         Recursively sanitises nested dicts and lists up to 3 levels deep.
+        When ``level`` is ``standard`` or ``strict``, also redacts free-text
+        value keys (query, prompt, description, etc). When ``level`` is
+        ``strict``, additionally hashes identifier keys (entity_name,
+        project_name, run_id, etc).
+
+        ``level`` defaults to the value of ``MCP_LOG_PRIVACY_LEVEL`` at call
+        time. Explicit ``level`` arg is used by tests and by the emit sites
+        that need deterministic behavior across a single call tree.
         """
         if not params:
             return {}
+        if level is None:
+            level = _resolve_privacy_level()
+        redact_free_text = level in (_PRIVACY_LEVEL_STANDARD, _PRIVACY_LEVEL_STRICT)
+        hash_identifiers = level == _PRIVACY_LEVEL_STRICT
         safe: Dict[str, Any] = {}
         for key, value in params.items():
-            if any(p in key.lower() for p in _SENSITIVE_PARAM_PATTERNS):
+            key_lower = key.lower()
+            if any(p in key_lower for p in _SENSITIVE_PARAM_PATTERNS):
                 safe[key] = "<redacted>"
+            elif redact_free_text and key_lower in _FREE_TEXT_KEYS and isinstance(value, str):
+                safe[key] = f"<redacted: text len={len(value)}>"
+            elif hash_identifiers and key_lower in _IDENTIFIER_KEYS_FOR_HASHING:
+                safe[key] = _hash_identifier(value)
             elif isinstance(value, dict) and _depth < 3:
-                safe[key] = cls._sanitise_params(value, _depth=_depth + 1)
+                safe[key] = cls._sanitise_params(value, _depth=_depth + 1, level=level)
             elif isinstance(value, list) and _depth < 3:
-                safe[key] = cls._sanitise_list(value, _depth=_depth + 1)
+                safe[key] = cls._sanitise_list(value, _depth=_depth + 1, level=level)
             elif isinstance(value, str) and len(value) > _MAX_PARAM_VALUE_LENGTH:
                 safe[key] = f"<truncated:{len(value)} chars>"
             else:
@@ -163,14 +286,22 @@ class AnalyticsTracker:
         return safe
 
     @classmethod
-    def _sanitise_list(cls, items: list, *, _depth: int = 0) -> list:
+    def _sanitise_list(
+        cls,
+        items: list,
+        *,
+        _depth: int = 0,
+        level: Optional[str] = None,
+    ) -> list:
         """Sanitise each element in a list, recursing into dicts and nested lists."""
+        if level is None:
+            level = _resolve_privacy_level()
         result = []
         for item in items:
             if isinstance(item, dict) and _depth < 3:
-                result.append(cls._sanitise_params(item, _depth=_depth))
+                result.append(cls._sanitise_params(item, _depth=_depth, level=level))
             elif isinstance(item, list) and _depth < 3:
-                result.append(cls._sanitise_list(item, _depth=_depth + 1))
+                result.append(cls._sanitise_list(item, _depth=_depth + 1, level=level))
             else:
                 result.append(item)
         return result
@@ -234,6 +365,29 @@ class AnalyticsTracker:
         except Exception as exc:
             logger.debug(f"Datadog forwarding failed (non-fatal): {exc}")
 
+    @staticmethod
+    def _apply_identity_privacy(
+        user_id: Optional[str],
+        email_domain: Optional[str],
+        *,
+        level: Optional[str] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Transform identity fields according to the active privacy level.
+
+        - ``off`` / ``standard``: return values unchanged.
+        - ``strict``: hash both to opaque sha256 prefixes so cardinality
+          is preserved for cohort analytics without retaining plaintext.
+
+        Returns ``(user_id, email_domain)`` tuple.
+        """
+        if level is None:
+            level = _resolve_privacy_level()
+        if level != _PRIVACY_LEVEL_STRICT:
+            return user_id, email_domain
+        hashed_user = _hash_identifier(user_id) if user_id else user_id
+        hashed_domain = _hash_identifier(email_domain) if email_domain else email_domain
+        return hashed_user, hashed_domain
+
     def track_user_session(
         self,
         session_id: str,
@@ -245,11 +399,14 @@ class AnalyticsTracker:
         if not self.enabled:
             return
         try:
+            level = _resolve_privacy_level()
+            user_id = self._extract_user_id(viewer_info)
             email_domain = self._extract_email_domain(viewer_info)
+            user_id, email_domain = self._apply_identity_privacy(user_id, email_domain, level=level)
             event = {
                 **self._base_event("user_session"),
                 "session_id": session_id,
-                "user_id": self._extract_user_id(viewer_info),
+                "user_id": user_id,
                 "email_domain": email_domain,
                 "api_key_hash": api_key_hash[:16] if api_key_hash else None,
                 "metadata": metadata or {},
@@ -272,14 +429,17 @@ class AnalyticsTracker:
         if not self.enabled:
             return
         try:
+            level = _resolve_privacy_level()
+            user_id = self._extract_user_id(viewer_info)
             email_domain = self._extract_email_domain(viewer_info)
+            user_id, email_domain = self._apply_identity_privacy(user_id, email_domain, level=level)
             event = {
                 **self._base_event("tool_call"),
                 "session_id": session_id,
-                "user_id": self._extract_user_id(viewer_info),
+                "user_id": user_id,
                 "email_domain": email_domain,
                 "tool_name": tool_name,
-                "params": self._sanitise_params(params),
+                "params": self._sanitise_params(params, level=level),
                 "success": success,
                 "error": error,
                 "duration_ms": duration_ms,
@@ -311,6 +471,7 @@ class AnalyticsTracker:
         if not self.enabled:
             return
         try:
+            user_id, email_domain = self._apply_identity_privacy(user_id, email_domain)
             event = {
                 **self._base_event("request"),
                 "request_id": request_id,

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -243,7 +243,19 @@ class DatadogForwarder:
         self._thread_local = threading.local()
 
         if self.live and not self._api_key:
-            logger.warning("MCP_DATADOG_FORWARD=true but DD_API_KEY is empty -- forwarding disabled")
+            # In managed K8s, the DD Agent DaemonSet (on the node at DD_AGENT_HOST:8126)
+            # already collects stdout logs and APM traces using its own API key. A pod
+            # with MCP_DATADOG_FORWARD=true and no DD_API_KEY would legitimately happen
+            # if a chart pre-0.42.2 toggled the forwarder flag without seeding a secret.
+            # That's a misconfiguration in serverless, but the correct state in K8s --
+            # demote to debug there so we don't log spam in every production pod.
+            if os.environ.get("DD_AGENT_HOST"):
+                logger.debug(
+                    "MCP_DATADOG_FORWARD=true but DD_API_KEY empty; DD_AGENT_HOST is set, "
+                    "assuming a local Datadog Agent is collecting logs/APM. Forwarder disabled."
+                )
+            else:
+                logger.warning("MCP_DATADOG_FORWARD=true but DD_API_KEY is empty -- forwarding disabled")
             self.live = False
 
     @property

--- a/src/wandb_mcp_server/mcp_tools/tools_utils.py
+++ b/src/wandb_mcp_server/mcp_tools/tools_utils.py
@@ -346,11 +346,21 @@ def track_tool_execution(
     Yields a ``_ToolExecutionContext`` so tools that return error dicts
     instead of raising can call ``ctx.mark_error(...)`` explicitly.
     """
-    from wandb_mcp_server.analytics import AnalyticsTracker, get_analytics_tracker
+    from wandb_mcp_server.analytics import (
+        AnalyticsTracker,
+        get_analytics_tracker,
+        is_verbose_log_site_gated,
+    )
     from wandb_mcp_server.session_manager import current_session_id
 
     safe_params = AnalyticsTracker._sanitise_params(params)
-    _tools_logger.info(f"ToolCall name={tool_name} params={safe_params}")
+    # Demote to DEBUG at standard+ privacy levels. The analytics event emitted in
+    # the finally-block below still captures tool_name/params/success structurally,
+    # so BigQuery / DD / Segment pipelines see the same information regardless.
+    if is_verbose_log_site_gated():
+        _tools_logger.debug(f"ToolCall name={tool_name} params={safe_params}")
+    else:
+        _tools_logger.info(f"ToolCall name={tool_name} params={safe_params}")
 
     ctx = _ToolExecutionContext()
     start = time.monotonic()

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -897,6 +897,15 @@ def cli():
     # Load .env only when running as CLI, not on import
     load_dotenv(dotenv_path=Path(__file__).parent.parent.parent / ".env")
 
+    # Normalize process-wide logging BEFORE any logger.info call fires. When
+    # MCP_LOG_FORMAT=json this installs our JSON handler on root + uvicorn.* + mcp,
+    # so access logs and MCP SDK logs are structured too (not just wandb_mcp_server.*
+    # loggers that go through get_rich_logger). No-op when MCP_LOG_FORMAT is unset
+    # or set to "rich" -- preserves today's Cloud Run behavior verbatim.
+    from wandb_mcp_server.utils import configure_process_logging
+
+    configure_process_logging()
+
     # Parse command line arguments
     import simple_parsing
 

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -150,6 +150,15 @@ def configure_process_logging() -> None:
         if name != "":
             lg.propagate = False
 
+    # Defensive: re-assert that the analytics logger does not propagate to the root
+    # handler. analytics.py sets this at import time, but uvicorn's dictConfig can
+    # reset propagation on existing loggers when the server boots -- resulting in
+    # every analytics event emitting twice (once via the analytics _StructuredJsonFormatter
+    # on stdout, and a minimal duplicate via the root _JsonLogFormatter on stderr).
+    # Runs only in json mode (rich mode returned early above), so Cloud Run today
+    # is unaffected. Observed live on staging revision 00084-p8s; this prevents it.
+    logging.getLogger("wandb_mcp_server.analytics").propagate = False
+
 
 # Moved get_rich_logger here
 def get_rich_logger(

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -97,6 +97,49 @@ def _build_log_handler() -> logging.Handler:
     )
 
 
+# Third-party loggers we explicitly reconfigure in JSON mode so every line emitted by
+# the process reaches Datadog (or any other container-log backend) as structured JSON,
+# not just ones from wandb_mcp_server.* modules that go through get_rich_logger().
+#
+# Excludes wandb_mcp_server.analytics: it has its own GCP-Logging-friendly formatter
+# (_StructuredJsonFormatter in analytics.py) that downstream BigQuery pipelines depend
+# on. Reconfiguring it would silently break analytics ingestion.
+_JSON_MODE_THIRD_PARTY_LOGGERS = (
+    "",  # root
+    "uvicorn",
+    "uvicorn.access",
+    "uvicorn.error",
+    "mcp",  # MCP SDK; covers mcp.server.streamable_http etc.
+)
+
+
+def configure_process_logging() -> None:
+    """Idempotent: install the JSON handler on root + third-party loggers when enabled.
+
+    Called once from the CLI entrypoint. No-op when MCP_LOG_FORMAT=rich (default) so
+    local dev and Cloud Run keep today's behavior. When MCP_LOG_FORMAT=json, replaces
+    handlers on root + uvicorn.* + mcp so access logs and SDK logs also emit
+    structured JSON lines -- closes the gap where get_rich_logger() only covers our
+    own modules.
+
+    Skips wandb_mcp_server.analytics intentionally: it owns its own formatter contract
+    with downstream BigQuery pipelines and must not be reconfigured here.
+    """
+    if os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower() != "json":
+        return
+
+    for name in _JSON_MODE_THIRD_PARTY_LOGGERS:
+        lg = logging.getLogger(name)
+        for h in list(lg.handlers):
+            lg.removeHandler(h)
+        lg.addHandler(_build_log_handler())
+        # Third-party loggers should not propagate up to root -- we already installed
+        # the JSON handler on each, and propagation would duplicate every record.
+        # The root logger itself keeps propagate=True (it's the root, nothing above).
+        if name != "":
+            lg.propagate = False
+
+
 # Moved get_rich_logger here
 def get_rich_logger(
     name: str,

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -113,18 +113,29 @@ _JSON_MODE_THIRD_PARTY_LOGGERS = (
 )
 
 
+_process_logging_configured = False
+
+
 def configure_process_logging() -> None:
     """Idempotent: install the JSON handler on root + third-party loggers when enabled.
 
-    Called once from the CLI entrypoint. No-op when MCP_LOG_FORMAT=rich (default) so
-    local dev and Cloud Run keep today's behavior. When MCP_LOG_FORMAT=json, replaces
-    handlers on root + uvicorn.* + mcp so access logs and SDK logs also emit
-    structured JSON lines -- closes the gap where get_rich_logger() only covers our
-    own modules.
+    Called automatically on the first get_rich_logger() invocation (so it fires from
+    any entrypoint -- `wandb_mcp_server` CLI, Cloud Run `uvicorn app:app`, tests).
+    Can also be called explicitly; running twice is a no-op.
+
+    No-op when MCP_LOG_FORMAT=rich (default) so local dev and Cloud Run keep today's
+    behavior. When MCP_LOG_FORMAT=json, replaces handlers on root + uvicorn.* + mcp
+    so access logs and SDK logs also emit structured JSON lines -- closes the gap
+    where get_rich_logger() only covers our own modules.
 
     Skips wandb_mcp_server.analytics intentionally: it owns its own formatter contract
     with downstream BigQuery pipelines and must not be reconfigured here.
     """
+    global _process_logging_configured
+    if _process_logging_configured:
+        return
+    _process_logging_configured = True
+
     if os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower() != "json":
         return
 
@@ -155,6 +166,12 @@ def get_rich_logger(
     The log level can be set via an environment variable if `env_var_name` is provided.
     Otherwise, it defaults to `default_level_str`.
     """
+    # Auto-configure process-wide logging on first call so root + uvicorn.* + mcp
+    # also get the JSON handler when MCP_LOG_FORMAT=json. Runs once per process;
+    # subsequent invocations are no-ops via the _process_logging_configured guard.
+    # This covers every entrypoint (CLI, uvicorn app:app on Cloud Run, tests).
+    configure_process_logging()
+
     logger = logging.getLogger(name)
     _log_handler = _build_log_handler()
 

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json as _json
 import logging
 import netrc
 import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -43,6 +45,58 @@ class RedirectLoggerHandler(logging.Handler):
             self.handleError(record)
 
 
+# JSON formatter for structured logs (e.g. when running behind a Datadog Agent that
+# parses JSON log payloads). Keeps a stable set of top-level fields so downstream
+# log backends (Datadog, GCP Cloud Logging) extract `level`, `timestamp`, `logger`,
+# `message` automatically without custom pipelines.
+class _JsonLogFormatter(logging.Formatter):
+    """One JSON object per record. stdlib-only, no extra deps."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: Dict[str, object] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Preserve session prefix context for correlation across request chains
+        session_prefix = getattr(record, "session_id_prefix", "")
+        if session_prefix:
+            payload["session_id_prefix"] = session_prefix
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        # stack_info is separate from exc_info; include if present
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+        return _json.dumps(payload, default=str)
+
+
+def _build_log_handler() -> logging.Handler:
+    """Build the log handler based on MCP_LOG_FORMAT.
+
+    - "rich" (default): RichHandler for pretty local dev output. Also the Cloud Run
+      production default today -- do NOT change without validating DD dashboards.
+    - "json": Structured JSON lines on stderr. Recommended when running under a DD Agent
+      (agent auto-parses level/timestamp) or in any container where downstream parsers
+      expect structured logs. Opt-in via env var; chart 0.42.2+ sets this when
+      mcp-server.datadog.enabled=true.
+    """
+    log_format = os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower()
+    if log_format == "json":
+        handler: logging.Handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(_JsonLogFormatter())
+        return handler
+    # Default: rich output, preserves today's behavior for local dev + Cloud Run.
+    stderr_console = Console(stderr=True)
+    return RichHandler(
+        console=stderr_console,
+        show_time=True,
+        show_level=True,
+        show_path=False,
+        markup=True,
+    )
+
+
 # Moved get_rich_logger here
 def get_rich_logger(
     name: str,
@@ -51,19 +105,15 @@ def get_rich_logger(
     env_var_name: Optional[str] = None,
 ) -> logging.Logger:
     """
-    Configure and return a logger with RichHandler.
+    Configure and return a logger. Output format is controlled by MCP_LOG_FORMAT
+    (values: "rich" default, or "json" for structured one-line-per-record output
+    suitable for containerized deployments behind a Datadog Agent).
+
     The log level can be set via an environment variable if `env_var_name` is provided.
     Otherwise, it defaults to `default_level_str`.
     """
     logger = logging.getLogger(name)
-    stderr_console = Console(stderr=True)
-    _rich_handler = RichHandler(
-        console=stderr_console,
-        show_time=True,
-        show_level=True,
-        show_path=False,
-        markup=True,
-    )
+    _log_handler = _build_log_handler()
 
     # Inject session prefix into message if provided via LoggerAdapter extra
     class _SessionPrefixInjectFilter(logging.Filter):
@@ -82,7 +132,7 @@ def get_rich_logger(
     logger.addFilter(_SessionPrefixInjectFilter())
     if logger.hasHandlers():
         logger.handlers.clear()
-    logger.addHandler(_rich_handler)
+    logger.addHandler(_log_handler)
 
     # Determine the effective log level string
     # Start with the function's default_level_str (e.g., "INFO")

--- a/src/wandb_mcp_server/weave_api/client.py
+++ b/src/wandb_mcp_server/weave_api/client.py
@@ -98,7 +98,16 @@ class WeaveApiClient:
         url = f"{self.server_url}/calls/stream_query"
         headers = self._get_auth_headers()
 
-        logger.info(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
+        # Demote the raw-body log to DEBUG at standard+ privacy levels. The body
+        # is a customer-supplied Weave filter expression that may contain PII-ish
+        # run/project identifiers or inline values; BigQuery/Segment get a
+        # sanitised view via the analytics tool_call event emitted upstream.
+        from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+        if is_verbose_log_site_gated():
+            logger.debug(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
+        else:
+            logger.info(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
         logger.debug(f"Full query parameters:\n{json.dumps(query_params, indent=2)}\n")
 
         try:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -403,3 +403,202 @@ class TestGlobalTracker:
     def test_singleton_respects_env(self):
         t = get_analytics_tracker()
         assert t.enabled is False
+
+
+# -- Privacy levels ------------------------------------------------------------
+
+
+class TestPrivacyLevel:
+    """MCP_LOG_PRIVACY_LEVEL gates how much customer content is redacted.
+
+    Three levels: off (today's behavior, Cloud Run default), standard (free-text
+    redaction, customer K8s default), strict (also hash identifiers).
+    """
+
+    # ---- _resolve_privacy_level --------------------------------------------
+
+    def test_default_is_off(self, monkeypatch):
+        monkeypatch.delenv("MCP_LOG_PRIVACY_LEVEL", raising=False)
+        from wandb_mcp_server.analytics import _resolve_privacy_level
+
+        assert _resolve_privacy_level() == "off"
+
+    def test_standard_recognised(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "standard")
+        from wandb_mcp_server.analytics import _resolve_privacy_level
+
+        assert _resolve_privacy_level() == "standard"
+
+    def test_strict_recognised(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "strict")
+        from wandb_mcp_server.analytics import _resolve_privacy_level
+
+        assert _resolve_privacy_level() == "strict"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "STANDARD")
+        from wandb_mcp_server.analytics import _resolve_privacy_level
+
+        assert _resolve_privacy_level() == "standard"
+
+    def test_unknown_falls_back_to_off(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "paranoid")
+        from wandb_mcp_server.analytics import _resolve_privacy_level
+
+        assert _resolve_privacy_level() == "off"
+
+    # ---- _sanitise_params: off mode is byte-identical to pre-amend ---------
+
+    def test_off_preserves_free_text_values(self):
+        """BigQuery contract: off-mode must pass free-text values through unchanged."""
+        params = {"query": "SELECT * FROM runs", "description": "my analysis"}
+        result = AnalyticsTracker._sanitise_params(params, level="off")
+        assert result["query"] == "SELECT * FROM runs"
+        assert result["description"] == "my analysis"
+
+    def test_off_preserves_identifiers(self):
+        params = {"entity_name": "acme-corp", "project_name": "llm-eval"}
+        result = AnalyticsTracker._sanitise_params(params, level="off")
+        assert result["entity_name"] == "acme-corp"
+        assert result["project_name"] == "llm-eval"
+
+    def test_off_still_redacts_sensitive_keys(self):
+        """The existing api_key/token redaction must still fire at off level."""
+        result = AnalyticsTracker._sanitise_params({"api_key": "leak"}, level="off")
+        assert result["api_key"] == "<redacted>"
+
+    # ---- _sanitise_params: standard mode redacts free-text values ----------
+
+    def test_standard_redacts_free_text_values(self):
+        params = {
+            "query": "SELECT * FROM runs",
+            "question": "How does W&B work?",
+            "description": "my private analysis",
+            "title": "Internal eval",
+        }
+        result = AnalyticsTracker._sanitise_params(params, level="standard")
+        assert result["query"] == f"<redacted: text len={len(params['query'])}>"
+        assert result["question"] == f"<redacted: text len={len(params['question'])}>"
+        assert result["description"] == f"<redacted: text len={len(params['description'])}>"
+        assert result["title"] == f"<redacted: text len={len(params['title'])}>"
+
+    def test_standard_preserves_identifiers(self):
+        """standard should leave entity/project plaintext -- only strict hashes."""
+        params = {"entity_name": "acme-corp", "project_name": "llm-eval"}
+        result = AnalyticsTracker._sanitise_params(params, level="standard")
+        assert result["entity_name"] == "acme-corp"
+        assert result["project_name"] == "llm-eval"
+
+    def test_standard_still_redacts_sensitive_keys(self):
+        result = AnalyticsTracker._sanitise_params({"api_key": "leak"}, level="standard")
+        assert result["api_key"] == "<redacted>"
+
+    def test_standard_preserves_non_string_free_text_values(self):
+        """Redaction only applies to string values; dict/list/int pass through."""
+        params = {"title": {"nested": "data"}, "body": 42}
+        result = AnalyticsTracker._sanitise_params(params, level="standard")
+        # Non-string values still go through the dict/list/primitive branches
+        assert result["title"] == {"nested": "data"}
+        assert result["body"] == 42
+
+    # ---- _sanitise_params: strict mode hashes identifiers ------------------
+
+    def test_strict_hashes_identifier_keys(self):
+        params = {
+            "entity_name": "acme-corp",
+            "project_name": "llm-eval",
+            "run_id": "abc123",
+        }
+        result = AnalyticsTracker._sanitise_params(params, level="strict")
+        for key in ("entity_name", "project_name", "run_id"):
+            assert result[key].startswith("<h:")
+            assert result[key].endswith(">")
+            assert len(result[key]) == len("<h:>") + 12
+
+    def test_strict_hash_is_deterministic_per_value(self):
+        """Same input must hash to the same digest so cohort analytics still work."""
+        r1 = AnalyticsTracker._sanitise_params({"entity_name": "acme"}, level="strict")
+        r2 = AnalyticsTracker._sanitise_params({"entity_name": "acme"}, level="strict")
+        assert r1["entity_name"] == r2["entity_name"]
+
+    def test_strict_different_values_produce_different_hashes(self):
+        r1 = AnalyticsTracker._sanitise_params({"entity_name": "acme"}, level="strict")
+        r2 = AnalyticsTracker._sanitise_params({"entity_name": "beta"}, level="strict")
+        assert r1["entity_name"] != r2["entity_name"]
+
+    def test_strict_also_redacts_free_text(self):
+        """Strict is additive on top of standard."""
+        result = AnalyticsTracker._sanitise_params({"query": "SELECT *", "entity_name": "acme"}, level="strict")
+        assert result["query"] == "<redacted: text len=8>"
+        assert result["entity_name"].startswith("<h:")
+
+    # ---- Nested structures propagate level --------------------------------
+
+    def test_level_propagates_through_nested_dicts(self):
+        result = AnalyticsTracker._sanitise_params({"filters": {"query": "private text"}}, level="standard")
+        assert result["filters"]["query"] == "<redacted: text len=12>"
+
+    def test_level_propagates_through_nested_lists(self):
+        result = AnalyticsTracker._sanitise_params({"filters": [{"query": "private text"}]}, level="standard")
+        assert result["filters"][0]["query"] == "<redacted: text len=12>"
+
+    # ---- Integration through track_tool_call ------------------------------
+
+    def test_track_tool_call_redacts_at_standard(self, capture, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "standard")
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_gql",
+            session_id="s",
+            viewer_info="alice",
+            params={"query": "{ viewer { id } }", "entity_name": "acme"},
+        )
+        assert capture.event["params"]["query"].startswith("<redacted: text len=")
+        # entity_name is an identifier, not free-text -> plaintext at standard
+        assert capture.event["params"]["entity_name"] == "acme"
+
+    def test_track_tool_call_hashes_identifiers_at_strict(self, capture, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "strict")
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="count_traces",
+            session_id="s",
+            viewer_info=SimpleNamespace(username="alice", email="a@co.com"),
+            params={"entity_name": "acme", "project_name": "eval"},
+        )
+        assert capture.event["params"]["entity_name"].startswith("<h:")
+        assert capture.event["params"]["project_name"].startswith("<h:")
+        # Strict also hashes user_id and email_domain
+        assert capture.event["user_id"].startswith("<h:")
+        assert capture.event["email_domain"].startswith("<h:")
+
+    def test_track_tool_call_off_mode_preserves_identity(self, capture, monkeypatch):
+        """BigQuery contract: off-mode must emit user_id/email_domain plaintext."""
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "off")
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="count_traces",
+            session_id="s",
+            viewer_info=SimpleNamespace(username="alice", email="a@co.com"),
+            params={"entity_name": "acme"},
+        )
+        assert capture.event["user_id"] == "alice"
+        assert capture.event["email_domain"] == "co.com"
+        assert capture.event["params"]["entity_name"] == "acme"
+
+    # ---- is_verbose_log_site_gated ----------------------------------------
+
+    def test_verbose_gated_is_false_at_off(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "off")
+        from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+        assert is_verbose_log_site_gated() is False
+
+    def test_verbose_gated_is_true_at_standard(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "standard")
+        from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+        assert is_verbose_log_site_gated() is True
+
+    def test_verbose_gated_is_true_at_strict(self, monkeypatch):
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "strict")
+        from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+        assert is_verbose_log_site_gated() is True

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -447,6 +447,42 @@ class TestPrivacyLevel:
 
         assert _resolve_privacy_level() == "off"
 
+    def test_invalid_level_warns_once(self, monkeypatch):
+        """Typos must surface as a WARNING, not silently downgrade to off.
+
+        Attaches a dedicated handler to the analytics logger because that logger
+        has propagate=False (BigQuery contract), so pytest's root-attached caplog
+        cannot see it.
+        """
+        import wandb_mcp_server.analytics as a
+
+        monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "stict")
+        a._warned_invalid_privacy_level = False  # reset the latch
+
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        a.logger.addHandler(handler)
+        try:
+            assert a._resolve_privacy_level() == "off"
+            # Second call must not double-log (latch active)
+            assert a._resolve_privacy_level() == "off"
+        finally:
+            a.logger.removeHandler(handler)
+
+        warnings = [r for r in captured if r.levelname == "WARNING" and "MCP_LOG_PRIVACY_LEVEL" in r.getMessage()]
+        assert len(warnings) == 1, f"expected exactly one warning for invalid level, got {len(warnings)}"
+        assert "stict" in warnings[0].getMessage()
+
+    def test_organization_hashed_at_strict(self):
+        """organization is a customer identifier (query_registry tool param); hash at strict."""
+        result = AnalyticsTracker._sanitise_params({"organization": "acme-corp"}, level="strict")
+        assert result["organization"].startswith("<h:")
+
     # ---- _sanitise_params: off mode is byte-identical to pre-amend ---------
 
     def test_off_preserves_free_text_values(self):

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -264,6 +264,34 @@ class TestDatadogForwarder:
         fwd = DatadogForwarder()
         assert not fwd.enabled
 
+    @patch.dict(
+        "os.environ",
+        {"MCP_DATADOG_FORWARD": "true", "DD_API_KEY": "", "DD_AGENT_HOST": ""},
+        clear=False,
+    )
+    def test_forwarder_without_key_warns_on_serverless(self):
+        """Serverless / Cloud Run misconfig: no DD_AGENT_HOST -> WARN (loud, needs action)."""
+        reset_datadog_forwarder()
+        with patch("wandb_mcp_server.analytics_datadog.logger") as mock_logger:
+            fwd = DatadogForwarder()
+            assert not fwd.enabled
+            mock_logger.warning.assert_called_once()
+            mock_logger.debug.assert_not_called()
+
+    @patch.dict(
+        "os.environ",
+        {"MCP_DATADOG_FORWARD": "true", "DD_API_KEY": "", "DD_AGENT_HOST": "10.0.0.1"},
+        clear=False,
+    )
+    def test_forwarder_without_key_debugs_in_agent_mode(self):
+        """K8s agent-mode: DD_AGENT_HOST set -> DEBUG (agent handles it, not a misconfig)."""
+        reset_datadog_forwarder()
+        with patch("wandb_mcp_server.analytics_datadog.logger") as mock_logger:
+            fwd = DatadogForwarder()
+            assert not fwd.enabled
+            mock_logger.debug.assert_called_once()
+            mock_logger.warning.assert_not_called()
+
     @patch.dict("os.environ", {"MCP_DATADOG_FORWARD": "false"}, clear=False)
     def test_forward_returns_none_when_disabled(self):
         reset_datadog_forwarder()

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -223,3 +223,45 @@ def test_configure_process_logging_does_not_touch_analytics_logger(_snapshot_thi
     assert analytics_before == analytics_after, (
         "configure_process_logging must leave wandb_mcp_server.analytics handlers untouched"
     )
+
+
+def test_configure_process_logging_locks_analytics_propagate_false(_snapshot_third_party_handlers):
+    """Defensive: analytics_logger.propagate must be False after configure in json mode.
+
+    analytics.py sets this at import time, but uvicorn's dictConfig (called during
+    server boot) can reset propagation on existing loggers, leading to every analytics
+    event emitting twice (rich payload via the analytics _StructuredJsonFormatter on
+    stdout, plus a minimal duplicate via the root _JsonLogFormatter on stderr).
+    Observed live on staging revision 00084-p8s; this guard prevents it.
+    """
+    from wandb_mcp_server import analytics as _analytics_mod
+
+    # Simulate uvicorn (or any other library) flipping propagation back to True
+    # after analytics.py has been imported but before configure_process_logging runs.
+    _analytics_mod.analytics_logger.propagate = True
+
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        utils.configure_process_logging()
+
+    assert _analytics_mod.analytics_logger.propagate is False, (
+        "configure_process_logging must re-assert propagate=False on analytics_logger "
+        "to prevent duplicate emission via the root JSON handler"
+    )
+
+
+def test_configure_process_logging_leaves_analytics_propagate_alone_in_rich_mode(
+    _snapshot_third_party_handlers,
+):
+    """Rich mode is a strict no-op (Cloud Run today): analytics propagate must not be touched."""
+    from wandb_mcp_server import analytics as _analytics_mod
+
+    # Pre-set to True so we can detect any unwanted reset
+    _analytics_mod.analytics_logger.propagate = True
+
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MCP_LOG_FORMAT", None)
+        utils = _reload_utils()
+        utils.configure_process_logging()
+
+    assert _analytics_mod.analytics_logger.propagate is True, "rich mode (default) must not touch analytics propagation"

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -265,3 +265,30 @@ def test_configure_process_logging_leaves_analytics_propagate_alone_in_rich_mode
         utils.configure_process_logging()
 
     assert _analytics_mod.analytics_logger.propagate is True, "rich mode (default) must not touch analytics propagation"
+
+
+# -- Privacy-level gating of verbose log sites -------------------------------
+
+
+def test_toolcall_log_is_info_at_privacy_off(caplog, monkeypatch):
+    """With MCP_LOG_PRIVACY_LEVEL=off (Cloud Run default), ToolCall log stays INFO."""
+    monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "off")
+    # Use the helper directly so we avoid the context-manager's analytics finaliser
+    from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+    assert is_verbose_log_site_gated() is False
+
+
+def test_toolcall_log_gated_at_privacy_standard(caplog, monkeypatch):
+    """At standard+ privacy, ToolCall log demotes to DEBUG (analytics event still captures it)."""
+    monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "standard")
+    from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+    assert is_verbose_log_site_gated() is True
+
+
+def test_toolcall_log_gated_at_privacy_strict(caplog, monkeypatch):
+    monkeypatch.setenv("MCP_LOG_PRIVACY_LEVEL", "strict")
+    from wandb_mcp_server.analytics import is_verbose_log_site_gated
+
+    assert is_verbose_log_site_gated() is True

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -1,0 +1,153 @@
+"""Tests for MCP_LOG_FORMAT-driven logger configuration.
+
+These cover the opt-in JSON formatter path added alongside the Datadog Agent-mode
+chart work. The default (rich) path must remain unchanged so Cloud Run production
+keeps the log shape the existing dashboards expect.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+from unittest import mock
+
+import pytest
+from rich.logging import RichHandler
+
+
+def _reload_utils():
+    """Reimport wandb_mcp_server.utils to pick up env-var changes at import time.
+
+    get_rich_logger reads MCP_LOG_FORMAT each call, so a fresh import is not strictly
+    required, but we bounce the logger state so handlers don't stack across tests.
+    """
+    import importlib
+
+    import wandb_mcp_server.utils as utils
+
+    importlib.reload(utils)
+    return utils
+
+
+@pytest.fixture(autouse=True)
+def _isolate_logger_between_tests():
+    """Each test gets a fresh logger with no inherited handlers."""
+    name = "wandb_mcp_server.tests.log_format"
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    yield name
+    logger.handlers.clear()
+
+
+def test_default_is_rich_when_env_unset(_isolate_logger_between_tests):
+    """MCP_LOG_FORMAT unset -> RichHandler (preserves today's Cloud Run behavior)."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MCP_LOG_FORMAT", None)
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+    handlers = [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], RichHandler)
+
+
+def test_rich_is_explicit_default(_isolate_logger_between_tests):
+    """MCP_LOG_FORMAT=rich -> RichHandler."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "rich"}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+    handlers = [h for h in logger.handlers if not isinstance(h, logging.NullHandler)]
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], RichHandler)
+
+
+def test_json_format_emits_structured_lines(_isolate_logger_between_tests, capsys):
+    """MCP_LOG_FORMAT=json -> one JSON object per record with the required fields."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+
+        # Swap handler stream for an in-memory buffer so we can read it back.
+        handler = logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        buf = io.StringIO()
+        handler.stream = buf
+
+        logger.info("hello %s", "world")
+        logger.error("boom")
+
+    raw_lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+    assert len(raw_lines) == 2
+
+    first = json.loads(raw_lines[0])
+    assert first["level"] == "info"
+    assert first["logger"] == name
+    assert first["message"] == "hello world"
+    assert first["timestamp"].endswith("Z")
+
+    second = json.loads(raw_lines[1])
+    assert second["level"] == "error"
+    assert second["message"] == "boom"
+
+
+def test_json_format_is_case_insensitive(_isolate_logger_between_tests):
+    """MCP_LOG_FORMAT=JSON (caps) and extraneous whitespace still mean JSON."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "  JSON  "}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+    handler = logger.handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+    assert not isinstance(handler, RichHandler)
+
+
+def test_json_format_includes_exception_info(_isolate_logger_between_tests):
+    """Exceptions serialize into exc_info field so DD captures the stack trace."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+        handler = logger.handlers[0]
+        buf = io.StringIO()
+        handler.stream = buf
+        try:
+            raise ValueError("intentional")
+        except ValueError:
+            logger.exception("it blew up")
+
+    payload = json.loads(buf.getvalue().strip().splitlines()[-1])
+    assert payload["level"] == "error"
+    assert "it blew up" in payload["message"]
+    assert "ValueError" in payload["exc_info"]
+    assert "intentional" in payload["exc_info"]
+
+
+def test_json_format_preserves_session_prefix(_isolate_logger_between_tests):
+    """The session_id_prefix LoggerAdapter contract still works in JSON mode."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+        handler = logger.handlers[0]
+        buf = io.StringIO()
+        handler.stream = buf
+
+        adapter = logging.LoggerAdapter(logger, {"session_id_prefix": "sess_abc "})
+        adapter.info("hello")
+
+    payload = json.loads(buf.getvalue().strip())
+    assert payload["session_id_prefix"] == "sess_abc "
+    assert payload["message"].startswith("sess_abc ")
+
+
+def test_unknown_log_format_falls_back_to_rich(_isolate_logger_between_tests):
+    """Unknown values (typos, etc.) fall back to rich, don't blow up startup."""
+    name = _isolate_logger_between_tests
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "rainbow"}, clear=False):
+        utils = _reload_utils()
+        logger = utils.get_rich_logger(name)
+    assert isinstance(logger.handlers[0], RichHandler)

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -151,3 +151,75 @@ def test_unknown_log_format_falls_back_to_rich(_isolate_logger_between_tests):
         utils = _reload_utils()
         logger = utils.get_rich_logger(name)
     assert isinstance(logger.handlers[0], RichHandler)
+
+
+# ---------------------------------------------------------------------------
+# configure_process_logging: root + uvicorn + mcp coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _snapshot_third_party_handlers():
+    """Capture handlers on third-party loggers so each test can restore them."""
+    names = ("", "uvicorn", "uvicorn.access", "uvicorn.error", "mcp")
+    before: dict = {n: (list(logging.getLogger(n).handlers), logging.getLogger(n).propagate) for n in names}
+    yield before
+    for n, (handlers, propagate) in before.items():
+        lg = logging.getLogger(n)
+        lg.handlers.clear()
+        for h in handlers:
+            lg.addHandler(h)
+        lg.propagate = propagate
+
+
+def test_configure_process_logging_noop_in_rich_mode(_snapshot_third_party_handlers):
+    """MCP_LOG_FORMAT unset -> no third-party loggers are reconfigured (Cloud Run path)."""
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MCP_LOG_FORMAT", None)
+        utils = _reload_utils()
+        utils.configure_process_logging()
+
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "mcp"):
+        handlers = logging.getLogger(name).handlers
+        # Must match the snapshot taken before the call
+        assert handlers == _snapshot_third_party_handlers[name][0]
+
+
+def test_configure_process_logging_installs_json_on_third_party_in_json_mode(
+    _snapshot_third_party_handlers,
+):
+    """MCP_LOG_FORMAT=json -> root + uvicorn.{access,error} + mcp all get a JSON handler."""
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        utils.configure_process_logging()
+
+        for name in ("", "uvicorn", "uvicorn.access", "uvicorn.error", "mcp"):
+            handlers = logging.getLogger(name).handlers
+            assert len(handlers) == 1, f"{name!r} should have exactly one handler after configure"
+            assert isinstance(handlers[0].formatter, utils._JsonLogFormatter), (
+                f"{name!r} handler must use _JsonLogFormatter, got {type(handlers[0].formatter).__name__}"
+            )
+
+        # Third-party loggers don't propagate (prevents duplicate records via root)
+        assert logging.getLogger("uvicorn").propagate is False
+        assert logging.getLogger("uvicorn.access").propagate is False
+        assert logging.getLogger("uvicorn.error").propagate is False
+        assert logging.getLogger("mcp").propagate is False
+        # Root logger keeps its default propagate (True; there's nothing above root)
+        assert logging.getLogger().propagate is True
+
+
+def test_configure_process_logging_does_not_touch_analytics_logger(_snapshot_third_party_handlers):
+    """wandb_mcp_server.analytics owns its own formatter for BigQuery; must not be reconfigured."""
+    from wandb_mcp_server import analytics as _analytics_mod
+
+    analytics_before = list(_analytics_mod.analytics_logger.handlers)
+
+    with mock.patch.dict(os.environ, {"MCP_LOG_FORMAT": "json"}, clear=False):
+        utils = _reload_utils()
+        utils.configure_process_logging()
+
+    analytics_after = list(_analytics_mod.analytics_logger.handlers)
+    assert analytics_before == analytics_after, (
+        "configure_process_logging must leave wandb_mcp_server.analytics handlers untouched"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "wandb-mcp-server"
-version = "0.3.0"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Two small, opt-in observability fixes that make the server play nicely behind a Datadog Agent DaemonSet on Kubernetes, without changing anything about the Cloud Run production deployment.

### 1. `MCP_LOG_FORMAT=json` opt-in

Today the server logs via `RichHandler`, which produces lines like:

```
[04/24/26 15:00:40] INFO     GET / -> 200 (0.001s)
```

Datadog's auto-classifier misreads a lot of these as `status:error` — 219 of 356 normal INFO request logs in the GKE smoke test were flagged. Setting `MCP_LOG_FORMAT=json` now emits:

```json
{"timestamp":"2026-04-24T15:00:40Z","level":"info","logger":"wandb_mcp_server.server","message":"GET / -> 200 (0.001s)"}
```

Datadog extracts `level`, `timestamp`, `logger`, `message` fields automatically; the `status:error` misclassification disappears.

Default stays `rich` — **Cloud Run production and local dev behavior is unchanged**. The companion helm-charts PR (wandb/helm-charts#594) sets `MCP_LOG_FORMAT=json` when `mcp-server.datadog.enabled=true`. Older image tags ignore the env var (no-op), so the chart change is forward-compatible.

### 2. Demote forwarder-without-key warning when `DD_AGENT_HOST` is set

In managed K8s, the DD Agent DaemonSet on the node collects pod stdout + APM already. A pod with `MCP_DATADOG_FORWARD=true` and no `DD_API_KEY` is legitimate during chart transitions or when the forwarder env leaks from a stale chart. Logging `WARNING` spam in every production pod is noise. On serverless (no `DD_AGENT_HOST`) it remains a real misconfig and still logs `WARNING`.

## Cloud Run production safety audit

Pre-merge I verified the live Cloud Run production env (`gcloud run services describe wandb-mcp-server`) sets:
```
MCP_DATADOG_FORWARD=true
DD_SITE=us5.datadoghq.com
DD_SERVICE=wandb-mcp-server
MCP_SERVER_SECRETS_PROVIDER=gcp
MCP_SERVER_SECRETS_PROJECT=wandb-mcp-production
```

| Risk | Mitigation |
|---|---|
| Log format change breaks Cloud Run dashboards | `MCP_LOG_FORMAT` defaults to `rich`. Cloud Run deploy.sh sets nothing. No change. A follow-up PR (not this one) can add `MCP_LOG_FORMAT=json` to the Cloud Run deploy once DD dashboards are validated. |
| Forwarder stops working in Cloud Run | Untouched. Default `MCP_DATADOG_FORWARD=false` preserved; Cloud Run sets `true` explicitly; SecretsResolver / GCP SM path in [`src/wandb_mcp_server/analytics_datadog.py`](src/wandb_mcp_server/analytics_datadog.py) is unchanged. |
| `DD_API_KEY` resolution breaks | `_resolve_dd_api_key()` untouched. |
| Warning demotion hides a real Cloud Run misconfig | DEBUG path fires only when `DD_AGENT_HOST` is set. Cloud Run doesn't set that env; WARN path is preserved. |

## Test plan

- [x] `pytest tests/test_log_format.py tests/test_analytics_datadog.py -v` — 53 pass
  - 7 new tests for `MCP_LOG_FORMAT` covering rich default, json opt-in, case-insensitivity, `exc_info` capture, session prefix preservation, unknown-value fallback
  - 2 new tests asserting WARN on serverless and DEBUG in agent mode
- [x] `ruff check` and `ruff format --check` clean on touched files
- [x] Local smoke: `MCP_LOG_FORMAT=json` emits valid JSON with expected fields; unset reproduces today's rich output
- [x] Confirms compatible with live Cloud Run env via config inspection (no deploy change in this PR)

## Docs

[`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md) (new) covers the two collection modes, full env var matrix, log format guidance, and explicitly documents what Cloud Run production sets today.

## Companion PR

[wandb/helm-charts#594](https://github.com/wandb/helm-charts/pull/594) — agent-first chart defaults + dashboard segmentation labels + chart 0.42.2. The two PRs compose cleanly: chart injects `MCP_LOG_FORMAT=json` and UST tags; server emits JSON that the agent parses and auto-tags.

Made with [Cursor](https://cursor.com)