### PR TITLE
fix(hosted): bound trace runtime guardrails

### DIFF
--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -51,6 +51,16 @@ MCP_MAX_FULL_TRACE_LIMIT: int = _env_int("MCP_MAX_FULL_TRACE_LIMIT", 25 if MCP_H
 MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HOSTED_MODE else 2000)
 MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
+COST_SORT_FIELDS: frozenset[str] = frozenset({"total_cost", "completion_cost", "prompt_cost"})
+
+
+class HostedLimitExceeded(ValueError):
+    """Raised when a hosted-mode request exceeds configured safety limits."""
+
+    def __init__(self, message: str, *, error: str = "quota_exceeded", **details: object) -> None:
+        super().__init__(message)
+        self.error = error
+        self.details = details
 
 
 def structured_error(error: str, message: str, **extra: object) -> dict[str, object]:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -12,6 +12,8 @@ This server provides tools for:
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 import json
 import logging
 import os
@@ -92,6 +94,83 @@ from wandb_mcp_server.weave_api.models import QueryResult
 # Configure logging (no side effects beyond logger setup)
 logging.basicConfig(level=logging.INFO)
 logger = get_rich_logger("weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL")
+
+_COUNT_EXECUTOR = ThreadPoolExecutor(
+    max_workers=int(os.environ.get("MCP_COUNT_TOOL_WORKERS", "8")),
+    thread_name_prefix="mcp-count",
+)
+
+
+def _count_traces_with_context(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    request_timeout: int,
+) -> int:
+    """Run count_traces inside a worker while preserving the request API key."""
+    from wandb_mcp_server.api_client import WandBApiManager
+
+    token = WandBApiManager.set_context_api_key(api_key) if api_key else None
+    try:
+        return count_traces(
+            entity_name=entity_name,
+            project_name=project_name,
+            filters=filters,
+            request_timeout=request_timeout,
+        )
+    finally:
+        if token is not None:
+            WandBApiManager.reset_context_api_key(token)
+
+
+async def _count_traces_with_deadline(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    deadline_seconds: int,
+) -> int:
+    """Run count_traces without letting executor shutdown extend wall time."""
+    request_timeout = max(1, deadline_seconds - 2)
+    loop = asyncio.get_running_loop()
+    future = loop.run_in_executor(
+        _COUNT_EXECUTOR,
+        partial(
+            _count_traces_with_context,
+            api_key,
+            entity_name,
+            project_name,
+            filters,
+            request_timeout,
+        ),
+    )
+    try:
+        return await asyncio.wait_for(future, timeout=deadline_seconds)
+    except asyncio.TimeoutError:
+        future.cancel()
+        raise
+
+
+async def _count_traces_or_none(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    deadline_seconds: int,
+) -> int | None:
+    """Best-effort count for preflight/enrichment paths."""
+    try:
+        return await _count_traces_with_deadline(
+            api_key,
+            entity_name,
+            project_name,
+            filters,
+            deadline_seconds,
+        )
+    except Exception:
+        logger.info("count_traces skipped after timeout or error", exc_info=True)
+        return None
 
 
 # ===============================================================================
@@ -298,7 +377,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         filters: Optional[Dict[str, Any]] = None,
         sort_by: str = "started_at",
         sort_direction: str = "desc",
-        limit: int = 1000,
+        limit: Optional[int] = None,
         include_costs: bool = True,
         include_feedback: bool = True,
         columns: Optional[List[str]] = None,
@@ -324,22 +403,38 @@ def register_tools(mcp_instance: FastMCP) -> None:
             MCP_HOSTED_MODE,
             MCP_MAX_FULL_TRACE_LIMIT,
             MCP_MAX_QUERY_LIMIT,
+            COST_SORT_FIELDS,
             structured_error,
         )
+        from wandb_mcp_server.api_client import WandBApiManager
 
         hosted_limit = MCP_MAX_FULL_TRACE_LIMIT if return_full_data else MCP_MAX_QUERY_LIMIT
