### PR TITLE
fix(release): set package version to 0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.3"
+version = "0.3.5"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.5"
 
 # Import the functions we want to expose
 from .server import cli

--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "wandb-mcp-server"
-version = "0.3.3"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bumps the MCP package metadata to `0.3.5` for the current staging release train.
- Updates the editable package entry in `uv.lock` so local/test installs report the same version.
- Keeps runtime release telemetry aligned with the deployment repo's `release_version=0.3.5` wiring.

## Test plan
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run --extra test pytest tests/test_create_report_panels.py tests/test_analytics_e2e.py tests/test_log_format.py -v --tb=short`

## Notes
- This PR is intentionally limited to release metadata; unrelated local report-panel edits are not included.

Made with [Cursor](https://cursor.com)