### PR TITLE
feat(analytics): add MCP release version to events

### DIFF
--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -14,6 +14,7 @@ datetime handling, cleaner auth integration, and structured event schema.
 """
 
 import hashlib
+import importlib.metadata
 import json
 import logging
 import os
@@ -194,6 +195,19 @@ _REQUIRED_BASE_FIELDS = frozenset({"schema_version", "event_type", "timestamp"})
 logger.info("Analytics ready: MCP_LOG_PRIVACY_LEVEL=%s", _resolve_privacy_level())
 
 
+def _resolve_release_version() -> str:
+    """Return release version for Datadog, Segment, BigQuery, and Hex joins."""
+    explicit = os.environ.get("MCP_RELEASE_VERSION") or os.environ.get("DD_VERSION")
+    if explicit:
+        return explicit.strip()
+    for package_name in ("wandb_mcp_server", "wandb-mcp-server"):
+        try:
+            return importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "0.0.0"
+
+
 def _utcnow_iso() -> str:
     """Return current UTC time in ISO-8601 format."""
     return datetime.now(UTC).isoformat()
@@ -342,6 +356,7 @@ class AnalyticsTracker:
             "schema_version": SCHEMA_VERSION,
             "event_type": event_type,
             "timestamp": _utcnow_iso(),
+            "release_version": _resolve_release_version(),
         }
         deployment_id = os.environ.get("MCP_DEPLOYMENT_ID")
         if deployment_id:

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -98,6 +98,8 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "schema_version": event.get("schema_version", "1.0"),
         "source": "wandb-mcp-server",
     }
+    if event.get("release_version"):
+        properties["release_version"] = event["release_version"]
     for key in property_keys:
         if key in event:
             properties[key] = event[key]

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -75,6 +75,7 @@ class TestSuccessfulToolCall:
         assert len(seg_payloads) == 1
         seg = seg_payloads[0]
         assert seg["event"] == "mcp_server.tool_call"
+        assert seg["properties"]["release_version"] == "0.3.1"
         assert seg["properties"]["tool_name"] == "query_traces"
         assert seg["properties"]["success"] is True
         assert seg["properties"]["error"] is None


### PR DESCRIPTION
## Summary
- Adds `release_version` to MCP analytics events, resolved from `MCP_RELEASE_VERSION` or `DD_VERSION`.
- Forwards `release_version` into Segment properties so Hex/Segment can identify 0.4.4 traffic.
- Keeps Datadog behavior intact; Datadog already tags logs with `DD_VERSION`.

## Test plan
- `uv run ruff check src/wandb_mcp_server/analytics.py src/wandb_mcp_server/analytics_segment.py tests/test_analytics_e2e.py`
- `uv run ruff format --check src/wandb_mcp_server/analytics.py src/wandb_mcp_server/analytics_segment.py tests/test_analytics_e2e.py`
- `uv sync --frozen --extra test`
- `uv run pytest tests/test_analytics_e2e.py -v --tb=short`


Made with [Cursor](https://cursor.com)