-        if MCP_HOSTED_MODE and limit > hosted_limit and not metadata_only:
+        effective_limit = hosted_limit if MCP_HOSTED_MODE and limit is None else (1000 if limit is None else limit)
+        if MCP_HOSTED_MODE and effective_limit > hosted_limit:
             return json.dumps(
                 structured_error(
                     "quota_exceeded",
                     f"Hosted MCP trace queries are limited to {hosted_limit} traces for detail_level='{detail_level}'.",
-                    limit=limit,
+                    limit=effective_limit,
                     max_limit=hosted_limit,
                     suggestions=[
                         "Use detail_level='schema' for broad discovery.",
                         f"Set limit={hosted_limit} or lower.",
-                        "Use metadata_only=True for counts and stats without trace payloads.",
+                        "Use count_weave_traces_tool for aggregate counts without trace payloads.",
                         "Add filters to narrow the result set.",
+                    ],
+                )
+            )
+        if MCP_HOSTED_MODE and sort_by in COST_SORT_FIELDS:
+            return json.dumps(
+                structured_error(
+                    "quota_exceeded",
+                    f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                    sort_by=sort_by,
+                    suggestions=[
+                        "Add time_range or op_name_contains filters.",
+                        "Sort by started_at, then inspect costs in the bounded result set.",
+                        "Use count_weave_traces_tool to size the query first.",
                     ],
                 )
             )
@@ -359,26 +454,33 @@ def register_tools(mcp_instance: FastMCP) -> None:
             effective_columns = _SCHEMA_COLUMNS
 
         try:
-            if detail_level != "schema" and limit > 100 and not metadata_only:
-                try:
-                    pre_count = count_traces(entity_name, project_name, filters or {})
-                    if pre_count > 500:
-                        return json.dumps(
-                            {
-                                "error": "query_too_large",
-                                "message": f"Found {pre_count} matching traces. Queries over 500 traces "
-                                f"risk server memory limits. Narrow your query.",
-                                "trace_count": pre_count,
-                                "suggestions": [
-                                    "detail_level='schema' (structural fields only, fast)",
-                                    f"limit={min(100, pre_count)} (reduce result count)",
-                                    "metadata_only=True (counts and stats without trace data)",
-                                    "Add filters to narrow results",
-                                ],
-                            }
-                        )
-                except Exception:
-                    pass
+            api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS
+
+            count_deadline = min(10, MCP_TOOL_TIMEOUT_SECONDS)
+            if detail_level != "schema" and effective_limit > 100 and not metadata_only:
+                pre_count = await _count_traces_or_none(
+                    api_key,
+                    entity_name,
+                    project_name,
+                    filters or {},
+                    count_deadline,
+                )
+                if pre_count and pre_count > 500:
+                    return json.dumps(
+                        {
+                            "error": "query_too_large",
+                            "message": f"Found {pre_count} matching traces. Queries over 500 traces "
+                            f"risk server memory limits. Narrow your query.",
+                            "trace_count": pre_count,
+                            "suggestions": [
+                                "detail_level='schema' (structural fields only, fast)",
+                                f"limit={min(100, pre_count)} (reduce result count)",
+                                "count_weave_traces_tool (counts and stats without trace data)",
+                                "Add filters to narrow results",
+                            ],
+                        }
+                    )
 
             result_model: QueryResult = await query_paginated_weave_traces(
                 entity_name=entity_name,
@@ -387,7 +489,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 filters=filters or {},
                 sort_by=sort_by,
                 sort_direction=sort_direction,
-                target_limit=limit,
+                target_limit=effective_limit,
                 include_costs=include_costs if detail_level != "schema" else False,
                 include_feedback=include_feedback if detail_level != "schema" else False,
                 columns=effective_columns,
@@ -398,12 +500,15 @@ def register_tools(mcp_instance: FastMCP) -> None:
             )
 
             try:
