### PR TITLE
fix(release): set MCP package version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.3"
+version = "0.3.4"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 # Import the functions we want to expose
 from .server import cli


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` package version to `0.3.4`.
- Bumps `wandb_mcp_server.__version__` to `0.3.4`.

## Test plan
- Verified `pyproject.toml` and `__version__` both equal `0.3.4`.


Made with [Cursor](https://cursor.com)