### PR TITLE
docs: clarify Le Chat MCP connector setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,20 @@ For local installation, see [Option 2](#general-installation-guide) below.
 ### Mistral Chat
 <details>
 <summary>Configuration setup</summary>
-  Mistral is currently the best supported Chat assistant based on API-key based authentication. 
-  Simply navigate to "[Connectors](https://mistral.ai/news/le-chat-mcp-connectors-memories)" and 1) paste in the URL `https://mcp.withwandb.com/mcp` and 2) select API Key Authentication and paste WANDB API key. 
+
+Mistral Le Chat is currently the best supported chat assistant for API-key based MCP authentication.
+
+Use the **Custom MCP Connector** flow:
+
+1. Open Le Chat and go to **Connectors**.
+2. Add a custom MCP connector.
+3. Set the server URL to `https://mcp.withwandb.com/mcp`.
+4. Select HTTP Bearer Token or API Key authentication.
+5. Paste your W&B API key from [wandb.ai/authorize](https://wandb.ai/authorize).
+
+If the UI asks for a token value, paste the raw W&B API key. If it asks for the full `Authorization` header value, use `Bearer <your-wandb-api-key>`.
+
+If adding the W&B connector from the Le Chat connector directory returns an `integrations.addIntegrationFromStore` 500 error, use the Custom MCP Connector flow above. That error happens in Mistral's connector-store add flow before Le Chat reaches the W&B MCP endpoint.
 </details>
 
 ### Claude Desktop

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 # Import the functions we want to expose
 from .server import cli


### PR DESCRIPTION
## Summary
- Documents the Le Chat Custom MCP Connector flow for W&B MCP.
- Calls out the Mistral connector-store 500 workaround and aligns package version metadata to v0.3.3.

## Test plan
- `uv run python -c \"import wandb_mcp_server; assert wandb_mcp_server.__version__ == '0.3.3'; print(wandb_mcp_server.__version__)\"`


Made with [Cursor](https://cursor.com)