### PR TITLE
fix(mcp): allow disabling Weave trace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ When running the server locally, you can customize its behavior with command lin
 | `WANDB_DEBUG` | Set to `"true"` to enable detailed W&B logging | No |
 | `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
+| `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 
 #### Usage Examples

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -51,6 +51,7 @@ MCP_MAX_FULL_TRACE_LIMIT: int = _env_int("MCP_MAX_FULL_TRACE_LIMIT", 25 if MCP_H
 MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HOSTED_MODE else 2000)
 MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
+WANDB_MCP_ENABLE_WEAVE_TOOLS: bool = _env_bool("WANDB_MCP_ENABLE_WEAVE_TOOLS", True)
 
 
 def structured_error(error: str, message: str, **extra: object) -> dict[str, object]:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -93,6 +93,25 @@ from wandb_mcp_server.weave_api.models import QueryResult
 logging.basicConfig(level=logging.INFO)
 logger = get_rich_logger("weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL")
 
+_WEAVE_TOOL_NAMES = {
+    "query_weave_traces_tool",
+    "count_weave_traces_tool",
+    "resolve_trace_roots_tool",
+    "infer_trace_schema_tool",
+    "summarize_evaluation_tool",
+}
+
+
+def _remove_registered_tools(mcp_instance: FastMCP, tool_names: set[str]) -> None:
+    """Remove tools from FastMCP's registry after decorator registration."""
+    tool_manager = getattr(mcp_instance, "_tool_manager", None)
+    tools = getattr(tool_manager, "_tools", None)
+    if not isinstance(tools, dict):
+        logger.warning("Could not remove disabled MCP tools; FastMCP internals changed")
+        return
+    for tool_name in tool_names:
+        tools.pop(tool_name, None)
+
 
 # ===============================================================================
 # SECTION 1: W&B AUTHENTICATION & API KEY SETUP
@@ -849,6 +868,12 @@ def register_tools(mcp_instance: FastMCP) -> None:
             project_name=project_name,
             sample_runs=sample_runs,
         )
+
+    from wandb_mcp_server.config import WANDB_MCP_ENABLE_WEAVE_TOOLS
+
+    if not WANDB_MCP_ENABLE_WEAVE_TOOLS:
+        logger.info("Weave MCP tools disabled by WANDB_MCP_ENABLE_WEAVE_TOOLS=false")
+        _remove_registered_tools(mcp_instance, _WEAVE_TOOL_NAMES)
 
 
 # ===============================================================================

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,56 @@
+import importlib
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from wandb_mcp_server.server import register_tools
+
+
+WEAVE_TOOLS = {
+    "query_weave_traces_tool",
+    "count_weave_traces_tool",
+    "resolve_trace_roots_tool",
+    "infer_trace_schema_tool",
+    "summarize_evaluation_tool",
+}
+
+NON_WEAVE_TOOLS = {
+    "query_wandb_tool",
+    "create_wandb_report_tool",
+    "get_run_history_tool",
+    "list_artifact_versions_tool",
+    "compare_runs_tool",
+    "probe_project_tool",
+}
+
+
+def _registered_tool_names() -> set[str]:
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    return set(mcp._tool_manager._tools)
+
+
+def test_weave_tools_registered_by_default():
+    os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+    import wandb_mcp_server.config as cfg
+
+    importlib.reload(cfg)
+    names = _registered_tool_names()
+
+    assert WEAVE_TOOLS.issubset(names)
+    assert NON_WEAVE_TOOLS.issubset(names)
+
+
+def test_weave_tools_can_be_disabled():
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = "false"
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+        importlib.reload(cfg)
+
+    assert WEAVE_TOOLS.isdisjoint(names)
+    assert NON_WEAVE_TOOLS.issubset(names)


### PR DESCRIPTION
## Summary
- Adds `WANDB_MCP_ENABLE_WEAVE_TOOLS` with a default of `true`.
- Removes Weave-only tools from FastMCP registration when the flag is false.
- Documents the flag for dedicated/on-prem installs without a trace backend.

## Test plan
- `uv run --extra test pytest tests/test_tool_registration.py tests/test_docs_search.py -v --tb=short`
- `uv run ruff check src/wandb_mcp_server/config.py src/wandb_mcp_server/server.py tests/test_tool_registration.py`
- `uv run ruff format --check src/wandb_mcp_server/config.py src/wandb_mcp_server/server.py tests/test_tool_registration.py`

Made with [Cursor](https://cursor.com)