-                matching_count = count_traces(
+                matching_count = await _count_traces_or_none(
+                    api_key,
                     entity_name=entity_name,
                     project_name=project_name,
                     filters=filters or {},
+                    deadline_seconds=count_deadline,
                 )
-                result_model.metadata.total_matching_count = matching_count
+                if matching_count is not None:
+                    result_model.metadata.total_matching_count = matching_count
             except Exception:
                 logger.debug("count_traces for total_matching_count failed", exc_info=True)
 
@@ -459,6 +564,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 }
             )
         except Exception as e:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            if isinstance(e, HostedLimitExceeded):
+                return json.dumps(structured_error(e.error, str(e), **e.details))
             logger.error(f"Error in query_weave_traces_tool: {e}", exc_info=True)
             return json.dumps(
                 {
@@ -471,7 +580,6 @@ def register_tools(mcp_instance: FastMCP) -> None:
     async def count_weave_traces_tool(
         entity_name: str, project_name: str, filters: Optional[Dict[str, Any]] = None
     ) -> str:
-        from concurrent.futures import ThreadPoolExecutor, TimeoutError
         from wandb_mcp_server.api_client import WandBApiManager
         from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS, structured_error
 
@@ -480,23 +588,28 @@ def register_tools(mcp_instance: FastMCP) -> None:
             root_filters["trace_roots_only"] = True
 
             api_key = WandBApiManager.get_api_key()
-
-            def _count_with_context(**kwargs):
-                WandBApiManager.set_context_api_key(api_key)
-                return count_traces(**kwargs)
-
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                total_future = executor.submit(
-                    _count_with_context, entity_name=entity_name, project_name=project_name, filters=filters or {}
-                )
-                root_future = executor.submit(
-                    _count_with_context, entity_name=entity_name, project_name=project_name, filters=root_filters
-                )
-                total_count = total_future.result(timeout=MCP_TOOL_TIMEOUT_SECONDS)
-                root_traces_count = root_future.result(timeout=MCP_TOOL_TIMEOUT_SECONDS)
+            total_count, root_traces_count = await asyncio.wait_for(
+                asyncio.gather(
+                    _count_traces_with_deadline(
+                        api_key,
+                        entity_name,
+                        project_name,
+                        filters or {},
+                        MCP_TOOL_TIMEOUT_SECONDS,
+                    ),
+                    _count_traces_with_deadline(
+                        api_key,
+                        entity_name,
+                        project_name,
+                        root_filters,
+                        MCP_TOOL_TIMEOUT_SECONDS,
+                    ),
+                ),
+                timeout=MCP_TOOL_TIMEOUT_SECONDS,
+            )
 
             return json.dumps({"total_count": total_count, "root_traces_count": root_traces_count})
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.error("Timed out in count_weave_traces_tool")
             return json.dumps(
                 structured_error(

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -11,7 +11,7 @@ import sys
 from typing import Any, Dict, List, Optional, Set
 
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.config import WF_TRACE_SERVER_URL, MAX_ACCUMULATED_BYTES
+from wandb_mcp_server.config import WF_TRACE_SERVER_URL, MAX_ACCUMULATED_BYTES, COST_SORT_FIELDS
 from wandb_mcp_server.weave_api.client import WeaveApiClient
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.weave_api.models import QueryResult
@@ -55,7 +55,7 @@ class TraceService:
     """Service for querying and processing Weave traces."""
 
     # Define cost fields once as a class constant
-    COST_FIELDS = {"total_cost", "completion_cost", "prompt_cost"}
+    COST_FIELDS = set(COST_SORT_FIELDS)
 
     COST_SORT_MAX_FIRST_PASS = 10_000
 
@@ -64,6 +64,37 @@ class TraceService:
 
     # Define latency field mapping
     LATENCY_FIELD_MAPPING = {"latency_ms": "summary.weave.latency_ms"}
+
+    @staticmethod
+    def _hosted_trace_limit(return_full_data: bool) -> int | None:
+        """Return the hosted trace cap, or None when hosted mode is disabled."""
+        from wandb_mcp_server.config import (
+            MCP_HOSTED_MODE,
+            MCP_MAX_FULL_TRACE_LIMIT,
+            MCP_MAX_QUERY_LIMIT,
+        )
+
+        if not MCP_HOSTED_MODE:
+            return None
+        return MCP_MAX_FULL_TRACE_LIMIT if return_full_data else MCP_MAX_QUERY_LIMIT
+
+    @staticmethod
+    def _enforce_hosted_trace_limit(limit: Optional[int], cap: int | None, *, detail: str) -> int | None:
+        """Apply hosted trace limits before any upstream Weave query is issued."""
+        if cap is None:
+            return limit
+        if limit is None:
+            return cap
+        if limit > cap:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP trace queries are limited to {cap} traces for {detail}.",
+                limit=limit,
+                max_limit=cap,
+                detail=detail,
+            )
+        return limit
 
     def __init__(
         self,
@@ -354,6 +385,16 @@ class TraceService:
 
         # Special handling for cost-based sorting
         client_side_cost_sort = sort_by in self.COST_FIELDS
+        hosted_cap = self._hosted_trace_limit(return_full_data)
+        limit = self._enforce_hosted_trace_limit(limit, hosted_cap, detail="trace query")
+        if client_side_cost_sort and hosted_cap is not None:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
 
         # Handle latency field mapping
         if sort_by in self.LATENCY_FIELD_MAPPING:
@@ -562,6 +603,22 @@ class TraceService:
 
         # Special handling for cost-based sorting
         client_side_cost_sort = sort_by in self.COST_FIELDS
+        hosted_cap = self._hosted_trace_limit(return_full_data)
+        target_limit = self._enforce_hosted_trace_limit(
+            target_limit,
+            hosted_cap,
+            detail="paginated trace query",
+        )
+        if chunk_size and hosted_cap is not None:
+            chunk_size = min(chunk_size, hosted_cap)
+        if client_side_cost_sort and hosted_cap is not None:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
 
         # Determine effective_sort_by for the server
         effective_sort_by = "started_at"  # Default
@@ -708,6 +765,17 @@ class TraceService:
         Returns:
             List of trace dictionaries sorted by the specified cost field.
         """
+        from wandb_mcp_server.config import MCP_HOSTED_MODE
+
+        if MCP_HOSTED_MODE:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
+
         if invalid_columns is None:
             invalid_columns = set()
 

--- a/tests/test_hosted_runtime_guardrails.py
+++ b/tests/test_hosted_runtime_guardrails.py
@@ -1,0 +1,223 @@
+import json
+import time
+
+import pytest
+
+import wandb_mcp_server.config as cfg
+import wandb_mcp_server.server as server
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.weave_api.models import QueryResult, TraceMetadata
+from wandb_mcp_server.weave_api.service import TraceService
+
+
+class FakeMCP:
+    """Capture FastMCP-decorated tool functions."""
+
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, description=None):
+        def decorator(func):
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+def _registered_tools(monkeypatch):
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    fake = FakeMCP()
+    server.register_tools(fake)
+    return fake.tools
+
+
+def _empty_query_result():
+    return QueryResult(metadata=TraceMetadata(total_traces=0), traces=[])
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_over_hosted_limit_is_rejected(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    called = False
+
+    async def fake_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", limit=101, metadata_only=True))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["max_limit"] == 100
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_hosted_omitted_limit_defaults_to_query_cap(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    seen_kwargs = {}
+
+    async def fake_query(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    async def no_count(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(server, "_count_traces_or_none", no_count)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", metadata_only=True))
+
+    assert "error" not in result
+    assert seen_kwargs["target_limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_full_trace_hosted_limit_uses_full_cap(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_FULL_TRACE_LIMIT", 25)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", detail_level="full", limit=26))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["max_limit"] == 25
+
+
+@pytest.mark.parametrize("sort_by", ["total_cost", "completion_cost", "prompt_cost"])
+@pytest.mark.asyncio
+async def test_cost_sort_rejected_in_hosted_mode(monkeypatch, sort_by):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    called = False
+
+    async def fake_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", sort_by=sort_by, limit=10))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["sort_by"] == sort_by
+    assert called is False
+
+
+def test_service_rejects_direct_hosted_over_limit(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+
+    service = TraceService(api_key="test-key")
+
+    with pytest.raises(cfg.HostedLimitExceeded):
+        service.query_paginated_traces("entity", "project", target_limit=101)
+
+
+def test_service_defaults_direct_hosted_limit(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 3)
+
+    service = TraceService(api_key="test-key")
+    calls = []
+
+    def fake_query(request_body):
+        calls.append(request_body)
+        for i in range(5):
+            yield {
+                "id": f"call-{i}",
+                "project_id": "entity/project",
+                "op_name": "op",
+                "trace_id": f"trace-{i}",
+                "started_at": "2026-01-01T00:00:00Z",
+            }
+
+    monkeypatch.setattr(service.client, "query_traces", fake_query)
+
+    result = service.query_paginated_traces("entity", "project", target_limit=None, chunk_size=10)
+
+    assert len(result.traces) == 3
+    assert calls[0]["limit"] == 3
+
+
+def test_service_rejects_direct_hosted_cost_sort(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+
+    service = TraceService(api_key="test-key")
+
+    with pytest.raises(cfg.HostedLimitExceeded):
+        service._query_for_cost_sorting("entity", "project", sort_by="total_cost")
+
+
+@pytest.mark.asyncio
+async def test_count_tool_timeout_returns_within_deadline(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+
+    def slow_count(*args, **kwargs):
+        time.sleep(3)
+        return 1
+
+    monkeypatch.setattr(server, "count_traces", slow_count)
+
+    tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+    start = time.monotonic()
+    result = json.loads(await tool("entity", "project"))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.5
+    assert result["error"] == "timeout"
+    assert result["timeout_seconds"] == 1
+
+
+@pytest.mark.asyncio
+async def test_count_tool_passes_bounded_request_timeout(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 3)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    request_timeouts = []
+
+    def capture_count(*args, **kwargs):
+        request_timeouts.append(kwargs["request_timeout"])
+        return 2
+
+    monkeypatch.setattr(server, "count_traces", capture_count)
+
+    tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project"))
+
+    assert result == {"total_count": 2, "root_traces_count": 2}
+    assert request_timeouts == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_trace_query_preflight_timeout_does_not_block_main_query(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 1)
+
+    def slow_count(*args, **kwargs):
+        time.sleep(3)
+        return 10
+
+    async def fake_query(*args, **kwargs):
+        return QueryResult(metadata=TraceMetadata(total_traces=1), traces=[])
+
+    monkeypatch.setattr(server, "count_traces", slow_count)
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    start = time.monotonic()
+    result = json.loads(await tool("entity", "project", limit=100))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 3
+    assert "error" not in result


### PR DESCRIPTION
## Summary
- Enforces hosted trace caps even for `metadata_only` and direct service calls.
- Rejects hosted cost-field sorting before the 10k first-pass scan can run.
- Moves trace count work onto a bounded executor so count calls and preflight checks respect wall-clock deadlines.

## Test plan
- `uv run --extra test pytest tests/test_hosted_runtime_guardrails.py -v --tb=short`
- `uv run ruff check src/wandb_mcp_server/config.py src/wandb_mcp_server/server.py src/wandb_mcp_server/weave_api/service.py tests/test_hosted_runtime_guardrails.py`
- `uv run ruff format --check src/wandb_mcp_server/config.py src/wandb_mcp_server/server.py src/wandb_mcp_server/weave_api/service.py tests/test_hosted_runtime_guardrails.py`

Made with [Cursor](https://cursor.com)