### PR TITLE
fix(hosted): preflight GraphQL pagination shape

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+import re
 import traceback
 from typing import Any, Dict, List, Optional
 
@@ -526,6 +527,113 @@ def get_nested_value(obj: Dict, path: list[str]) -> Optional[Any]:
     return current
 
 
+_HOSTED_LIMIT_VARIABLE_RE = re.compile(r"^(first|limit|count|max_?items|page_?size|items_per_page)$", re.I)
+
+
+def _field_name(node: gql_ast.FieldNode) -> str:
+    """Return the response field name for a GraphQL field."""
+    return node.alias.value if node.alias else node.name.value
+
+
+def _is_connection_field(node: gql_ast.FieldNode) -> bool:
+    """Return True if a field selection looks like a W&B connection."""
+    if not node.selection_set:
+        return False
+    child_names = {
+        selection.name.value for selection in node.selection_set.selections if isinstance(selection, gql_ast.FieldNode)
+    }
+    return {"edges", "pageInfo"}.issubset(child_names)
+
+
+class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
+    """Clamp hosted GraphQL page sizes and reject unsafe fanout shapes."""
+
+    def __init__(self, max_first: int) -> None:
+        super().__init__()
+        self.max_first = max_first
+        self.path: list[str] = []
+        self.connection_depth = 0
+        self.connection_paths: list[tuple[str, ...]] = []
+        self.rewrites: list[str] = []
+        self.rejections: list[str] = []
+
+    def enter_field(self, node, key, parent, path, ancestors):
+        if not isinstance(node, gql_ast.FieldNode):
+            return
+
+        self.path.append(_field_name(node))
+        if not _is_connection_field(node):
+            return
+
+        current_path = tuple(self.path)
+        self.connection_paths.append(current_path)
+        if self.connection_depth > 0:
+            self.rejections.append(
+                f"Nested paginated collection is not allowed in hosted mode: {'/'.join(current_path)}"
+            )
+        if len(self.connection_paths) > 1:
+            self.rejections.append(
+                f"Hosted GraphQL queries may include only one paginated collection; found {len(self.connection_paths)}."
+            )
+
+        existing_args = list(node.arguments or [])
+        has_first = False
+        for idx, arg in enumerate(existing_args):
+            arg_name = arg.name.value
+            if arg_name == "last":
+                self.rejections.append(
+                    f"Hosted GraphQL does not support reverse pagination with last: {'/'.join(current_path)}"
+                )
+            if arg_name != "first":
+                continue
+            has_first = True
+            if isinstance(arg.value, gql_ast.IntValueNode):
+                requested = int(arg.value.value)
+                if requested > self.max_first:
+                    existing_args[idx] = gql_ast.ArgumentNode(
+                        name=arg.name,
+                        value=gql_ast.IntValueNode(value=str(self.max_first)),
+                    )
+                    self.rewrites.append(f"Clamped {'/'.join(current_path)} first from {requested} to {self.max_first}")
+
+        if not has_first:
+            existing_args.append(
+                gql_ast.ArgumentNode(
+                    name=gql_ast.NameNode(value="first"),
+                    value=gql_ast.IntValueNode(value=str(self.max_first)),
+                )
+            )
+            self.rewrites.append(f"Added first={self.max_first} to {'/'.join(current_path)}")
+
+        node.arguments = tuple(existing_args)
+        self.connection_depth += 1
+
+    def leave_field(self, node, key, parent, path, ancestors):
+        if isinstance(node, gql_ast.FieldNode) and _is_connection_field(node):
+            self.connection_depth = max(0, self.connection_depth - 1)
+        if self.path:
+            self.path.pop()
+
+
+def _hosted_preprocess_graphql_query(query: str, max_first: int) -> tuple[str, list[str], list[str]]:
+    """Rewrite hosted GraphQL pagination limits before the first execution."""
+    document = parse(query.strip())
+    visitor = HostedGraphQLPreflightVisitor(max_first=max_first)
+    rewritten = gql_visitor.visit(document, visitor)
+    return gql_printer.print_ast(rewritten), visitor.rewrites, visitor.rejections
+
+
+def _hosted_clamp_variables(variables: Dict[str, Any], max_first: int) -> Dict[str, Any]:
+    """Clamp common page-size variable names before the initial GraphQL execute."""
+    clamped = dict(variables)
+    for key, value in list(clamped.items()):
+        if not _HOSTED_LIMIT_VARIABLE_RE.match(key):
+            continue
+        if isinstance(value, int) and value > max_first:
+            clamped[key] = max_first
+    return clamped
+
+
 def query_paginated_wandb_gql(
     query: str,
     variables: Optional[Dict[str, Any]] = None,
@@ -595,6 +703,34 @@ def query_paginated_wandb_gql(
                 limit_key = "limit"
                 page1_vars_func[limit_key] = items_per_page
                 logger.debug(f"No limit variable found in input, adding '{limit_key}={items_per_page}'")
+
+            if MCP_HOSTED_MODE:
+                try:
+                    query, rewrites, rejections = _hosted_preprocess_graphql_query(
+                        query,
+                        MCP_MAX_GQL_ITEMS_PER_PAGE,
+                    )
+                    page1_vars_func = _hosted_clamp_variables(
+                        page1_vars_func,
+                        MCP_MAX_GQL_ITEMS_PER_PAGE,
+                    )
+                    if rejections:
+                        ctx.mark_error(f"query_too_complex: {rejections[0]}")
+                        return {
+                            "errors": [
+                                {
+                                    "message": rejections[0],
+                                    "details": rejections,
+                                    "error": "query_too_complex",
+                                }
+                            ]
+                        }
+                    if rewrites:
+                        logger.warning("Hosted GraphQL preflight rewrote query: %s", rewrites)
+                except Exception as e:
+                    logger.error("Hosted GraphQL preflight failed: %s", e, exc_info=True)
+                    ctx.mark_error(f"invalid_input: {e}")
+                    return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
 
             try:
                 parsed_initial_query = gql(query.strip())

--- a/tests/test_hosted_gql_guardrails.py
+++ b/tests/test_hosted_gql_guardrails.py
@@ -1,0 +1,212 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from graphql import parse
+from graphql.language.printer import print_ast
+
+import wandb_mcp_server.api_client as api_client
+import wandb_mcp_server.config as cfg
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+
+
+class DummyToolContext:
+    def __init__(self):
+        self.errors = []
+
+    def mark_error(self, error):
+        self.errors.append(error)
+
+
+class FakeClient:
+    def __init__(self, response=None):
+        self.response = response or {
+            "project": {
+                "runs": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        self.executions = []
+
+    def execute(self, document, variable_values=None):
+        self.executions.append((print_ast(document), dict(variable_values or {})))
+        return self.response
+
+
+class FakeApi:
+    def __init__(self, client):
+        self.client = client
+        self.viewer = SimpleNamespace(username="tester")
+
+
+def _install_fake_api(monkeypatch, client):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
+    monkeypatch.setattr(gql_tool, "gql", parse)
+
+    @contextmanager
+    def fake_track_tool_execution(*args, **kwargs):
+        yield DummyToolContext()
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_track_tool_execution)
+
+
+def _run_query():
+    return """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 100000) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+
+def test_hosted_literal_first_is_rewritten_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        _run_query(),
+        variables={"entity": "e", "project": "p"},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "first: 50" in executed_query
+    assert "100000" not in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result
+
+
+def test_hosted_limit_variable_is_clamped_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!, $first: Int) {
+      project(name: $project, entityName: $entity) {
+        runs(first: $first) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p", "first": 100000},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    assert client.executions[0][1]["first"] == 50
+
+
+def test_hosted_multi_connection_query_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Multi($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+        sweeps(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert client.executions == []
+
+
+def test_hosted_nested_connection_query_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Nested($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              loggedArtifacts(first: 10) {
+                edges { node { id } }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert "Nested paginated collection" in result["errors"][0]["details"][0]
+    assert client.executions == []
+
+
+def test_hosted_last_pagination_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(last: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert client.executions == []
+
+
+def test_non_hosted_query_passes_literal_first_unchanged(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", False)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    gql_tool.query_paginated_wandb_gql(
+        _run_query(),
+        variables={"entity": "e", "project": "p"},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "first: 100000" in executed_query
+    assert variables["limit"] == 100


### PR DESCRIPTION
## Summary
- Rewrites hosted GraphQL `first:` literals to the configured page cap before the first upstream execution.
- Clamps common page-size variables before execution.
- Rejects multi-connection, nested-connection, and reverse-pagination shapes that the hosted pagination loop cannot safely bound.

## Test plan
- `uv run --extra test pytest tests/test_hosted_gql_guardrails.py -v --tb=short`
- `uv run ruff check src/wandb_mcp_server/mcp_tools/query_wandb_gql.py tests/test_hosted_gql_guardrails.py`
- `uv run ruff format --check src/wandb_mcp_server/mcp_tools/query_wandb_gql.py tests/test_hosted_gql_guardrails.py`

Made with [Cursor](https://cursor.com)