### PR TITLE
fix(analytics): populate Segment local_version

### DIFF
--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -100,6 +100,10 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     }
     if event.get("release_version"):
         properties["release_version"] = event["release_version"]
+        # Existing Hex MCP analytics tables expose `local_version`, not
+        # `release_version`. Populate both so 0.4.4 is queryable immediately
+        # without waiting for downstream Segment schema changes.
+        properties["local_version"] = event["release_version"]
     for key in property_keys:
         if key in event:
             properties[key] = event[key]

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -76,6 +76,7 @@ class TestSuccessfulToolCall:
         seg = seg_payloads[0]
         assert seg["event"] == "mcp_server.tool_call"
         assert seg["properties"]["release_version"] == "0.3.1"
+        assert seg["properties"]["local_version"] == "0.3.1"
         assert seg["properties"]["tool_name"] == "query_traces"
         assert seg["properties"]["success"] is True
         assert seg["properties"]["error"] is None


### PR DESCRIPTION
## Summary
- Mirrors MCP `release_version` into Segment `local_version`.
- Keeps `release_version` for future schemas while making 0.4.4 visible in the existing Hex MCP analytics table today.

## Test plan
- `uv run ruff check src/wandb_mcp_server/analytics_segment.py tests/test_analytics_e2e.py`
- `uv run ruff format --check src/wandb_mcp_server/analytics_segment.py tests/test_analytics_e2e.py`
- `uv sync --frozen --extra test`
- `uv run pytest tests/test_analytics_e2e.py -v --tb=short`


Made with [Cursor](https://cursor.com)