### PR TITLE
release MCP server 0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ When running the server locally, you can customize its behavior with command lin
 | `WANDB_DEBUG` | Set to `"true"` to enable detailed W&B logging | No |
 | `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
+| `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 
 #### Usage Examples

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ When running the server locally, you can customize its behavior with command lin
 | `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
+| `MCP_ANALYTICS_DISABLED` | Disable structured MCP analytics events. Useful as a workaround for older stdio builds that wrote analytics to stdout. | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 
 #### Usage Examples
@@ -521,6 +522,13 @@ uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 # Or with API key as argument
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server --wandb_api_key your-api-key
 ```
+
+For stdio clients such as Claude Desktop, stdout is reserved for MCP JSON-RPC
+messages. The server routes logs and analytics to stderr in stdio mode so
+desktop clients do not parse diagnostics as protocol messages. If you are using
+an older version and see JSON-RPC parse warnings containing analytics fields
+such as `schema_version` or `event_type`, set `MCP_ANALYTICS_DISABLED=true` as
+a workaround.
 
 **HTTP Transport (for testing and development):**
 ```bash

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -188,6 +188,23 @@ params there, and redaction reduces legal exposure if customer logs are
 subpoenaed, exported, or retained longer than needed. `standard` is the safe
 default. `strict` goes one step further for regulated customers.
 
+### Datadog params privacy
+
+Cloud Run uses `MCP_LOG_PRIVACY_LEVEL=off` so the W&B-managed BigQuery product
+analytics sink keeps its historical cohort fields. The Datadog HTTP forwarder is
+an operational sink, so it applies a separate params privacy level:
+`MCP_DATADOG_PARAM_PRIVACY_LEVEL`, defaulting to `standard`.
+
+This gives Cloud Run Datadog logs semantic parity with Helm/agent-ingested
+`ANALYTICS_EVENT` logs without forwarding raw free text. Cloud Run Datadog
+payloads include sanitized fields under `attributes.params.*`, corresponding to
+Helm's `custom.params.*` fields. Free-text values such as GraphQL queries,
+prompts, descriptions, report text, and messages are redacted to
+`<redacted: text len=N>` by default; secret-like keys are always redacted.
+
+Only use `MCP_DATADOG_PARAM_PRIVACY_LEVEL=off` for short-lived debugging in a
+controlled environment. Do not set it as a production default.
+
 ### Identifier hashing at `strict`
 
 `<h:sha256_prefix>` uses the first 12 hex chars of `sha256(value)`.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -123,15 +123,23 @@ It already uses its own `_StructuredJsonFormatter` ([`src/wandb_mcp_server/analy
 whose schema downstream GCP Cloud Logging -> BigQuery pipelines depend on. Touching
 it would silently break analytics ingestion.
 
+For MCP stdio transport, stdout is the JSON-RPC wire. The CLI reconfigures
+`wandb_mcp_server.analytics` to write structured analytics to stderr in stdio
+mode, while HTTP/container deployments keep stdout for Cloud Logging ingestion.
+If an older stdio build writes analytics JSON to stdout, set
+`MCP_ANALYTICS_DISABLED=true` to suppress analytics as a workaround.
+
 ### Defensive analytics propagation lock
 
 `analytics.py` sets `analytics_logger.propagate = False` at module import time so that
 the analytics record is emitted only by its own `_StructuredJsonFormatter` handler
-(stdout) and never reaches the root logger. However, when the server boots under
+and never reaches the root logger. In HTTP/container deployments this handler
+writes to stdout for Cloud Logging; in stdio deployments it writes to stderr so
+stdout remains pure MCP JSON-RPC. However, when the server boots under
 `uvicorn`, `logging.config.dictConfig` can reset propagation on existing loggers,
 silently re-enabling propagation. In that case every analytics event is emitted
-twice: once via the rich `_StructuredJsonFormatter` payload on stdout, and a
-minimal duplicate via the root `_JsonLogFormatter` on stderr.
+twice: once via the rich `_StructuredJsonFormatter` payload on the analytics
+stream, and a minimal duplicate via the root `_JsonLogFormatter` on stderr.
 
 To prevent this, `configure_process_logging()` re-asserts
 `logging.getLogger("wandb_mcp_server.analytics").propagate = False` after the
@@ -174,7 +182,7 @@ to BigQuery for product analytics. That pipeline depends on plaintext
 preserves this byte-for-byte.
 
 Customer K8s installs do NOT feed W&B's BigQuery; their analytics logger goes
-to stdout for the local Datadog Agent to collect into the customer's own
+to the container log stream for the local Datadog Agent to collect into the customer's own
 Datadog tenant. There's no business need to retain plaintext free-text
 params there, and redaction reduces legal exposure if customer logs are
 subpoenaed, exported, or retained longer than needed. `standard` is the safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "simple-parsing>=0.1.7",
     "python-dotenv>=1.0.0",
     "tiktoken>=0.9.0",
-    "wandb-workspaces>=0.1.12",
+    "wandb-workspaces>=0.3.9",
     "requests>=2.31.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.3"
+version = "0.3.5"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/scripts/report_agent_harness.py
+++ b/scripts/report_agent_harness.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Seed a complex W&B project and validate agent-style report creation.
+
+This is a live harness for WB-34806. It creates a synthetic project with
+multiple runs, metric histories, and table-backed AP curves, then uses a small
+deterministic "agent" to emit the same `create_wandb_report_tool` payload shape
+an MCP client should use for a multi-section report.
+
+Requirements:
+    WANDB_API_KEY must be set in the environment or in `.env`.
+
+Usage:
+    uv run python scripts/report_agent_harness.py
+    uv run python scripts/report_agent_harness.py --env-file ../wandb-mcp-server/.env
+    uv run python scripts/report_agent_harness.py --panel-def-id cruise/bar_chart/v2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import wandb
+import wandb_workspaces.reports.v2 as wr
+from dotenv import load_dotenv
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.create_report import create_report
+
+OBJECT_CLASSES = ("CAR", "TRUCK", "MOTORCYCLE")
+TABLE_KEYS = {
+    "CAR": "car_ap_curve",
+    "TRUCK": "truck_ap_curve",
+    "MOTORCYCLE": "motorcycle_ap_curve",
+}
+
+
+@dataclass(frozen=True)
+class HarnessConfig:
+    """Runtime configuration for the live report harness."""
+
+    entity: str
+    project: str
+    run_count: int
+    panel_def_id: str
+    timeout_s: int
+    stamp: str
+
+
+@dataclass(frozen=True)
+class SeededRun:
+    """Synthetic run metadata needed by the agent harness."""
+
+    run_id: str
+    display_name: str
+    model_family: str
+
+
+class BasicReportAgent:
+    """Deterministic agent that emits a complex MCP report layout payload."""
+
+    def __init__(self, *, panel_def_id: str) -> None:
+        self.panel_def_id = panel_def_id
+
+    def build_panels(self, seeded_runs: list[SeededRun]) -> list[dict[str, Any]]:
+        """Build ordered report layout blocks from seeded run metadata."""
+        run_ids = [run.run_id for run in seeded_runs]
+        return [
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Scenario summary",
+            },
+            {
+                "type": "markdown",
+                "text": (
+                    "This synthetic report mimics an agent assembling a customer evaluation report "
+                    "with narrative text, shared runsets, native metric panels, and custom Vega panels."
+                ),
+            },
+            {
+                "type": "markdown_table",
+                "title": "Seeded runs",
+                "headers": ["Run ID", "Display name", "Model family"],
+                "rows": [[run.run_id, run.display_name, run.model_family] for run in seeded_runs],
+            },
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Training and evaluation metrics",
+            },
+            {
+                "type": "markdown",
+                "text": "These native panels share one deterministic runset filter across all seeded runs.",
+            },
+            {
+                "type": "panel_grid",
+                "run_ids": run_ids,
+                "hide_run_sets": False,
+                "panels": [
+                    {
+                        "type": "line",
+                        "x": "_step",
+                        "y": ["train/loss", "eval/mAP"],
+                        "title": "Loss and mAP over steps",
+                    },
+                    {
+                        "type": "bar",
+                        "metrics": ["summary/final_map", "summary/p95_latency_ms"],
+                        "title": "Final quality and latency",
+                    },
+                    {
+                        "type": "scatter",
+                        "x": "summary/p95_latency_ms",
+                        "y": "summary/final_map",
+                        "title": "Latency vs mAP",
+                    },
+                ],
+            },
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Average precision by class",
+            },
+            {
+                "type": "markdown",
+                "text": "Each custom Vega panel reads a table key from the same shared runset.",
+            },
+            {
+                "type": "panel_grid",
+                "run_ids": run_ids,
+                "hide_run_sets": False,
+                "panels": [self._class_ap_panel(class_name) for class_name in OBJECT_CLASSES],
+            },
+        ]
+
+    def _class_ap_panel(self, class_name: str) -> dict[str, Any]:
+        """Build a table-backed custom chart panel for one object class."""
+        return {
+            "type": "custom_chart_table",
+            "table_name": TABLE_KEYS[class_name],
+            "chart_name": self.panel_def_id,
+            "chart_fields": {"x": "threshold", "y": "ap"},
+            "chart_strings": {"title": f"{class_name} AP by confidence threshold"},
+        }
+
+
+def _env_first(*names: str, default: str) -> str:
+    """Return the first non-empty environment variable value."""
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return default
+
+
+def _parse_args() -> HarnessConfig:
+    """Parse CLI arguments and environment fallbacks."""
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument(
+        "--env-file",
+        default=os.getenv("MCP_REPORT_HARNESS_ENV_FILE", ""),
+        help="Optional .env file to load before reading W&B settings.",
+    )
+    pre_args, _ = pre_parser.parse_known_args()
+
+    load_dotenv()
+    if pre_args.env_file and not load_dotenv(pre_args.env_file, override=True):
+        pre_parser.error(f"Could not load --env-file {pre_args.env_file!r}")
+
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    parser = argparse.ArgumentParser(description=__doc__, parents=[pre_parser])
+    parser.add_argument(
+        "--entity",
+        default=_env_first(
+            "MCP_REPORT_TEST_ENTITY",
+            "MCP_LOGS_WANDB_ENTITY",
+            "WANDB_ENTITY",
+            default="wandb-applied-ai-team",
+        ),
+        help="W&B entity to seed.",
+    )
+    parser.add_argument(
+        "--project",
+        default=_env_first(
+            "MCP_REPORT_HARNESS_PROJECT",
+            "MCP_REPORT_TEST_PROJECT",
+            "MCP_LOGS_WANDB_PROJECT",
+            "WANDB_PROJECT",
+            default="wandb-mcp-report-agent-harness",
+        ),
+        help="W&B project to seed.",
+    )
+    parser.add_argument("--run-count", type=int, default=3, help="Number of synthetic runs to create.")
+    parser.add_argument(
+        "--panel-def-id",
+        default=os.getenv("MCP_REPORT_HARNESS_PANEL_DEF_ID", "wandb/line/v0"),
+        help="Vega panelDefId to persist for custom charts.",
+    )
+    parser.add_argument("--timeout-s", type=int, default=90, help="Seconds to wait for table summaries.")
+    args = parser.parse_args()
+    if args.run_count < 2:
+        parser.error("--run-count must be at least 2")
+    return HarnessConfig(
+        entity=args.entity,
+        project=args.project,
+        run_count=args.run_count,
+        panel_def_id=args.panel_def_id,
+        timeout_s=args.timeout_s,
+        stamp=stamp,
+    )
+
+
+def _setup_wandb_context() -> str:
+    """Load credentials for W&B SDK calls and MCP report creation."""
+    api_key = os.getenv("WANDB_API_KEY", "")
+    if not api_key:
+        print("ERROR: WANDB_API_KEY is not set in the environment or .env.", file=sys.stderr)
+        sys.exit(1)
+    WandBApiManager.set_context_api_key(api_key)
+    return api_key
+
+
+def _seed_mock_project(config: HarnessConfig) -> list[SeededRun]:
+    """Create synthetic runs with metrics and table-backed AP curves."""
+    seeded_runs: list[SeededRun] = []
+    model_families = ("baseline", "candidate", "experimental", "ablation")
+    for run_index in range(config.run_count):
+        model_family = model_families[run_index % len(model_families)]
+        display_name = f"agent-harness-{model_family}-{config.stamp}"
+        with wandb.init(
+            entity=config.entity,
+            project=config.project,
+            name=display_name,
+            job_type="mcp-report-agent-harness",
+            tags=["mcp-generated", "report-layout-harness", config.stamp],
+            config={
+                "model_family": model_family,
+                "dataset": "synthetic-urban-perception",
+                "seed": 9000 + run_index,
+            },
+        ) as run:
+            final_map = 0.64 + run_index * 0.045
+            p95_latency = 42 - run_index * 3.5
+            for step in range(12):
+                progress = step / 11
+                run.log(
+                    {
+                        "train/loss": round(1.25 - progress * (0.48 + run_index * 0.06), 4),
+                        "eval/mAP": round(0.38 + progress * (final_map - 0.38), 4),
+                        "summary/p95_latency_ms": round(p95_latency + (1 - progress) * 4.0, 4),
+                    },
+                    step=step,
+                )
+
+            for class_index, class_name in enumerate(OBJECT_CLASSES):
+                run.log({TABLE_KEYS[class_name]: _ap_curve_table(run_index, class_index)})
+
+            run.summary["summary/final_map"] = round(final_map, 4)
+            run.summary["summary/p95_latency_ms"] = round(p95_latency, 4)
+            run.summary["summary/report_harness_stamp"] = config.stamp
+            seeded_runs.append(
+                SeededRun(
+                    run_id=run.id,
+                    display_name=display_name,
+                    model_family=model_family,
+                )
+            )
+    return seeded_runs
+
+
+def _ap_curve_table(run_index: int, class_index: int) -> wandb.Table:
+    """Create one synthetic AP curve table."""
+    rows = []
+    class_name = OBJECT_CLASSES[class_index]
+    for threshold_index in range(7):
+        threshold = round(0.2 + threshold_index * 0.1, 2)
+        ap = 0.48 + run_index * 0.05 + class_index * 0.025 + threshold_index * 0.018
+        precision = 0.72 + run_index * 0.025 + threshold_index * 0.02
+        recall = 0.92 - threshold_index * 0.055 + run_index * 0.01
+        rows.append(
+            [
+                threshold,
+                round(min(ap, 0.98), 4),
+                round(min(precision, 0.99), 4),
+                round(max(recall, 0.1), 4),
+                class_name,
+            ]
+        )
+    return wandb.Table(
+        columns=["threshold", "ap", "precision", "recall", "class_name"],
+        data=rows,
+    )
+
+
+def _wait_for_tables(api_key: str, config: HarnessConfig, seeded_runs: list[SeededRun]) -> None:
+    """Wait until table-backed chart inputs are queryable from run summaries."""
+    api = wandb.Api(api_key=api_key)
+    deadline = time.monotonic() + config.timeout_s
+    pending = {(run.run_id, table_key) for run in seeded_runs for table_key in TABLE_KEYS.values()}
+    last_seen: dict[str, list[str]] = {}
+
+    while pending and time.monotonic() < deadline:
+        for run in seeded_runs:
+            api_run = api.run(f"{config.entity}/{config.project}/{run.run_id}")
+            summary = dict(api_run.summary)
+            last_seen[run.run_id] = sorted(summary.keys())
+            for table_key in TABLE_KEYS.values():
+                table_ref = summary.get(table_key)
+                if getattr(table_ref, "get", lambda *_: None)("_type") == "table-file":
+                    pending.discard((run.run_id, table_key))
+        if pending:
+            time.sleep(2)
+
+    if pending:
+        raise AssertionError(
+            f"Timed out waiting for table summaries. Pending={sorted(pending)} Last summary keys={last_seen}"
+        )
+
+
+def _create_agent_report(config: HarnessConfig, seeded_runs: list[SeededRun]) -> str:
+    """Create a report using the same MCP implementation exposed to agents."""
+    agent = BasicReportAgent(panel_def_id=config.panel_def_id)
+    result = create_report(
+        entity_name=config.entity,
+        project_name=config.project,
+        title=f"MCP agent report harness {config.stamp}",
+        description="Synthetic validation report for structured MCP report assembly.",
+        markdown_report_text=(
+            "# MCP agent report harness\n\n"
+            "[TOC]\n\n"
+            "This report was generated by a deterministic local harness that mimics an agent using only MCP inputs."
+        ),
+        panels=agent.build_panels(seeded_runs),
+    )
+    return result["url"]
+
+
+def _validate_report(report_url: str, config: HarnessConfig, seeded_runs: list[SeededRun]) -> None:
+    """Reload the saved report and validate the Reports v2 structure."""
+    report_model = wr.Report.from_url(report_url, as_model=True)
+    panel_grids = [block for block in report_model.spec.blocks if getattr(block, "type", None) == "panel-grid"]
+    if len(panel_grids) != 2:
+        raise AssertionError(f"Expected 2 panel grids, found {len(panel_grids)}")
+
+    run_ids = [run.run_id for run in seeded_runs]
+    for index, grid in enumerate(panel_grids):
+        if len(grid.metadata.run_sets) != 1:
+            raise AssertionError(f"Grid {index} should have exactly one runset")
+        runset_json = grid.metadata.run_sets[0].model_dump_json(by_alias=True, exclude_none=True)
+        for run_id in run_ids:
+            if run_id not in runset_json:
+                raise AssertionError(f"Run ID {run_id} missing from grid {index} runset filter")
+        if '"name"' not in runset_json:
+            raise AssertionError(f"Grid {index} runset filter is not keyed by run name: {runset_json}")
+
+    custom_grid = panel_grids[1]
+    custom_panels = [
+        panel
+        for panel in custom_grid.metadata.panel_bank_section_config.panels
+        if getattr(getattr(panel, "config", None), "panel_def_id", None)
+    ]
+    if len(custom_panels) != len(OBJECT_CLASSES):
+        raise AssertionError(f"Expected {len(OBJECT_CLASSES)} custom panels, found {len(custom_panels)}")
+
+    panel_def_ids = [panel.config.panel_def_id for panel in custom_panels]
+    if panel_def_ids != [config.panel_def_id] * len(OBJECT_CLASSES):
+        raise AssertionError(f"Unexpected panelDefIds: {panel_def_ids}")
+
+    report_json = report_model.model_dump_json(by_alias=True, exclude_none=True)
+    for table_key in TABLE_KEYS.values():
+        if table_key not in report_json:
+            raise AssertionError(f"Table key {table_key!r} missing from saved report viewspec")
+
+
+def main() -> int:
+    """Run the live harness and return a process exit code."""
+    config = _parse_args()
+    api_key = _setup_wandb_context()
+
+    print(f"Seeding {config.run_count} runs in {config.entity}/{config.project}")
+    seeded_runs = _seed_mock_project(config)
+    print("Seeded run IDs:", ", ".join(run.run_id for run in seeded_runs))
+
+    print("Waiting for AP curve tables to appear in run summaries")
+    _wait_for_tables(api_key, config, seeded_runs)
+
+    print("Creating report through create_report() with an agent-style layout payload")
+    report_url = _create_agent_report(config, seeded_runs)
+    print(f"Report URL: {report_url}")
+
+    print("Reloading report and validating saved Reports v2 structure")
+    _validate_report(report_url, config, seeded_runs)
+    print("Harness validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.5"
 
 # Import the functions we want to expose
 from .server import cli

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -21,6 +21,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from wandb_mcp_server.utils import get_rich_logger
 
@@ -266,6 +267,85 @@ def _utcnow_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Read a boolean environment variable."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_stripped(name: str) -> Optional[str]:
+    """Return a stripped environment value or None when unset/empty."""
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _safe_wandb_base_host() -> Optional[str]:
+    """Return a host-only W&B base URL dimension."""
+    raw = _env_stripped("WANDB_BASE_URL")
+    if not raw:
+        return None
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    return parsed.netloc or parsed.path or None
+
+
+def _resolve_transport() -> str:
+    """Resolve the MCP transport dimension."""
+    transport = (_env_stripped("MCP_TRANSPORT") or "unknown").lower()
+    if transport in {"stdio", "http", "streamable-http", "sse"}:
+        return "http" if transport == "streamable-http" else transport
+    return transport
+
+
+def _resolve_runtime_surface(transport: str) -> str:
+    """Resolve where the MCP server is running."""
+    explicit = _env_stripped("MCP_RUNTIME_SURFACE")
+    if explicit:
+        return explicit
+    if os.environ.get("K_SERVICE") or os.environ.get("K_REVISION"):
+        return "cloud_run"
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return "helm_k8s"
+    if transport == "stdio":
+        return "local_stdio"
+    if transport == "http":
+        return "local_http"
+    return "unknown"
+
+
+def _resolve_deployment_type(runtime_surface: str, transport: str) -> str:
+    """Resolve the deployment type dimension."""
+    explicit = _env_stripped("MCP_DEPLOYMENT_TYPE")
+    if explicit:
+        return explicit
+    if _env_bool("MCP_HOSTED_MODE"):
+        return "hosted"
+    if runtime_surface.startswith("local") or transport == "stdio":
+        return "local"
+    return "unknown"
+
+
+def _deployment_context() -> Dict[str, Any]:
+    """Build low-cardinality deployment dimensions shared by all events."""
+    transport = _resolve_transport()
+    runtime_surface = _resolve_runtime_surface(transport)
+    context: Dict[str, Any] = {
+        "runtime_surface": runtime_surface,
+        "transport": transport,
+        "deployment_type": _resolve_deployment_type(runtime_surface, transport),
+        "environment": _env_stripped("ENVIRONMENT") or _env_stripped("DD_ENV") or "unknown",
+        "hosted_mode": _env_bool("MCP_HOSTED_MODE"),
+    }
+    wandb_base_host = _safe_wandb_base_host()
+    if wandb_base_host:
+        context["wandb_base_host"] = wandb_base_host
+    return context
+
+
 class AnalyticsTracker:
     """Emit structured analytics events for the MCP server.
 
@@ -410,6 +490,7 @@ class AnalyticsTracker:
             "event_type": event_type,
             "timestamp": _utcnow_iso(),
             "release_version": _resolve_release_version(),
+            **_deployment_context(),
         }
         deployment_id = os.environ.get("MCP_DEPLOYMENT_ID")
         if deployment_id:
@@ -517,6 +598,7 @@ class AnalyticsTracker:
         success: bool = True,
         error: Optional[str] = None,
         duration_ms: Optional[float] = None,
+        mcp_tool_name: Optional[str] = None,
     ) -> None:
         """Record an MCP tool invocation."""
         if not self.enabled:
@@ -537,14 +619,19 @@ class AnalyticsTracker:
                 "error": error,
                 "duration_ms": duration_ms,
             }
+            if mcp_tool_name:
+                event["mcp_tool_name"] = mcp_tool_name
+            labels = {
+                "event_type": "tool_call",
+                "tool_name": tool_name,
+                "email_domain": email_domain or "unknown",
+                "success": str(success),
+            }
+            if mcp_tool_name:
+                labels["mcp_tool_name"] = mcp_tool_name
             self._emit(
                 event,
-                {
-                    "event_type": "tool_call",
-                    "tool_name": tool_name,
-                    "email_domain": email_domain or "unknown",
-                    "success": str(success),
-                },
+                labels,
             )
         except Exception as exc:
             logger.warning(f"Failed to track tool call: {exc}")

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -182,9 +182,62 @@ analytics_logger = logging.getLogger("wandb_mcp_server.analytics")
 analytics_logger.setLevel(logging.INFO)
 analytics_logger.propagate = False
 
-_handler = logging.StreamHandler(sys.stdout)
-_handler.setFormatter(_StructuredJsonFormatter())
-analytics_logger.addHandler(_handler)
+_ANALYTICS_STREAM_STDOUT = "stdout"
+_ANALYTICS_STREAM_STDERR = "stderr"
+_VALID_ANALYTICS_STREAMS = frozenset({_ANALYTICS_STREAM_STDOUT, _ANALYTICS_STREAM_STDERR})
+
+
+def _resolve_analytics_stream_name(stream: Optional[str] = None) -> str:
+    """Resolve the structured analytics log stream name."""
+    raw = stream or os.environ.get("MCP_ANALYTICS_LOG_STREAM", _ANALYTICS_STREAM_STDOUT)
+    stream_name = raw.strip().lower()
+    if stream_name in _VALID_ANALYTICS_STREAMS:
+        return stream_name
+
+    logger.warning(
+        "MCP_ANALYTICS_LOG_STREAM=%r is not one of %s; falling back to stdout.",
+        raw,
+        sorted(_VALID_ANALYTICS_STREAMS),
+    )
+    return _ANALYTICS_STREAM_STDOUT
+
+
+def configure_analytics_logging(stream: Optional[str] = None) -> str:
+    """Configure the structured analytics logger stream.
+
+    HTTP/container deployments keep stdout so Cloud Logging can parse analytics
+    JSON. Stdio transport must use stderr because stdout is the MCP JSON-RPC
+    wire and any non-protocol line corrupts clients like Claude Desktop.
+
+    Args:
+        stream: Optional explicit stream name, "stdout" or "stderr". If omitted,
+            MCP_ANALYTICS_LOG_STREAM is honored, then stdout is used.
+
+    Returns:
+        The resolved stream name.
+    """
+    stream_name = _resolve_analytics_stream_name(stream)
+    target_stream = sys.stderr if stream_name == _ANALYTICS_STREAM_STDERR else sys.stdout
+
+    analytics_logger.handlers.clear()
+    handler = logging.StreamHandler(target_stream)
+    handler.setFormatter(_StructuredJsonFormatter())
+    analytics_logger.addHandler(handler)
+    analytics_logger.setLevel(logging.INFO)
+    analytics_logger.propagate = False
+    return stream_name
+
+
+def configure_analytics_logging_for_transport(transport: str) -> str:
+    """Configure analytics output for an MCP transport."""
+    if os.environ.get("MCP_ANALYTICS_LOG_STREAM"):
+        return configure_analytics_logging()
+    if transport == "stdio":
+        return configure_analytics_logging(_ANALYTICS_STREAM_STDERR)
+    return configure_analytics_logging(_ANALYTICS_STREAM_STDOUT)
+
+
+configure_analytics_logging()
 
 _REQUIRED_BASE_FIELDS = frozenset({"schema_version", "event_type", "timestamp"})
 

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -31,6 +31,7 @@ from wandb_mcp_server.utils import get_rich_logger
 logger = get_rich_logger(__name__)
 
 _DATADOG_EVENT_PREFIX = "mcp"
+_DATADOG_PARAM_PRIVACY_LEVEL_DEFAULT = "standard"
 
 
 def _build_retry_session() -> requests.Session:
@@ -45,6 +46,36 @@ def _build_retry_session() -> requests.Session:
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     return session
+
+
+def _datadog_safe_params(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return Datadog-safe analytics params.
+
+    Cloud Run keeps MCP_LOG_PRIVACY_LEVEL=off for product analytics, but Datadog
+    is an operational sink. Use standard redaction by default so free text is
+    summarized, secrets are redacted, and structured dimensions remain useful.
+    """
+    params = event.get("params")
+    if not params:
+        return {}
+
+    from wandb_mcp_server.analytics import AnalyticsTracker
+
+    privacy_level = os.environ.get(
+        "MCP_DATADOG_PARAM_PRIVACY_LEVEL",
+        _DATADOG_PARAM_PRIVACY_LEVEL_DEFAULT,
+    )
+    return AnalyticsTracker._sanitise_params(params, level=privacy_level)
+
+
+def _datadog_safe_labels(event: Dict[str, Any]) -> Dict[str, str]:
+    """Return low-cardinality labels safe for Datadog attributes."""
+    labels: Dict[str, str] = {"event_type": str(event.get("event_type", "unknown"))}
+    for key in ("tool_name", "mcp_tool_name", "success", "runtime_surface", "transport", "deployment_type"):
+        value = event.get(key)
+        if value is not None:
+            labels[key] = str(value)
+    return labels
 
 
 def map_to_datadog_log(
@@ -97,7 +128,16 @@ def map_to_datadog_log(
     if success is not None:
         tags.append(f"success:{str(success).lower()}")
 
-    attributes: Dict[str, Any] = {"event_type": event_type}
+    attributes: Dict[str, Any] = {
+        "event_type": event_type,
+        "schema_version": event.get("schema_version", "1.0"),
+    }
+    if success is not None:
+        attributes["success"] = success
+    for key in ("release_version", "timestamp"):
+        value = event.get(key)
+        if value is not None:
+            attributes[key] = value
     for key in (
         "runtime_surface",
         "transport",
@@ -113,6 +153,7 @@ def map_to_datadog_log(
 
     duration_ms = event.get("duration_ms")
     if duration_ms is not None:
+        attributes["duration_ms"] = duration_ms
         attributes["duration"] = int(duration_ms * 1_000_000)
 
     if event_type == "request":
@@ -136,7 +177,16 @@ def map_to_datadog_log(
 
     user_id = event.get("user_id")
     if user_id:
+        attributes["user_id"] = user_id
         attributes["usr"] = {"id": user_id}
+
+    safe_params = _datadog_safe_params(event)
+    if safe_params:
+        attributes["params"] = safe_params
+
+    labels = _datadog_safe_labels(event)
+    if labels:
+        attributes["labels"] = labels
 
     if event_type == "tool_call":
         tool_attrs: Dict[str, Any] = {}

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -83,14 +83,33 @@ def map_to_datadog_log(
         f"version:{dd_version}",
         f"event_type:{event_type}",
     ]
+    for key in ("runtime_surface", "transport", "deployment_type", "environment"):
+        value = event.get(key)
+        if value is not None:
+            tags.append(f"{key}:{value}")
     tool_name = event.get("tool_name")
     if tool_name:
         tags.append(f"tool_name:{tool_name}")
+    mcp_tool_name = event.get("mcp_tool_name")
+    if mcp_tool_name:
+        tags.append(f"mcp_tool_name:{mcp_tool_name}")
     success = event.get("success")
     if success is not None:
         tags.append(f"success:{str(success).lower()}")
 
     attributes: Dict[str, Any] = {"event_type": event_type}
+    for key in (
+        "runtime_surface",
+        "transport",
+        "deployment_type",
+        "environment",
+        "hosted_mode",
+        "deployment_id",
+        "wandb_base_host",
+    ):
+        value = event.get(key)
+        if value is not None:
+            attributes[key] = value
 
     duration_ms = event.get("duration_ms")
     if duration_ms is not None:
@@ -123,6 +142,10 @@ def map_to_datadog_log(
         tool_attrs: Dict[str, Any] = {}
         if tool_name:
             tool_attrs["name"] = tool_name
+            attributes["tool_name"] = tool_name
+        if mcp_tool_name:
+            tool_attrs["mcp_name"] = mcp_tool_name
+            attributes["mcp_tool_name"] = mcp_tool_name
         if success is not None:
             tool_attrs["success"] = success
         if tool_attrs:

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -51,9 +51,21 @@ _SESSION_PROPERTY_KEYS: List[str] = [
     "metadata",
 ]
 
+_BASE_PROPERTY_KEYS: List[str] = [
+    "release_version",
+    "deployment_id",
+    "runtime_surface",
+    "transport",
+    "deployment_type",
+    "environment",
+    "hosted_mode",
+    "wandb_base_host",
+]
+
 _TOOL_CALL_PROPERTY_KEYS: List[str] = [
     "session_id",
     "tool_name",
+    "mcp_tool_name",
     "params",
     "success",
     "error",
@@ -98,9 +110,7 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "schema_version": event.get("schema_version", "1.0"),
         "source": "wandb-mcp-server",
     }
-    if event.get("release_version"):
-        properties["release_version"] = event["release_version"]
-    for key in property_keys:
+    for key in [*_BASE_PROPERTY_KEYS, *property_keys]:
         if key in event:
             properties[key] = event[key]
 

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -51,6 +51,7 @@ MCP_MAX_FULL_TRACE_LIMIT: int = _env_int("MCP_MAX_FULL_TRACE_LIMIT", 25 if MCP_H
 MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HOSTED_MODE else 2000)
 MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
+WANDB_MCP_ENABLE_WEAVE_TOOLS: bool = _env_bool("WANDB_MCP_ENABLE_WEAVE_TOOLS", True)
 
 
 def structured_error(error: str, message: str, **extra: object) -> dict[str, object]:

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -51,6 +51,16 @@ MCP_MAX_FULL_TRACE_LIMIT: int = _env_int("MCP_MAX_FULL_TRACE_LIMIT", 25 if MCP_H
 MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HOSTED_MODE else 2000)
 MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
+COST_SORT_FIELDS: frozenset[str] = frozenset({"total_cost", "completion_cost", "prompt_cost"})
+
+
+class HostedLimitExceeded(ValueError):
+    """Raised when a hosted-mode request exceeds configured safety limits."""
+
+    def __init__(self, message: str, *, error: str = "quota_exceeded", **details: object) -> None:
+        super().__init__(message)
+        self.error = error
+        self.details = details
 
 
 def structured_error(error: str, message: str, **extra: object) -> dict[str, object]:

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -5,6 +5,7 @@ This version eliminates the singleton contamination vulnerability and uses only 
 """
 
 from typing import Any, Dict, List, Optional, Union
+import json
 import re
 
 import wandb_workspaces.reports.v2 as wr
@@ -97,7 +98,7 @@ Args:
     title: str, Title of the W&B Report - required
     description: str, Optional brief description of the report
     markdown_report_text: str, Well-structured markdown content for the report body
-    panels: list of dict, optional - Chart panels to add after the markdown content.
+    panels: list of dict, optional - Chart panels or ordered layout blocks to add after the markdown content.
         Each dict specifies a chart type and configuration:
         - {"type": "line", "x": "_step", "y": ["loss", "val_loss"], "title": "Training Loss"}
           Creates a LinePlot tracking metrics over steps.
@@ -113,8 +114,17 @@ Args:
            "chart_name": "wandb/line/v0", "chart_fields": {"x": "recall", "y": "precision"},
            "chart_strings": {"title": "PR Curve"}, "hide_run_sets": true}
           Creates a CustomChart from a W&B Table or summary table key via CustomChart.from_table().
+        - {"type": "heading", "level": 2, "text": "Average precision by class"}
+          Adds an H1/H2/H3 report heading at this position.
+        - {"type": "markdown", "text": "These charts share the same filtered runset."}
+          Adds markdown narrative at this position.
+        - {"type": "panel_grid", "run_ids": ["run_a", "run_b"], "hide_run_sets": false,
+           "panels": [{...chart panel...}, {...chart panel...}]}
+          Creates one PanelGrid whose child panels share a single Runset.
         Use custom_chart_table for PR curves, ROC curves, confusion matrices, and other table-backed Vega charts.
-        Panels are additive to markdown content. If omitted, report is markdown-only.
+        If panels only contains chart specs, the tool appends them under a Charts heading for backward compatibility.
+        If panels contains heading, markdown, or panel_grid blocks, the list is treated as an ordered layout and no
+        automatic Charts heading is added. If omitted, report is markdown-only.
 
 <custom_chart_panel_guide>
 Use native panel types for ordinary run metrics:
@@ -150,6 +160,31 @@ If the chart data is computed inside MCP rather than already stored as a W&B
 Table, call log_analysis_to_wandb first, then reference the logged run/table
 from this report tool.
 </custom_chart_panel_guide>
+
+<report_layout_guide>
+Use panel_grid when multiple panels should share one run selector / Runset. This is the correct structure for
+reports such as H2 / markdown / panel-grid / H2 / markdown / panel-grid:
+{
+  "type": "panel_grid",
+  "run_ids": ["run_a", "run_b"],
+  "hide_run_sets": false,
+  "panels": [
+    {"type": "custom_chart", "query": {"summaryTable": {"tableKey": "car_ap"}},
+     "chart_name": "cruise/bar_chart/v2", "chart_fields": {"x": "threshold", "y": "ap"},
+     "chart_strings": {"title": "CAR AP"}},
+    {"type": "custom_chart", "query": {"summaryTable": {"tableKey": "truck_ap"}},
+     "chart_name": "cruise/bar_chart/v2", "chart_fields": {"x": "threshold", "y": "ap"},
+     "chart_strings": {"title": "TRUCK AP"}}
+  ]
+}
+
+Runset scoping:
+- run_ids means W&B internal run keys (Python SDK run.id / GraphQL Run.name), not display names.
+- run_ids are converted to deterministic Reports v2 filters, for example name in ["run_a", "run_b"].
+- filters may be passed as a Reports v2 expression string and wins over generated run_ids filters.
+- runset_query may be passed for explicit search behavior. Do not use custom_chart query for run filtering.
+- chart_name maps to the Vega panelDefId such as wandb/line/v0 or cruise/bar_chart/v2. Put visible titles in chart_strings.
+</report_layout_guide>
 
 <manual_validation_recipe>
 To validate a table-backed custom chart manually:
@@ -262,9 +297,15 @@ def create_report(
             report.blocks = [security_notice] + blocks
 
             if panels:
-                panel_blocks = _build_panel_blocks(panels, entity_name, project_name)
+                layout_mode = _is_layout_mode(panels)
+                panel_blocks = (
+                    _build_layout_blocks(panels, entity_name, project_name)
+                    if layout_mode
+                    else _build_panel_blocks(panels, entity_name, project_name)
+                )
                 if panel_blocks:
-                    report.blocks.append(wr.H2("Charts"))
+                    if not layout_mode:
+                        report.blocks.append(wr.H2("Charts"))
                     report.blocks.extend(panel_blocks)
 
             report.save()
@@ -314,6 +355,12 @@ _KNOWN_PANEL_TYPES = {
     "custom_chart_table",
 }
 
+_LAYOUT_BLOCK_TYPES = {
+    "heading",
+    "markdown",
+    "panel_grid",
+}
+
 
 def _build_panel_block(
     panel_spec: Dict[str, Any],
@@ -322,12 +369,11 @@ def _build_panel_block(
 ):
     """Build one report block for a panel spec."""
     panel_type = panel_spec.get("type", "").lower()
-    if panel_type in {"line", "bar", "scatter", "run_comparison", "markdown_table", "markdown_panel"}:
-        return _build_native_panel(panel_spec, entity_name, project_name)
-    if panel_type == "custom_chart":
-        return _build_custom_chart_panel(panel_spec, entity_name, project_name)
-    if panel_type == "custom_chart_table":
-        return _build_custom_chart_from_table_panel(panel_spec, entity_name, project_name)
+    if panel_type == "markdown_table":
+        return _build_markdown_table_block(panel_spec)
+    panel = _build_panel_object(panel_spec)
+    if panel is not None:
+        return _build_panel_grid(panel_spec, _build_runset(panel_spec, entity_name, project_name), panel)
     return None
 
 
@@ -338,18 +384,53 @@ def _build_runset(
     *,
     include_run_ids: bool = False,
 ):
-    """Build a Runset, preserving the query= workaround used by current panels."""
+    """Build a Reports v2 Runset from MCP JSON-safe runset fields."""
+    runset_spec = panel_spec.get("runset", {})
+    if runset_spec is None:
+        runset_spec = {}
+    if not isinstance(runset_spec, dict):
+        raise ValueError("runset must be an object")
+
+    filters = panel_spec.get("filters", runset_spec.get("filters"))
+    if filters is not None and not isinstance(filters, str):
+        raise ValueError("filters must be a Reports v2 expression string")
+
     run_id = panel_spec.get("analysis_run_id")
-    if run_id:
-        # Use query= instead of filters= because wandb-workspaces
-        # ast.literal_eval chokes on dict-based JSON filter strings.
-        return wr.Runset(entity=entity_name, project=project_name, query=run_id)
+    if not filters and run_id:
+        filters = _run_ids_filter([run_id])
 
-    run_ids = panel_spec.get("run_ids", [])
-    if include_run_ids and run_ids:
-        return wr.Runset(entity=entity_name, project=project_name, query=" ".join(run_ids))
+    run_ids = panel_spec.get("run_ids", runset_spec.get("run_ids", []))
+    if not filters and run_ids:
+        filters = _run_ids_filter(run_ids)
 
-    return wr.Runset(entity=entity_name, project=project_name)
+    query = panel_spec.get("runset_query", runset_spec.get("query", ""))
+    if query is None:
+        query = ""
+    if not isinstance(query, str):
+        raise ValueError("runset query must be a string")
+
+    kwargs = {"entity": entity_name, "project": project_name}
+    if query:
+        kwargs["query"] = query
+    if filters:
+        kwargs["filters"] = filters
+    return wr.Runset(**kwargs)
+
+
+def _run_ids_filter(run_ids: List[str]) -> str:
+    """Return a deterministic Reports v2 filter expression for run keys."""
+    if isinstance(run_ids, str) or not isinstance(run_ids, list):
+        raise ValueError("run_ids must be a list of W&B internal run keys")
+    normalized = []
+    for run_id in run_ids:
+        if not isinstance(run_id, str) or not run_id:
+            raise ValueError("run_ids must contain non-empty strings")
+        normalized.append(run_id)
+    if not normalized:
+        return ""
+    if len(normalized) == 1:
+        return f"name == {json.dumps(normalized[0])}"
+    return f"name in {json.dumps(normalized)}"
 
 
 def _build_panel_grid(panel_spec: Dict[str, Any], runset, panel):
@@ -361,99 +442,90 @@ def _build_panel_grid(panel_spec: Dict[str, Any], runset, panel):
     )
 
 
-def _build_native_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
-    """Build existing native/markdown panel types."""
+def _build_panel_object(panel_spec: Dict[str, Any]):
+    """Build one wandb_workspaces panel object without wrapping it in a grid."""
     panel_type = panel_spec.get("type", "").lower()
     panel_title = panel_spec.get("title", "")
-    runset = _build_runset(panel_spec, entity_name, project_name)
 
     if panel_type == "line":
         x_key = panel_spec.get("x", "_step")
         y_keys = panel_spec.get("y", [])
         if not y_keys:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.LinePlot(x=x_key, y=y_keys, title=panel_title))
+        return wr.LinePlot(x=x_key, y=y_keys, title=panel_title)
 
     if panel_type == "bar":
         metrics = panel_spec.get("metrics", [])
         if not metrics:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.BarPlot(metrics=metrics, title=panel_title))
+        return wr.BarPlot(metrics=metrics, title=panel_title)
 
     if panel_type == "scatter":
         x_key = panel_spec.get("x", "")
         y_key = panel_spec.get("y", "")
         if not x_key or not y_key:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.ScatterPlot(x=x_key, y=y_key, title=panel_title))
+        return wr.ScatterPlot(x=x_key, y=y_key, title=panel_title)
 
     if panel_type == "run_comparison":
         metrics = panel_spec.get("metrics", [])
-        run_ids = panel_spec.get("run_ids", [])
         if not metrics:
             return None
-        if run_ids and not panel_spec.get("analysis_run_id"):
-            comp_runset = wr.Runset(entity=entity_name, project=project_name, query=" ".join(run_ids))
-        else:
-            comp_runset = runset
-        return _build_panel_grid(panel_spec, comp_runset, wr.LinePlot(x="_step", y=metrics, title=panel_title))
+        return wr.LinePlot(x="_step", y=metrics, title=panel_title)
 
     if panel_type == "markdown_table":
-        headers = panel_spec.get("headers", [])
-        rows = panel_spec.get("rows", [])
-        if not headers or not rows:
-            return None
-        md = f"### {panel_title}\n\n" if panel_title else ""
-        md += "| " + " | ".join(str(h) for h in headers) + " |\n"
-        md += "| " + " | ".join(["---"] * len(headers)) + " |\n"
-        for row in rows:
-            md += "| " + " | ".join(str(v) for v in row) + " |\n"
-        return wr.MarkdownBlock(md)
+        return None
 
     if panel_type == "markdown_panel":
         markdown = panel_spec.get("markdown", "")
         if not markdown:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.MarkdownPanel(markdown=markdown))
+        return wr.MarkdownPanel(markdown=markdown)
+
+    if panel_type == "custom_chart":
+        return _build_custom_chart_object(panel_spec)
+
+    if panel_type == "custom_chart_table":
+        return _build_custom_chart_from_table_object(panel_spec)
 
     return None
 
 
-def _build_custom_chart_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
+def _build_markdown_table_block(panel_spec: Dict[str, Any]):
+    """Build a report-level MarkdownBlock table."""
+    panel_title = panel_spec.get("title", "")
+    headers = panel_spec.get("headers", [])
+    rows = panel_spec.get("rows", [])
+    if not headers or not rows:
+        return None
+    md = f"### {panel_title}\n\n" if panel_title else ""
+    md += "| " + " | ".join(str(h) for h in headers) + " |\n"
+    md += "| " + " | ".join(["---"] * len(headers)) + " |\n"
+    for row in rows:
+        md += "| " + " | ".join(str(v) for v in row) + " |\n"
+    return wr.MarkdownBlock(md)
+
+
+def _build_custom_chart_object(panel_spec: Dict[str, Any]):
     """Build a CustomChart from an explicit workspaces query."""
     query = _required_dict(panel_spec, "query")
     chart_fields = _required_dict(panel_spec, "chart_fields")
     chart_strings = _optional_dict(panel_spec, "chart_strings")
     chart_name = _required_string(panel_spec, "chart_name")
-    runset = _build_runset(panel_spec, entity_name, project_name, include_run_ids=True)
-    chart = wr.CustomChart(
+    return wr.CustomChart(
         query=query,
         chart_name=chart_name,
         chart_fields=chart_fields,
         chart_strings=chart_strings,
     )
-    return _build_panel_grid(panel_spec, runset, chart)
 
 
-def _build_custom_chart_from_table_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
+def _build_custom_chart_from_table_object(panel_spec: Dict[str, Any]):
     """Build a CustomChart backed by a W&B Table or summary table key."""
     table_name = _required_string(panel_spec, "table_name")
     chart_fields = _required_dict(panel_spec, "chart_fields")
     chart_strings = _optional_dict(panel_spec, "chart_strings")
-    chart_name = panel_spec.get("chart_name") or panel_spec.get("title") or ""
-    runset = _build_runset(panel_spec, entity_name, project_name, include_run_ids=True)
+    chart_name = panel_spec.get("chart_name") or ""
     chart = wr.CustomChart.from_table(
         table_name,
         chart_fields=chart_fields,
@@ -461,7 +533,86 @@ def _build_custom_chart_from_table_panel(
     )
     if chart_name:
         chart.chart_name = chart_name
-    return _build_panel_grid(panel_spec, runset, chart)
+    return chart
+
+
+def _is_layout_mode(panels: List[Dict[str, Any]]) -> bool:
+    """Return True when panels contains ordered report layout blocks."""
+    return any(panel.get("type", "").lower() in _LAYOUT_BLOCK_TYPES for panel in panels)
+
+
+def _build_layout_blocks(
+    panels: List[Dict[str, Any]],
+    entity_name: str,
+    project_name: str,
+) -> List:
+    """Build ordered report blocks from layout-mode panel specs."""
+    blocks = []
+    for panel_spec in panels:
+        panel_type = panel_spec.get("type", "").lower()
+        panel_title = panel_spec.get("title") or panel_spec.get("text", "")
+        try:
+            block = _build_layout_block(panel_spec, entity_name, project_name)
+            if block is None:
+                if panel_type not in _KNOWN_PANEL_TYPES and panel_type not in _LAYOUT_BLOCK_TYPES:
+                    logger.warning(f"Unknown panel type: {panel_type}")
+                continue
+            if isinstance(block, list):
+                blocks.extend(block)
+            else:
+                blocks.append(block)
+        except Exception as e:
+            logger.warning(f"Failed to build layout block '{panel_title}': {e}", exc_info=True)
+            blocks.append(wr.P(f"*Panel '{panel_title}' could not be rendered.*"))
+    return blocks
+
+
+def _build_layout_block(
+    panel_spec: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+):
+    """Build one ordered layout block."""
+    panel_type = panel_spec.get("type", "").lower()
+    if panel_type == "heading":
+        text = _required_string(panel_spec, "text")
+        level = panel_spec.get("level", 2)
+        if level == 1:
+            return wr.H1(text)
+        if level == 3:
+            return wr.H3(text)
+        return wr.H2(text)
+    if panel_type == "markdown":
+        text = _required_string(panel_spec, "text")
+        return parse_markdown_to_blocks(text)
+    if panel_type == "panel_grid":
+        return _build_panel_grid_block(panel_spec, entity_name, project_name)
+    return _build_panel_block(panel_spec, entity_name, project_name)
+
+
+def _build_panel_grid_block(
+    panel_spec: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+):
+    """Build one PanelGrid with a shared Runset and multiple child panels."""
+    child_specs = panel_spec.get("panels", [])
+    if not isinstance(child_specs, list) or not child_specs:
+        raise ValueError("panel_grid panels must be a non-empty list")
+    panel_objects = []
+    for child_spec in child_specs:
+        if not isinstance(child_spec, dict):
+            raise ValueError("panel_grid child panels must be objects")
+        child = _build_panel_object(child_spec)
+        if child is not None:
+            panel_objects.append(child)
+    if not panel_objects:
+        return None
+    return wr.PanelGrid(
+        runsets=[_build_runset(panel_spec, entity_name, project_name)],
+        hide_run_sets=bool(panel_spec.get("hide_run_sets", False)),
+        panels=panel_objects,
+    )
 
 
 def _required_string(panel_spec: Dict[str, Any], key: str) -> str:

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -557,6 +557,21 @@ class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
         self.rewrites: list[str] = []
         self.rejections: list[str] = []
 
+    def enter_variable_definition(self, node, key, parent, path, ancestors):
+        if not isinstance(node, gql_ast.VariableDefinitionNode):
+            return
+        if not _HOSTED_LIMIT_VARIABLE_RE.match(node.variable.name.value):
+            return
+        if not isinstance(node.default_value, gql_ast.IntValueNode):
+            return
+
+        requested = int(node.default_value.value)
+        if requested <= self.max_first:
+            return
+
+        node.default_value = gql_ast.IntValueNode(value=str(self.max_first))
+        self.rewrites.append(f"Clamped ${node.variable.name.value} default from {requested} to {self.max_first}")
+
     def enter_field(self, node, key, parent, path, ancestors):
         if not isinstance(node, gql_ast.FieldNode):
             return
@@ -597,13 +612,10 @@ class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
                     self.rewrites.append(f"Clamped {'/'.join(current_path)} first from {requested} to {self.max_first}")
 
         if not has_first:
-            existing_args.append(
-                gql_ast.ArgumentNode(
-                    name=gql_ast.NameNode(value="first"),
-                    value=gql_ast.IntValueNode(value=str(self.max_first)),
-                )
+            self.rejections.append(
+                "Hosted GraphQL paginated collections must include a first argument so the initial request "
+                f"can be bounded: {'/'.join(current_path)}"
             )
-            self.rewrites.append(f"Added first={self.max_first} to {'/'.join(current_path)}")
 
         node.arguments = tuple(existing_args)
         self.connection_depth += 1

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+import re
 import traceback
 from typing import Any, Dict, List, Optional
 
@@ -526,6 +527,113 @@ def get_nested_value(obj: Dict, path: list[str]) -> Optional[Any]:
     return current
 
 
+_HOSTED_LIMIT_VARIABLE_RE = re.compile(r"^(first|limit|count|max_?items|page_?size|items_per_page)$", re.I)
+
+
+def _field_name(node: gql_ast.FieldNode) -> str:
+    """Return the response field name for a GraphQL field."""
+    return node.alias.value if node.alias else node.name.value
+
+
+def _is_connection_field(node: gql_ast.FieldNode) -> bool:
+    """Return True if a field selection looks like a W&B connection."""
+    if not node.selection_set:
+        return False
+    child_names = {
+        selection.name.value for selection in node.selection_set.selections if isinstance(selection, gql_ast.FieldNode)
+    }
+    return {"edges", "pageInfo"}.issubset(child_names)
+
+
+class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
+    """Clamp hosted GraphQL page sizes and reject unsafe fanout shapes."""
+
+    def __init__(self, max_first: int) -> None:
+        super().__init__()
+        self.max_first = max_first
+        self.path: list[str] = []
+        self.connection_depth = 0
+        self.connection_paths: list[tuple[str, ...]] = []
+        self.rewrites: list[str] = []
+        self.rejections: list[str] = []
+
+    def enter_field(self, node, key, parent, path, ancestors):
+        if not isinstance(node, gql_ast.FieldNode):
+            return
+
+        self.path.append(_field_name(node))
+        if not _is_connection_field(node):
+            return
+
+        current_path = tuple(self.path)
+        self.connection_paths.append(current_path)
+        if self.connection_depth > 0:
+            self.rejections.append(
+                f"Nested paginated collection is not allowed in hosted mode: {'/'.join(current_path)}"
+            )
+        if len(self.connection_paths) > 1:
+            self.rejections.append(
+                f"Hosted GraphQL queries may include only one paginated collection; found {len(self.connection_paths)}."
+            )
+
+        existing_args = list(node.arguments or [])
+        has_first = False
+        for idx, arg in enumerate(existing_args):
+            arg_name = arg.name.value
+            if arg_name == "last":
+                self.rejections.append(
+                    f"Hosted GraphQL does not support reverse pagination with last: {'/'.join(current_path)}"
+                )
+            if arg_name != "first":
+                continue
+            has_first = True
+            if isinstance(arg.value, gql_ast.IntValueNode):
+                requested = int(arg.value.value)
+                if requested > self.max_first:
+                    existing_args[idx] = gql_ast.ArgumentNode(
+                        name=arg.name,
+                        value=gql_ast.IntValueNode(value=str(self.max_first)),
+                    )
+                    self.rewrites.append(f"Clamped {'/'.join(current_path)} first from {requested} to {self.max_first}")
+
+        if not has_first:
+            existing_args.append(
+                gql_ast.ArgumentNode(
+                    name=gql_ast.NameNode(value="first"),
+                    value=gql_ast.IntValueNode(value=str(self.max_first)),
+                )
+            )
+            self.rewrites.append(f"Added first={self.max_first} to {'/'.join(current_path)}")
+
+        node.arguments = tuple(existing_args)
+        self.connection_depth += 1
+
+    def leave_field(self, node, key, parent, path, ancestors):
+        if isinstance(node, gql_ast.FieldNode) and _is_connection_field(node):
+            self.connection_depth = max(0, self.connection_depth - 1)
+        if self.path:
+            self.path.pop()
+
+
+def _hosted_preprocess_graphql_query(query: str, max_first: int) -> tuple[str, list[str], list[str]]:
+    """Rewrite hosted GraphQL pagination limits before the first execution."""
+    document = parse(query.strip())
+    visitor = HostedGraphQLPreflightVisitor(max_first=max_first)
+    rewritten = gql_visitor.visit(document, visitor)
+    return gql_printer.print_ast(rewritten), visitor.rewrites, visitor.rejections
+
+
+def _hosted_clamp_variables(variables: Dict[str, Any], max_first: int) -> Dict[str, Any]:
+    """Clamp common page-size variable names before the initial GraphQL execute."""
+    clamped = dict(variables)
+    for key, value in list(clamped.items()):
+        if not _HOSTED_LIMIT_VARIABLE_RE.match(key):
+            continue
+        if isinstance(value, int) and value > max_first:
+            clamped[key] = max_first
+    return clamped
+
+
 def query_paginated_wandb_gql(
     query: str,
     variables: Optional[Dict[str, Any]] = None,
@@ -595,6 +703,34 @@ def query_paginated_wandb_gql(
                 limit_key = "limit"
                 page1_vars_func[limit_key] = items_per_page
                 logger.debug(f"No limit variable found in input, adding '{limit_key}={items_per_page}'")
+
+            if MCP_HOSTED_MODE:
+                try:
+                    query, rewrites, rejections = _hosted_preprocess_graphql_query(
+                        query,
+                        MCP_MAX_GQL_ITEMS_PER_PAGE,
+                    )
+                    page1_vars_func = _hosted_clamp_variables(
+                        page1_vars_func,
+                        MCP_MAX_GQL_ITEMS_PER_PAGE,
+                    )
+                    if rejections:
+                        ctx.mark_error(f"query_too_complex: {rejections[0]}")
+                        return {
+                            "errors": [
+                                {
+                                    "message": rejections[0],
+                                    "details": rejections,
+                                    "error": "query_too_complex",
+                                }
+                            ]
+                        }
+                    if rewrites:
+                        logger.warning("Hosted GraphQL preflight rewrote query: %s", rewrites)
+                except Exception as e:
+                    logger.error("Hosted GraphQL preflight failed: %s", e, exc_info=True)
+                    ctx.mark_error(f"invalid_input: {e}")
+                    return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
 
             try:
                 parsed_initial_query = gql(query.strip())

--- a/src/wandb_mcp_server/mcp_tools/tools_utils.py
+++ b/src/wandb_mcp_server/mcp_tools/tools_utils.py
@@ -335,6 +335,7 @@ def track_tool_execution(
     tool_name: str,
     viewer: Any,
     params: Dict[str, Any],
+    mcp_tool_name: Optional[str] = None,
 ):
     """Context manager that wraps MCP tool execution with timing and error capture.
 
@@ -381,6 +382,7 @@ def track_tool_execution(
                 success=ctx.success,
                 error=ctx.error,
                 duration_ms=duration_ms,
+                mcp_tool_name=mcp_tool_name,
             )
         except Exception:
             _tools_logger.debug(f"Analytics tracking failed for {tool_name}")

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -1084,6 +1084,10 @@ def cli():
 
     args = simple_parsing.parse(ServerMCPArgs)
 
+    from wandb_mcp_server.analytics import configure_analytics_logging_for_transport
+
+    configure_analytics_logging_for_transport(args.transport)
+
     # Configure W&B logging behavior
     configure_wandb_logging()
 

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -12,6 +12,8 @@ This server provides tools for:
 """
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 import json
 import logging
 import os
@@ -92,6 +94,83 @@ from wandb_mcp_server.weave_api.models import QueryResult
 # Configure logging (no side effects beyond logger setup)
 logging.basicConfig(level=logging.INFO)
 logger = get_rich_logger("weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL")
+
+_COUNT_EXECUTOR = ThreadPoolExecutor(
+    max_workers=int(os.environ.get("MCP_COUNT_TOOL_WORKERS", "8")),
+    thread_name_prefix="mcp-count",
+)
+
+
+def _count_traces_with_context(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    request_timeout: int,
+) -> int:
+    """Run count_traces inside a worker while preserving the request API key."""
+    from wandb_mcp_server.api_client import WandBApiManager
+
+    token = WandBApiManager.set_context_api_key(api_key) if api_key else None
+    try:
+        return count_traces(
+            entity_name=entity_name,
+            project_name=project_name,
+            filters=filters,
+            request_timeout=request_timeout,
+        )
+    finally:
+        if token is not None:
+            WandBApiManager.reset_context_api_key(token)
+
+
+async def _count_traces_with_deadline(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    deadline_seconds: int,
+) -> int:
+    """Run count_traces without letting executor shutdown extend wall time."""
+    request_timeout = max(1, deadline_seconds - 2)
+    loop = asyncio.get_running_loop()
+    future = loop.run_in_executor(
+        _COUNT_EXECUTOR,
+        partial(
+            _count_traces_with_context,
+            api_key,
+            entity_name,
+            project_name,
+            filters,
+            request_timeout,
+        ),
+    )
+    try:
+        return await asyncio.wait_for(future, timeout=deadline_seconds)
+    except asyncio.TimeoutError:
+        future.cancel()
+        raise
+
+
+async def _count_traces_or_none(
+    api_key: Optional[str],
+    entity_name: str,
+    project_name: str,
+    filters: Dict[str, Any],
+    deadline_seconds: int,
+) -> int | None:
+    """Best-effort count for preflight/enrichment paths."""
+    try:
+        return await _count_traces_with_deadline(
+            api_key,
+            entity_name,
+            project_name,
+            filters,
+            deadline_seconds,
+        )
+    except Exception:
+        logger.info("count_traces skipped after timeout or error", exc_info=True)
+        return None
 
 
 # ===============================================================================
@@ -298,7 +377,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         filters: Optional[Dict[str, Any]] = None,
         sort_by: str = "started_at",
         sort_direction: str = "desc",
-        limit: int = 1000,
+        limit: Optional[int] = None,
         include_costs: bool = True,
         include_feedback: bool = True,
         columns: Optional[List[str]] = None,
@@ -324,22 +403,38 @@ def register_tools(mcp_instance: FastMCP) -> None:
             MCP_HOSTED_MODE,
             MCP_MAX_FULL_TRACE_LIMIT,
             MCP_MAX_QUERY_LIMIT,
+            COST_SORT_FIELDS,
             structured_error,
         )
+        from wandb_mcp_server.api_client import WandBApiManager
 
         hosted_limit = MCP_MAX_FULL_TRACE_LIMIT if return_full_data else MCP_MAX_QUERY_LIMIT
-        if MCP_HOSTED_MODE and limit > hosted_limit and not metadata_only:
+        effective_limit = hosted_limit if MCP_HOSTED_MODE and limit is None else (1000 if limit is None else limit)
+        if MCP_HOSTED_MODE and effective_limit > hosted_limit:
             return json.dumps(
                 structured_error(
                     "quota_exceeded",
                     f"Hosted MCP trace queries are limited to {hosted_limit} traces for detail_level='{detail_level}'.",
-                    limit=limit,
+                    limit=effective_limit,
                     max_limit=hosted_limit,
                     suggestions=[
                         "Use detail_level='schema' for broad discovery.",
                         f"Set limit={hosted_limit} or lower.",
-                        "Use metadata_only=True for counts and stats without trace payloads.",
+                        "Use count_weave_traces_tool for aggregate counts without trace payloads.",
                         "Add filters to narrow the result set.",
+                    ],
+                )
+            )
+        if MCP_HOSTED_MODE and sort_by in COST_SORT_FIELDS:
+            return json.dumps(
+                structured_error(
+                    "quota_exceeded",
+                    f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                    sort_by=sort_by,
+                    suggestions=[
+                        "Add time_range or op_name_contains filters.",
+                        "Sort by started_at, then inspect costs in the bounded result set.",
+                        "Use count_weave_traces_tool to size the query first.",
                     ],
                 )
             )
@@ -359,26 +454,33 @@ def register_tools(mcp_instance: FastMCP) -> None:
             effective_columns = _SCHEMA_COLUMNS
 
         try:
-            if detail_level != "schema" and limit > 100 and not metadata_only:
-                try:
-                    pre_count = count_traces(entity_name, project_name, filters or {})
-                    if pre_count > 500:
-                        return json.dumps(
-                            {
-                                "error": "query_too_large",
-                                "message": f"Found {pre_count} matching traces. Queries over 500 traces "
-                                f"risk server memory limits. Narrow your query.",
-                                "trace_count": pre_count,
-                                "suggestions": [
-                                    "detail_level='schema' (structural fields only, fast)",
-                                    f"limit={min(100, pre_count)} (reduce result count)",
-                                    "metadata_only=True (counts and stats without trace data)",
-                                    "Add filters to narrow results",
-                                ],
-                            }
-                        )
-                except Exception:
-                    pass
+            api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS
+
+            count_deadline = min(10, MCP_TOOL_TIMEOUT_SECONDS)
+            if detail_level != "schema" and effective_limit > 100 and not metadata_only:
+                pre_count = await _count_traces_or_none(
+                    api_key,
+                    entity_name,
+                    project_name,
+                    filters or {},
+                    count_deadline,
+                )
+                if pre_count and pre_count > 500:
+                    return json.dumps(
+                        {
+                            "error": "query_too_large",
+                            "message": f"Found {pre_count} matching traces. Queries over 500 traces "
+                            f"risk server memory limits. Narrow your query.",
+                            "trace_count": pre_count,
+                            "suggestions": [
+                                "detail_level='schema' (structural fields only, fast)",
+                                f"limit={min(100, pre_count)} (reduce result count)",
+                                "count_weave_traces_tool (counts and stats without trace data)",
+                                "Add filters to narrow results",
+                            ],
+                        }
+                    )
 
             result_model: QueryResult = await query_paginated_weave_traces(
                 entity_name=entity_name,
@@ -387,7 +489,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 filters=filters or {},
                 sort_by=sort_by,
                 sort_direction=sort_direction,
-                target_limit=limit,
+                target_limit=effective_limit,
                 include_costs=include_costs if detail_level != "schema" else False,
                 include_feedback=include_feedback if detail_level != "schema" else False,
                 columns=effective_columns,
@@ -398,12 +500,15 @@ def register_tools(mcp_instance: FastMCP) -> None:
             )
 
             try:
-                matching_count = count_traces(
+                matching_count = await _count_traces_or_none(
+                    api_key,
                     entity_name=entity_name,
                     project_name=project_name,
                     filters=filters or {},
+                    deadline_seconds=count_deadline,
                 )
-                result_model.metadata.total_matching_count = matching_count
+                if matching_count is not None:
+                    result_model.metadata.total_matching_count = matching_count
             except Exception:
                 logger.debug("count_traces for total_matching_count failed", exc_info=True)
 
@@ -459,6 +564,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 }
             )
         except Exception as e:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            if isinstance(e, HostedLimitExceeded):
+                return json.dumps(structured_error(e.error, str(e), **e.details))
             logger.error(f"Error in query_weave_traces_tool: {e}", exc_info=True)
             return json.dumps(
                 {
@@ -471,7 +580,6 @@ def register_tools(mcp_instance: FastMCP) -> None:
     async def count_weave_traces_tool(
         entity_name: str, project_name: str, filters: Optional[Dict[str, Any]] = None
     ) -> str:
-        from concurrent.futures import ThreadPoolExecutor, TimeoutError
         from wandb_mcp_server.api_client import WandBApiManager
         from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS, structured_error
 
@@ -480,23 +588,28 @@ def register_tools(mcp_instance: FastMCP) -> None:
             root_filters["trace_roots_only"] = True
 
             api_key = WandBApiManager.get_api_key()
-
-            def _count_with_context(**kwargs):
-                WandBApiManager.set_context_api_key(api_key)
-                return count_traces(**kwargs)
-
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                total_future = executor.submit(
-                    _count_with_context, entity_name=entity_name, project_name=project_name, filters=filters or {}
-                )
-                root_future = executor.submit(
-                    _count_with_context, entity_name=entity_name, project_name=project_name, filters=root_filters
-                )
-                total_count = total_future.result(timeout=MCP_TOOL_TIMEOUT_SECONDS)
-                root_traces_count = root_future.result(timeout=MCP_TOOL_TIMEOUT_SECONDS)
+            total_count, root_traces_count = await asyncio.wait_for(
+                asyncio.gather(
+                    _count_traces_with_deadline(
+                        api_key,
+                        entity_name,
+                        project_name,
+                        filters or {},
+                        MCP_TOOL_TIMEOUT_SECONDS,
+                    ),
+                    _count_traces_with_deadline(
+                        api_key,
+                        entity_name,
+                        project_name,
+                        root_filters,
+                        MCP_TOOL_TIMEOUT_SECONDS,
+                    ),
+                ),
+                timeout=MCP_TOOL_TIMEOUT_SECONDS,
+            )
 
             return json.dumps({"total_count": total_count, "root_traces_count": root_traces_count})
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.error("Timed out in count_weave_traces_tool")
             return json.dumps(
                 structured_error(

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -93,6 +93,25 @@ from wandb_mcp_server.weave_api.models import QueryResult
 logging.basicConfig(level=logging.INFO)
 logger = get_rich_logger("weave-mcp-server", default_level_str="WARNING", env_var_name="MCP_SERVER_LOG_LEVEL")
 
+_WEAVE_TOOL_NAMES = {
+    "query_weave_traces_tool",
+    "count_weave_traces_tool",
+    "resolve_trace_roots_tool",
+    "infer_trace_schema_tool",
+    "summarize_evaluation_tool",
+}
+
+
+def _remove_registered_tools(mcp_instance: FastMCP, tool_names: set[str]) -> None:
+    """Remove tools from FastMCP's registry after decorator registration."""
+    tool_manager = getattr(mcp_instance, "_tool_manager", None)
+    tools = getattr(tool_manager, "_tools", None)
+    if not isinstance(tools, dict):
+        logger.warning("Could not remove disabled MCP tools; FastMCP internals changed")
+        return
+    for tool_name in tool_names:
+        tools.pop(tool_name, None)
+
 
 # ===============================================================================
 # SECTION 1: W&B AUTHENTICATION & API KEY SETUP
@@ -849,6 +868,12 @@ def register_tools(mcp_instance: FastMCP) -> None:
             project_name=project_name,
             sample_runs=sample_runs,
         )
+
+    from wandb_mcp_server.config import WANDB_MCP_ENABLE_WEAVE_TOOLS
+
+    if not WANDB_MCP_ENABLE_WEAVE_TOOLS:
+        logger.info("Weave MCP tools disabled by WANDB_MCP_ENABLE_WEAVE_TOOLS=false")
+        _remove_registered_tools(mcp_instance, _WEAVE_TOOL_NAMES)
 
 
 # ===============================================================================

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -123,6 +123,7 @@ _COUNT_EXECUTOR = ThreadPoolExecutor(
 
 def _count_traces_with_context(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -130,8 +131,10 @@ def _count_traces_with_context(
 ) -> int:
     """Run count_traces inside a worker while preserving the request API key."""
     from wandb_mcp_server.api_client import WandBApiManager
+    from wandb_mcp_server.session_manager import current_session_id
 
     token = WandBApiManager.set_context_api_key(api_key) if api_key else None
+    session_token = current_session_id.set(session_id) if session_id else None
     try:
         return count_traces(
             entity_name=entity_name,
@@ -140,12 +143,15 @@ def _count_traces_with_context(
             request_timeout=request_timeout,
         )
     finally:
+        if session_token is not None:
+            current_session_id.reset(session_token)
         if token is not None:
             WandBApiManager.reset_context_api_key(token)
 
 
 async def _count_traces_with_deadline(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -159,6 +165,7 @@ async def _count_traces_with_deadline(
         partial(
             _count_traces_with_context,
             api_key,
+            session_id,
             entity_name,
             project_name,
             filters,
@@ -174,6 +181,7 @@ async def _count_traces_with_deadline(
 
 async def _count_traces_or_none(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -183,6 +191,7 @@ async def _count_traces_or_none(
     try:
         return await _count_traces_with_deadline(
             api_key,
+            session_id,
             entity_name,
             project_name,
             filters,
@@ -475,12 +484,16 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
         try:
             api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.session_manager import current_session_id
+
+            session_id = current_session_id.get()
             from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS
 
             count_deadline = min(10, MCP_TOOL_TIMEOUT_SECONDS)
             if detail_level != "schema" and effective_limit > 100 and not metadata_only:
                 pre_count = await _count_traces_or_none(
                     api_key,
+                    session_id,
                     entity_name,
                     project_name,
                     filters or {},
@@ -522,6 +535,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
             try:
                 matching_count = await _count_traces_or_none(
                     api_key,
+                    session_id,
                     entity_name=entity_name,
                     project_name=project_name,
                     filters=filters or {},
@@ -608,10 +622,14 @@ def register_tools(mcp_instance: FastMCP) -> None:
             root_filters["trace_roots_only"] = True
 
             api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.session_manager import current_session_id
+
+            session_id = current_session_id.get()
             total_count, root_traces_count = await asyncio.wait_for(
                 asyncio.gather(
                     _count_traces_with_deadline(
                         api_key,
+                        session_id,
                         entity_name,
                         project_name,
                         filters or {},
@@ -619,6 +637,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                     ),
                     _count_traces_with_deadline(
                         api_key,
+                        session_id,
                         entity_name,
                         project_name,
                         root_filters,

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -11,7 +11,7 @@ import sys
 from typing import Any, Dict, List, Optional, Set
 
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.config import WF_TRACE_SERVER_URL, MAX_ACCUMULATED_BYTES
+from wandb_mcp_server.config import WF_TRACE_SERVER_URL, MAX_ACCUMULATED_BYTES, COST_SORT_FIELDS
 from wandb_mcp_server.weave_api.client import WeaveApiClient
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.weave_api.models import QueryResult
@@ -55,7 +55,7 @@ class TraceService:
     """Service for querying and processing Weave traces."""
 
     # Define cost fields once as a class constant
-    COST_FIELDS = {"total_cost", "completion_cost", "prompt_cost"}
+    COST_FIELDS = set(COST_SORT_FIELDS)
 
     COST_SORT_MAX_FIRST_PASS = 10_000
 
@@ -64,6 +64,37 @@ class TraceService:
 
     # Define latency field mapping
     LATENCY_FIELD_MAPPING = {"latency_ms": "summary.weave.latency_ms"}
+
+    @staticmethod
+    def _hosted_trace_limit(return_full_data: bool) -> int | None:
+        """Return the hosted trace cap, or None when hosted mode is disabled."""
+        from wandb_mcp_server.config import (
+            MCP_HOSTED_MODE,
+            MCP_MAX_FULL_TRACE_LIMIT,
+            MCP_MAX_QUERY_LIMIT,
+        )
+
+        if not MCP_HOSTED_MODE:
+            return None
+        return MCP_MAX_FULL_TRACE_LIMIT if return_full_data else MCP_MAX_QUERY_LIMIT
+
+    @staticmethod
+    def _enforce_hosted_trace_limit(limit: Optional[int], cap: int | None, *, detail: str) -> int | None:
+        """Apply hosted trace limits before any upstream Weave query is issued."""
+        if cap is None:
+            return limit
+        if limit is None:
+            return cap
+        if limit > cap:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP trace queries are limited to {cap} traces for {detail}.",
+                limit=limit,
+                max_limit=cap,
+                detail=detail,
+            )
+        return limit
 
     def __init__(
         self,
@@ -354,6 +385,16 @@ class TraceService:
 
         # Special handling for cost-based sorting
         client_side_cost_sort = sort_by in self.COST_FIELDS
+        hosted_cap = self._hosted_trace_limit(return_full_data)
+        limit = self._enforce_hosted_trace_limit(limit, hosted_cap, detail="trace query")
+        if client_side_cost_sort and hosted_cap is not None:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
 
         # Handle latency field mapping
         if sort_by in self.LATENCY_FIELD_MAPPING:
@@ -562,6 +603,22 @@ class TraceService:
 
         # Special handling for cost-based sorting
         client_side_cost_sort = sort_by in self.COST_FIELDS
+        hosted_cap = self._hosted_trace_limit(return_full_data)
+        target_limit = self._enforce_hosted_trace_limit(
+            target_limit,
+            hosted_cap,
+            detail="paginated trace query",
+        )
+        if chunk_size and hosted_cap is not None:
+            chunk_size = min(chunk_size, hosted_cap)
+        if client_side_cost_sort and hosted_cap is not None:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
 
         # Determine effective_sort_by for the server
         effective_sort_by = "started_at"  # Default
@@ -708,6 +765,17 @@ class TraceService:
         Returns:
             List of trace dictionaries sorted by the specified cost field.
         """
+        from wandb_mcp_server.config import MCP_HOSTED_MODE
+
+        if MCP_HOSTED_MODE:
+            from wandb_mcp_server.config import HostedLimitExceeded
+
+            raise HostedLimitExceeded(
+                f"Hosted MCP does not support sort_by='{sort_by}' because it requires a large first-pass scan.",
+                sort_by=sort_by,
+                max_scan=self.COST_SORT_MAX_FIRST_PASS,
+            )
+
         if invalid_columns is None:
             invalid_columns = set()
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -4,6 +4,8 @@ Rewritten from Nico's PR #2 with improved datetime handling and
 cleaner param sanitisation.
 """
 
+import io
+import json
 import logging
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
@@ -14,6 +16,9 @@ import pytest
 from wandb_mcp_server.analytics import (
     SCHEMA_VERSION,
     AnalyticsTracker,
+    analytics_logger,
+    configure_analytics_logging,
+    configure_analytics_logging_for_transport,
     get_analytics_tracker,
     reset_analytics_tracker,
 )
@@ -22,8 +27,10 @@ from wandb_mcp_server.analytics import (
 @pytest.fixture(autouse=True)
 def _reset():
     reset_analytics_tracker()
+    configure_analytics_logging("stdout")
     yield
     reset_analytics_tracker()
+    configure_analytics_logging("stdout")
 
 
 class _EventCapture(logging.Filter):
@@ -69,6 +76,113 @@ class TestEnableDisable:
     @patch.dict("os.environ", {"MCP_ANALYTICS_DISABLED": "false"})
     def test_env_false_keeps_enabled(self):
         assert AnalyticsTracker(enabled=True).enabled is True
+
+
+# -- Analytics log stream ----------------------------------------------------
+
+
+class TestAnalyticsLogStream:
+    def test_configure_analytics_logging_uses_stdout(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging("stdout") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+            duration_ms=1.0,
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_configure_analytics_logging_uses_stderr(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging("stderr") == "stderr"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="get_run_history",
+            session_id="s",
+            viewer_info="viewer",
+            duration_ms=1.0,
+        )
+
+        assert stdout.getvalue() == ""
+        payload = json.loads(stderr.getvalue())
+        assert payload["message"] == "ANALYTICS_EVENT"
+        assert payload["event_type"] == "tool_call"
+        assert payload["tool_name"] == "get_run_history"
+        assert payload["duration_ms"] == 1.0
+
+    def test_configure_analytics_logging_for_stdio_uses_stderr(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging_for_transport("stdio") == "stderr"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="get_run_history",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert stdout.getvalue() == ""
+        assert "ANALYTICS_EVENT" in stderr.getvalue()
+
+    def test_configure_analytics_logging_for_http_uses_stdout(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging_for_transport("http") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_explicit_stream_env_overrides_transport(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+        monkeypatch.setenv("MCP_ANALYTICS_LOG_STREAM", "stdout")
+
+        assert configure_analytics_logging_for_transport("stdio") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_reconfiguration_replaces_handler_instead_of_duplicating(self, monkeypatch):
+        stdout = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        configure_analytics_logging("stdout")
+        configure_analytics_logging("stdout")
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert len(analytics_logger.handlers) == 1
+        assert stdout.getvalue().count("ANALYTICS_EVENT") == 1
 
 
 # -- Email domain extraction --------------------------------------------------

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -353,6 +353,45 @@ class TestSchemaVersion:
         t._emit({"event_type": "test"}, {})
         assert capture.event is None
 
+    @patch.dict(
+        "os.environ",
+        {
+            "MCP_RUNTIME_SURFACE": "cloud_run",
+            "MCP_TRANSPORT": "http",
+            "MCP_DEPLOYMENT_TYPE": "hosted",
+            "ENVIRONMENT": "production",
+            "MCP_HOSTED_MODE": "true",
+            "WANDB_BASE_URL": "https://api.wandb.ai",
+        },
+        clear=False,
+    )
+    def test_base_event_has_deployment_dimensions(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_gql",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event is not None
+        assert capture.event["runtime_surface"] == "cloud_run"
+        assert capture.event["transport"] == "http"
+        assert capture.event["deployment_type"] == "hosted"
+        assert capture.event["environment"] == "production"
+        assert capture.event["hosted_mode"] is True
+        assert capture.event["wandb_base_host"] == "api.wandb.ai"
+
+    @patch.dict("os.environ", {"MCP_TRANSPORT": "stdio"}, clear=False)
+    def test_base_event_infers_local_stdio(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_gql",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event is not None
+        assert capture.event["runtime_surface"] == "local_stdio"
+        assert capture.event["deployment_type"] == "local"
+
 
 # -- track_user_session -------------------------------------------------------
 
@@ -449,6 +488,18 @@ class TestTrackToolCall:
             duration_ms=123.4,
         )
         assert capture.event["duration_ms"] == 123.4
+
+    def test_mcp_tool_name_recorded_when_available(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_paginated_wandb_gql",
+            mcp_tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event["tool_name"] == "query_paginated_wandb_gql"
+        assert capture.event["mcp_tool_name"] == "query_wandb_tool"
+        assert capture.labels["mcp_tool_name"] == "query_wandb_tool"
 
     def test_labels_include_tool_name(self, capture):
         AnalyticsTracker(enabled=True).track_tool_call(

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -143,11 +143,33 @@ class TestDatadogAttributes:
         assert "usr" not in entry["attributes"]
 
     def test_tool_attributes(self):
-        event = _make_event("tool_call", tool_name="count_traces", success=True)
+        event = _make_event(
+            "tool_call",
+            tool_name="count_traces",
+            mcp_tool_name="count_weave_traces_tool",
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+            environment="production",
+            hosted_mode=True,
+            success=True,
+        )
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
         tool = entry["attributes"]["tool"]
         assert tool["name"] == "count_traces"
+        assert tool["mcp_name"] == "count_weave_traces_tool"
         assert tool["success"] is True
+        assert entry["attributes"]["tool_name"] == "count_traces"
+        assert entry["attributes"]["mcp_tool_name"] == "count_weave_traces_tool"
+        assert entry["attributes"]["runtime_surface"] == "cloud_run"
+        assert entry["attributes"]["transport"] == "http"
+        assert entry["attributes"]["deployment_type"] == "hosted"
+        assert entry["attributes"]["environment"] == "production"
+        assert entry["attributes"]["hosted_mode"] is True
+        assert "runtime_surface:cloud_run" in entry["ddtags"]
+        assert "transport:http" in entry["ddtags"]
+        assert "deployment_type:hosted" in entry["ddtags"]
+        assert "mcp_tool_name:count_weave_traces_tool" in entry["ddtags"]
 
     def test_session_id_forwarded(self):
         event = _make_event("tool_call", tool_name="x", success=True, session_id="sess_abc")

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -176,6 +176,40 @@ class TestDatadogAttributes:
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
         assert entry["attributes"]["session_id"] == "sess_abc"
 
+    def test_tool_call_includes_raw_analytics_parity_fields(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            duration_ms=546.08,
+            release_version="0.3.5",
+            timestamp="2026-05-27T17:58:00+00:00",
+            params={
+                "entity_name": "wandb-applied-ai-team",
+                "project_name": "mcp-tests",
+                "run_id": "h0fm5qp5",
+                "samples": 20,
+            },
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        attrs = entry["attributes"]
+
+        assert attrs["schema_version"] == "1.0"
+        assert attrs["release_version"] == "0.3.5"
+        assert attrs["timestamp"] == "2026-05-27T17:58:00+00:00"
+        assert attrs["tool_name"] == "get_run_history"
+        assert attrs["success"] is True
+        assert attrs["duration_ms"] == 546.08
+        assert attrs["params"]["entity_name"] == "wandb-applied-ai-team"
+        assert attrs["params"]["project_name"] == "mcp-tests"
+        assert attrs["params"]["run_id"] == "h0fm5qp5"
+        assert attrs["params"]["samples"] == 20
+        assert attrs["labels"]["tool_name"] == "get_run_history"
+        assert attrs["labels"]["event_type"] == "tool_call"
+
 
 # ---------------------------------------------------------------------------
 # map_to_datadog_log -- PII exclusion
@@ -185,16 +219,76 @@ class TestDatadogAttributes:
 class TestPIIExclusion:
     """Datadog must NOT receive params, api_key_hash, metadata, or email_domain."""
 
-    def test_params_excluded(self):
+    def test_params_are_sanitized_not_raw(self):
         event = _make_event(
             "tool_call",
             tool_name="query_traces",
             success=True,
-            params={"entity": "team", "project": "proj"},
+            params={"query": "query { viewer { username } }"},
         )
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
-        assert "team" not in entry["attributes"]
-        assert "params" not in entry["attributes"]
+        assert entry["attributes"]["params"]["query"] == "<redacted: text len=29>"
+
+    def test_params_redact_secrets(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="query_traces",
+            success=True,
+            params={"api_key": "secret", "Authorization": "Bearer token", "token": "x"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        assert entry["attributes"]["params"]["api_key"] == "<redacted>"
+        assert entry["attributes"]["params"]["Authorization"] == "<redacted>"
+        assert entry["attributes"]["params"]["token"] == "<redacted>"
+
+    def test_params_preserve_safe_dimensions(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={
+                "entity_name": "team",
+                "project_name": "project",
+                "run_id": "abc123",
+                "samples": 20,
+                "max_items": 100,
+            },
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        assert entry["attributes"]["params"] == {
+            "entity_name": "team",
+            "project_name": "project",
+            "run_id": "abc123",
+            "samples": 20,
+            "max_items": 100,
+        }
+
+    @patch.dict("os.environ", {"MCP_DATADOG_PARAM_PRIVACY_LEVEL": "strict"})
+    def test_params_can_hash_identifiers_at_strict(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={"entity_name": "team", "project_name": "project", "run_id": "abc123"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        params = entry["attributes"]["params"]
+        assert params["entity_name"].startswith("<h:")
+        assert params["project_name"].startswith("<h:")
+        assert params["run_id"].startswith("<h:")
+
+    def test_params_do_not_become_tags(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={"entity_name": "team", "project_name": "project", "run_id": "abc123"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        tags = entry["ddtags"]
+        assert "team" not in tags
+        assert "project" not in tags
+        assert "abc123" not in tags
 
     def test_api_key_hash_excluded(self):
         event = _make_event("user_session", session_id="s1", api_key_hash="abcdef1234567890")
@@ -516,7 +610,7 @@ class TestE2ETrackerToDatadog:
             assert entry["status"] == "info"
             assert entry["attributes"]["tool"]["name"] == "query_traces"
             assert entry["attributes"]["duration"] == 150_500_000
-            assert "params" not in entry["attributes"]
+            assert entry["attributes"]["params"]["entity"] == "team"
 
     @patch.dict(
         "os.environ",

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -103,7 +103,7 @@ class TestSuccessfulToolCall:
         assert "error" not in dd["attributes"]
         assert dd["attributes"]["duration"] >= 0
         assert dd["attributes"]["usr"]["id"] == "testuser"
-        assert "params" not in dd["attributes"]
+        assert dd["attributes"]["params"] == {"entity": "org", "project": "proj"}
 
     @pytest.mark.usefixtures("_enable_analytics")
     def test_success_segment_excludes_email_domain(self):
@@ -242,15 +242,20 @@ class TestDurationTracking:
 
 
 class TestDataSeparation:
-    """Segment and Datadog must receive different data per their purposes."""
+    """Segment and Datadog receive differently sanitized analytics data."""
 
     @pytest.mark.usefixtures("_enable_analytics")
-    def test_segment_gets_params_datadog_does_not(self):
+    def test_segment_gets_raw_params_datadog_gets_sanitized_params(self):
         from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 
         viewer = _mock_viewer()
         dd_fwd = get_datadog_forwarder()
-        params = {"entity_name": "wandb-smle", "project_name": "email-agent", "limit": 10}
+        params = {
+            "entity_name": "wandb-smle",
+            "project_name": "email-agent",
+            "limit": 10,
+            "query": "query { viewer { username } }",
+        }
 
         with patch.object(dd_fwd, "_post"):
             with track_tool_execution("query_traces", viewer, params):
@@ -259,10 +264,13 @@ class TestDataSeparation:
         seg = get_segment_forwarder().get_forwarded_payloads()[0]
         assert "params" in seg["properties"]
         assert seg["properties"]["params"]["entity_name"] == "wandb-smle"
+        assert seg["properties"]["params"]["query"] == "query { viewer { username } }"
 
         dd = dd_fwd.get_forwarded_payloads()[0]
-        assert "params" not in dd["attributes"]
-        assert "wandb-smle" not in str(dd["attributes"])
+        assert dd["attributes"]["params"]["entity_name"] == "wandb-smle"
+        assert dd["attributes"]["params"]["project_name"] == "email-agent"
+        assert dd["attributes"]["params"]["limit"] == 10
+        assert dd["attributes"]["params"]["query"] == "<redacted: text len=29>"
 
     @pytest.mark.usefixtures("_enable_analytics")
     def test_datadog_has_structured_severity_segment_does_not(self):

--- a/tests/test_analytics_segment.py
+++ b/tests/test_analytics_segment.py
@@ -53,6 +53,12 @@ class TestMapToSegmentTrack:
             "tool_call",
             session_id="s1",
             tool_name="query_wandb_gql",
+            mcp_tool_name="query_wandb_tool",
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+            environment="production",
+            hosted_mode=True,
             params={"entity": "team"},
             success=True,
         )
@@ -61,6 +67,12 @@ class TestMapToSegmentTrack:
         assert result["userId"] == "alice"
         assert result["event"] == f"{SEGMENT_EVENT_PREFIX}.tool_call"
         assert result["properties"]["tool_name"] == "query_wandb_gql"
+        assert result["properties"]["mcp_tool_name"] == "query_wandb_tool"
+        assert result["properties"]["runtime_surface"] == "cloud_run"
+        assert result["properties"]["transport"] == "http"
+        assert result["properties"]["deployment_type"] == "hosted"
+        assert result["properties"]["environment"] == "production"
+        assert result["properties"]["hosted_mode"] is True
         assert result["properties"]["source"] == "wandb-mcp-server"
         assert result["properties"]["schema_version"] == "1.0"
 
@@ -76,10 +88,16 @@ class TestMapToSegmentTrack:
             session_id="sess",
             email_domain="wandb.com",
             api_key_hash="abcd1234",
+            runtime_surface="local_stdio",
+            transport="stdio",
+            deployment_type="local",
         )
         result = map_to_segment_track(event)
         assert result["event"] == f"{SEGMENT_EVENT_PREFIX}.session_start"
         assert result["properties"]["email_domain"] == "wandb.com"
+        assert result["properties"]["runtime_surface"] == "local_stdio"
+        assert result["properties"]["transport"] == "stdio"
+        assert result["properties"]["deployment_type"] == "local"
 
     def test_request_basic(self):
         event = self._make_event(

--- a/tests/test_create_report_panels.py
+++ b/tests/test_create_report_panels.py
@@ -1,13 +1,17 @@
 """Tests for the panels parameter on create_wandb_report_tool."""
 
+import importlib
 from unittest.mock import MagicMock, patch
 
 
 from wandb_mcp_server.mcp_tools.create_report import (
     CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
+    _build_layout_blocks,
     _build_panel_blocks,
     create_report,
 )
+
+create_report_module = importlib.import_module("wandb_mcp_server.mcp_tools.create_report")
 
 
 class TestCreateReportPanelsDescription:
@@ -60,12 +64,12 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert len(blocks) == 1
-        assert mock_wr.Runset.call_count == 2
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name in ["r1", "r2"]')
         mock_wr.LinePlot.assert_called_once()
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
-    def test_analysis_run_id_uses_query_not_filters(self, mock_wr):
-        """Runset for analysis_run_id must use query= to avoid ast.Dict crash."""
+    def test_analysis_run_id_uses_deterministic_filter(self, mock_wr):
+        """Runset for analysis_run_id uses persisted Reports v2 filters."""
         mock_wr.PanelGrid = MagicMock()
         mock_wr.BarPlot = MagicMock()
         mock_wr.Runset = MagicMock()
@@ -74,12 +78,12 @@ class TestBuildPanelBlocks:
         _build_panel_blocks(panels, "entity", "project")
 
         runset_call = mock_wr.Runset.call_args
-        assert runset_call[1].get("query") == "abc123"
-        assert "filters" not in runset_call[1]
+        assert runset_call[1].get("filters") == 'name == "abc123"'
+        assert "query" not in runset_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
-    def test_run_comparison_uses_query_not_filters(self, mock_wr):
-        """run_comparison with run_ids must use query= to avoid ast.Dict crash."""
+    def test_run_comparison_uses_deterministic_filter(self, mock_wr):
+        """run_comparison with run_ids uses a deterministic Reports v2 filter."""
         mock_wr.PanelGrid = MagicMock()
         mock_wr.LinePlot = MagicMock()
         mock_wr.Runset = MagicMock()
@@ -87,9 +91,9 @@ class TestBuildPanelBlocks:
         panels = [{"type": "run_comparison", "metrics": ["loss"], "run_ids": ["r1", "r2"], "title": "Compare"}]
         _build_panel_blocks(panels, "entity", "project")
 
-        comp_call = mock_wr.Runset.call_args_list[1]
-        assert comp_call[1].get("query") == "r1 r2"
-        assert "filters" not in comp_call[1]
+        comp_call = mock_wr.Runset.call_args
+        assert comp_call[1].get("filters") == 'name in ["r1", "r2"]'
+        assert "query" not in comp_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_empty_panels_list(self, mock_wr):
@@ -182,7 +186,7 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert len(blocks) == 1
-        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", query="abc123")
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name == "abc123"')
         mock_wr.CustomChart.assert_called_once_with(
             query={"summaryTable": {"tableKey": "pr_curve_table"}},
             chart_name="wandb/line/v0",
@@ -252,6 +256,100 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert blocks == ["markdown", "grid:line", "grid:custom"]
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_explicit_filters_win_over_run_ids(self, mock_wr):
+        mock_wr.PanelGrid = MagicMock()
+        mock_wr.LinePlot = MagicMock()
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        panels = [
+            {
+                "type": "line",
+                "x": "_step",
+                "y": ["loss"],
+                "title": "Loss",
+                "run_ids": ["ignored"],
+                "filters": 'displayName == "Customer Run"',
+            }
+        ]
+
+        _build_panel_blocks(panels, "entity", "project")
+
+        mock_wr.Runset.assert_called_once_with(
+            entity="entity",
+            project="project",
+            filters='displayName == "Customer Run"',
+        )
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_explicit_runset_query_is_search_passthrough(self, mock_wr):
+        mock_wr.PanelGrid = MagicMock()
+        mock_wr.LinePlot = MagicMock()
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        panels = [{"type": "line", "x": "_step", "y": ["loss"], "runset_query": "baseline"}]
+
+        _build_panel_blocks(panels, "entity", "project")
+
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", query="baseline")
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_panel_grid_groups_multiple_custom_charts(self, mock_wr):
+        mock_wr.H2 = MagicMock(side_effect=lambda text: f"H2:{text}")
+        mock_wr.P = MagicMock(side_effect=lambda text: f"P:{text}")
+        mock_wr.MarkdownBlock = MagicMock(side_effect=lambda text: f"Markdown:{text}")
+        mock_wr.PanelGrid = MagicMock(return_value="PanelGrid")
+        mock_wr.CustomChart = MagicMock(side_effect=lambda **kw: f"Custom:{kw['chart_strings']['title']}")
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        blocks = _build_layout_blocks(
+            [
+                {"type": "heading", "level": 2, "text": "Average precision by class"},
+                {"type": "markdown", "text": "These panels share the same filtered runset."},
+                {
+                    "type": "panel_grid",
+                    "run_ids": ["run_a", "run_b"],
+                    "panels": [
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "car_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "CAR AP"},
+                        },
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "truck_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "TRUCK AP"},
+                        },
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "motorcycle_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "MOTORCYCLE AP"},
+                        },
+                    ],
+                },
+            ],
+            "entity",
+            "project",
+        )
+
+        assert blocks == [
+            "H2:Average precision by class",
+            "P:These panels share the same filtered runset.",
+            "PanelGrid",
+        ]
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name in ["run_a", "run_b"]')
+        mock_wr.PanelGrid.assert_called_once_with(
+            runsets=["Runset"],
+            hide_run_sets=False,
+            panels=["Custom:CAR AP", "Custom:TRUCK AP", "Custom:MOTORCYCLE AP"],
+        )
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_markdown_table_with_unicode_titles(self, mock_wr):
@@ -373,3 +471,110 @@ class TestCreateReportWithPanels:
         assert "MCP Server" in str(blocks[0])
         assert "H2:Charts" in blocks
         assert blocks[-1] == "PanelGrid"
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    @patch("wandb_mcp_server.api_client.WandBApiManager")
+    def test_create_report_with_ordered_layout_does_not_add_charts_heading(self, mock_api_mgr, mock_wr):
+        mock_api_mgr.get_api_key.return_value = "fake_key"
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
+
+        mock_report = MagicMock()
+        mock_report.url = "https://wandb.ai/report/layout"
+        mock_wr.Report.return_value = mock_report
+        mock_wr.P = MagicMock(side_effect=lambda text: f"P:{text}")
+        mock_wr.H2 = MagicMock(side_effect=lambda text: f"H2:{text}")
+        mock_wr.MarkdownBlock = MagicMock(side_effect=lambda text: f"Markdown:{text}")
+        mock_wr.PanelGrid = MagicMock(side_effect=lambda **kw: "PanelGrid")
+        mock_wr.LinePlot = MagicMock(return_value="LinePlot")
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        create_report(
+            "entity",
+            "project",
+            "Layout Report",
+            markdown_report_text="Hello world",
+            panels=[
+                {"type": "heading", "level": 2, "text": "Section"},
+                {"type": "markdown", "text": "Section intro"},
+                {"type": "panel_grid", "run_ids": ["run_a"], "panels": [{"type": "line", "y": ["loss"]}]},
+            ],
+        )
+
+        blocks = mock_report.blocks
+        assert "H2:Charts" not in blocks
+        assert blocks[-3:] == ["H2:Section", "P:Section intro", "PanelGrid"]
+
+
+class TestRealWorkspacesReportObjects:
+    @patch("wandb_mcp_server.api_client.WandBApiManager")
+    def test_agent_style_layout_serializes_panel_grid_and_runset_filter(self, mock_api_mgr):
+        """Build the same report shape an agent should send and inspect Reports v2 objects."""
+        mock_api_mgr.get_api_key.return_value = "fake_key"
+        mock_api_mgr.get_api.return_value = MagicMock(viewer={"username": "test-user"})
+
+        fake_api = MagicMock()
+        fake_api.client.app_url = "https://wandb.ai"
+        fake_api.client.execute.return_value = {"project": {"internalId": "project-internal-id"}}
+        captured_reports = []
+
+        def fake_save(report, *args, **kwargs):
+            captured_reports.append(report)
+            report.id = "report-id"
+
+        with (
+            patch.object(create_report_module.wr.Report, "save", fake_save),
+            patch("wandb_workspaces.reports.v2.interface._get_api", return_value=fake_api),
+        ):
+            result = create_report(
+                "entity",
+                "project",
+                "Agent Report",
+                markdown_report_text="# Agent Report\n\n[TOC]",
+                panels=[
+                    {"type": "heading", "level": 2, "text": "Average precision by class"},
+                    {"type": "markdown", "text": "These panels share the same filtered runset."},
+                    {
+                        "type": "panel_grid",
+                        "run_ids": ["run_a", "run_b"],
+                        "hide_run_sets": False,
+                        "panels": [
+                            {
+                                "type": "custom_chart",
+                                "query": {"summaryTable": {"tableKey": "car_ap"}},
+                                "chart_name": "cruise/bar_chart/v2",
+                                "chart_fields": {"x": "threshold", "y": "ap"},
+                                "chart_strings": {"title": "CAR AP"},
+                            },
+                            {
+                                "type": "custom_chart",
+                                "query": {"summaryTable": {"tableKey": "truck_ap"}},
+                                "chart_name": "cruise/bar_chart/v2",
+                                "chart_fields": {"x": "threshold", "y": "ap"},
+                                "chart_strings": {"title": "TRUCK AP"},
+                            },
+                        ],
+                    },
+                ],
+            )
+            report_model = captured_reports[0]._to_model()
+
+        assert result["url"] == "https://wandb.ai/entity/project/reports/Agent-Report--report-id"
+        panel_grids = [block for block in report_model.spec.blocks if getattr(block, "type", None) == "panel-grid"]
+        assert len(panel_grids) == 1
+
+        panel_grid = panel_grids[0]
+        runset = panel_grid.metadata.run_sets[0]
+        assert runset.search.query == ""
+        filters = runset.filters.filters[0].filters
+        assert len(filters) == 1
+        assert filters[0].key.name == "name"
+        assert filters[0].op == "IN"
+        assert filters[0].value == ["run_a", "run_b"]
+
+        panels = panel_grid.metadata.panel_bank_section_config.panels
+        assert len(panels) == 2
+        assert [panel.config.panel_def_id for panel in panels] == [
+            "cruise/bar_chart/v2",
+            "cruise/bar_chart/v2",
+        ]
+        assert [panel.config.string_settings["title"] for panel in panels] == ["CAR AP", "TRUCK AP"]

--- a/tests/test_hosted_gql_guardrails.py
+++ b/tests/test_hosted_gql_guardrails.py
@@ -1,0 +1,212 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from graphql import parse
+from graphql.language.printer import print_ast
+
+import wandb_mcp_server.api_client as api_client
+import wandb_mcp_server.config as cfg
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+
+
+class DummyToolContext:
+    def __init__(self):
+        self.errors = []
+
+    def mark_error(self, error):
+        self.errors.append(error)
+
+
+class FakeClient:
+    def __init__(self, response=None):
+        self.response = response or {
+            "project": {
+                "runs": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        self.executions = []
+
+    def execute(self, document, variable_values=None):
+        self.executions.append((print_ast(document), dict(variable_values or {})))
+        return self.response
+
+
+class FakeApi:
+    def __init__(self, client):
+        self.client = client
+        self.viewer = SimpleNamespace(username="tester")
+
+
+def _install_fake_api(monkeypatch, client):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
+    monkeypatch.setattr(gql_tool, "gql", parse)
+
+    @contextmanager
+    def fake_track_tool_execution(*args, **kwargs):
+        yield DummyToolContext()
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_track_tool_execution)
+
+
+def _run_query():
+    return """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 100000) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+
+def test_hosted_literal_first_is_rewritten_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        _run_query(),
+        variables={"entity": "e", "project": "p"},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "first: 50" in executed_query
+    assert "100000" not in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result
+
+
+def test_hosted_limit_variable_is_clamped_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!, $first: Int) {
+      project(name: $project, entityName: $entity) {
+        runs(first: $first) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p", "first": 100000},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    assert client.executions[0][1]["first"] == 50
+
+
+def test_hosted_multi_connection_query_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Multi($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+        sweeps(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert client.executions == []
+
+
+def test_hosted_nested_connection_query_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Nested($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              loggedArtifacts(first: 10) {
+                edges { node { id } }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert "Nested paginated collection" in result["errors"][0]["details"][0]
+    assert client.executions == []
+
+
+def test_hosted_last_pagination_is_rejected_before_execute(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(last: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "e", "project": "p"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert client.executions == []
+
+
+def test_non_hosted_query_passes_literal_first_unchanged(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", False)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    gql_tool.query_paginated_wandb_gql(
+        _run_query(),
+        variables={"entity": "e", "project": "p"},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "first: 100000" in executed_query
+    assert variables["limit"] == 100

--- a/tests/test_hosted_gql_production_errors.py
+++ b/tests/test_hosted_gql_production_errors.py
@@ -1,0 +1,263 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from graphql import parse
+from graphql.language.printer import print_ast
+
+import wandb_mcp_server.api_client as api_client
+import wandb_mcp_server.config as cfg
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+
+
+class DummyToolContext:
+    def __init__(self):
+        self.errors = []
+
+    def mark_error(self, error):
+        self.errors.append(error)
+
+
+class FakeClient:
+    def __init__(self, response=None):
+        self.response = response or {
+            "project": {
+                "runs": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        self.executions = []
+
+    def execute(self, document, variable_values=None):
+        self.executions.append((print_ast(document), dict(variable_values or {})))
+        return self.response
+
+
+class FakeApi:
+    def __init__(self, client):
+        self.client = client
+        self.viewer = SimpleNamespace(username="tester")
+
+
+def _install_fake_api(monkeypatch, client):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
+    monkeypatch.setattr(gql_tool, "gql", parse)
+
+    @contextmanager
+    def fake_track_tool_execution(*args, **kwargs):
+        yield DummyToolContext()
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_track_tool_execution)
+
+
+def _enable_hosted(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS", 100)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+
+
+def test_malformed_natural_language_query_fails_before_execute(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        "Show the latest runs in this project with summary metrics",
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    assert "Failed to validate initial query" in result["errors"][0]["message"]
+    assert client.executions == []
+
+
+def test_scalar_selection_error_is_not_rewritten(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Field "tags" must not have a selection since type "[String!]" has no subfields.'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              tags { name }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "tags {" in executed_query
+    assert "first: 10" in executed_query
+    assert result == upstream_error
+
+
+def test_sampled_history_scalar_error_is_not_rewritten(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Field "sampledHistory" must not have a selection since type "[JSON!]!" has no subfields.'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              sampledHistory { step }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "sampledHistory {" in executed_query
+    assert "first: 10" in executed_query
+    assert result == upstream_error
+
+
+def test_ambiguous_connection_without_first_is_rejected_before_execute(
+    monkeypatch,
+):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query ProjectViews($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        views {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert "must include a first argument" in result["errors"][0]["message"]
+    assert client.executions == []
+
+
+def test_existing_first_on_ambiguous_connection_is_not_changed(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Unknown argument "first" on field "views" of type "Project".'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query ProjectViews($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        views(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "views(first: 10)" in executed_query
+    assert result == upstream_error
+
+
+def test_valid_run_query_still_clamps_literal_first(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 100000) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+        max_items=500,
+        items_per_page=500,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "runs(first: 50)" in executed_query
+    assert "100000" not in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result
+
+
+def test_variable_default_first_is_clamped_before_execute(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!, $first: Int = 100000) {
+      project(name: $project, entityName: $entity) {
+        runs(first: $first) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+        max_items=500,
+        items_per_page=500,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "$first: Int = 50" in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result

--- a/tests/test_hosted_runtime_guardrails.py
+++ b/tests/test_hosted_runtime_guardrails.py
@@ -1,0 +1,223 @@
+import json
+import time
+
+import pytest
+
+import wandb_mcp_server.config as cfg
+import wandb_mcp_server.server as server
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.weave_api.models import QueryResult, TraceMetadata
+from wandb_mcp_server.weave_api.service import TraceService
+
+
+class FakeMCP:
+    """Capture FastMCP-decorated tool functions."""
+
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, description=None):
+        def decorator(func):
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+
+def _registered_tools(monkeypatch):
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    fake = FakeMCP()
+    server.register_tools(fake)
+    return fake.tools
+
+
+def _empty_query_result():
+    return QueryResult(metadata=TraceMetadata(total_traces=0), traces=[])
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_over_hosted_limit_is_rejected(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    called = False
+
+    async def fake_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", limit=101, metadata_only=True))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["max_limit"] == 100
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_hosted_omitted_limit_defaults_to_query_cap(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    seen_kwargs = {}
+
+    async def fake_query(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    async def no_count(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(server, "_count_traces_or_none", no_count)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", metadata_only=True))
+
+    assert "error" not in result
+    assert seen_kwargs["target_limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_full_trace_hosted_limit_uses_full_cap(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_FULL_TRACE_LIMIT", 25)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", detail_level="full", limit=26))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["max_limit"] == 25
+
+
+@pytest.mark.parametrize("sort_by", ["total_cost", "completion_cost", "prompt_cost"])
+@pytest.mark.asyncio
+async def test_cost_sort_rejected_in_hosted_mode(monkeypatch, sort_by):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    called = False
+
+    async def fake_query(*args, **kwargs):
+        nonlocal called
+        called = True
+        return _empty_query_result()
+
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project", sort_by=sort_by, limit=10))
+
+    assert result["error"] == "quota_exceeded"
+    assert result["sort_by"] == sort_by
+    assert called is False
+
+
+def test_service_rejects_direct_hosted_over_limit(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+
+    service = TraceService(api_key="test-key")
+
+    with pytest.raises(cfg.HostedLimitExceeded):
+        service.query_paginated_traces("entity", "project", target_limit=101)
+
+
+def test_service_defaults_direct_hosted_limit(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 3)
+
+    service = TraceService(api_key="test-key")
+    calls = []
+
+    def fake_query(request_body):
+        calls.append(request_body)
+        for i in range(5):
+            yield {
+                "id": f"call-{i}",
+                "project_id": "entity/project",
+                "op_name": "op",
+                "trace_id": f"trace-{i}",
+                "started_at": "2026-01-01T00:00:00Z",
+            }
+
+    monkeypatch.setattr(service.client, "query_traces", fake_query)
+
+    result = service.query_paginated_traces("entity", "project", target_limit=None, chunk_size=10)
+
+    assert len(result.traces) == 3
+    assert calls[0]["limit"] == 3
+
+
+def test_service_rejects_direct_hosted_cost_sort(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+
+    service = TraceService(api_key="test-key")
+
+    with pytest.raises(cfg.HostedLimitExceeded):
+        service._query_for_cost_sorting("entity", "project", sort_by="total_cost")
+
+
+@pytest.mark.asyncio
+async def test_count_tool_timeout_returns_within_deadline(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+
+    def slow_count(*args, **kwargs):
+        time.sleep(3)
+        return 1
+
+    monkeypatch.setattr(server, "count_traces", slow_count)
+
+    tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+    start = time.monotonic()
+    result = json.loads(await tool("entity", "project"))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.5
+    assert result["error"] == "timeout"
+    assert result["timeout_seconds"] == 1
+
+
+@pytest.mark.asyncio
+async def test_count_tool_passes_bounded_request_timeout(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 3)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    request_timeouts = []
+
+    def capture_count(*args, **kwargs):
+        request_timeouts.append(kwargs["request_timeout"])
+        return 2
+
+    monkeypatch.setattr(server, "count_traces", capture_count)
+
+    tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+    result = json.loads(await tool("entity", "project"))
+
+    assert result == {"total_count": 2, "root_traces_count": 2}
+    assert request_timeouts == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_trace_query_preflight_timeout_does_not_block_main_query(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 1)
+
+    def slow_count(*args, **kwargs):
+        time.sleep(3)
+        return 10
+
+    async def fake_query(*args, **kwargs):
+        return QueryResult(metadata=TraceMetadata(total_traces=1), traces=[])
+
+    monkeypatch.setattr(server, "count_traces", slow_count)
+    monkeypatch.setattr(server, "query_paginated_weave_traces", fake_query)
+
+    tool = _registered_tools(monkeypatch)["query_weave_traces_tool"]
+    start = time.monotonic()
+    result = json.loads(await tool("entity", "project", limit=100))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 3
+    assert "error" not in result

--- a/tests/test_hosted_runtime_guardrails.py
+++ b/tests/test_hosted_runtime_guardrails.py
@@ -199,6 +199,31 @@ async def test_count_tool_passes_bounded_request_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_count_tool_preserves_session_context_in_executor(monkeypatch):
+    from wandb_mcp_server.session_manager import current_session_id
+
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 3)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    observed_session_ids = []
+
+    def capture_count(*args, **kwargs):
+        observed_session_ids.append(current_session_id.get())
+        return 2
+
+    monkeypatch.setattr(server, "count_traces", capture_count)
+
+    token = current_session_id.set("sess_test")
+    try:
+        tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+        result = json.loads(await tool("entity", "project"))
+    finally:
+        current_session_id.reset(token)
+
+    assert result == {"total_count": 2, "root_traces_count": 2}
+    assert observed_session_ids == ["sess_test", "sess_test"]
+
+
+@pytest.mark.asyncio
 async def test_trace_query_preflight_timeout_does_not_block_main_query(monkeypatch):
     monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
     monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)

--- a/tests/test_report_improvements.py
+++ b/tests/test_report_improvements.py
@@ -123,8 +123,8 @@ class TestAnalysisRunId:
 
         assert len(blocks) == 1
         runset_call = mock_wr.Runset.call_args
-        assert runset_call[1]["query"] == "abc123"
-        assert "filters" not in runset_call[1]
+        assert runset_call[1]["filters"] == 'name == "abc123"'
+        assert "query" not in runset_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_no_analysis_run_id_uses_default_runset(self, mock_wr):
@@ -161,5 +161,5 @@ class TestRunComparisonFix:
 
         assert len(blocks) == 1
         filtered_runset_call = mock_wr.Runset.call_args_list[-1]
-        assert filtered_runset_call[1]["query"] == "r1 r2"
-        assert "filters" not in filtered_runset_call[1]
+        assert filtered_runset_call[1]["filters"] == 'name in ["r1", "r2"]'
+        assert "query" not in filtered_runset_call[1]

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+import simple_parsing
+
+from wandb_mcp_server import analytics
+from wandb_mcp_server import server
+
+
+class _DummyMCPServer:
+    def __init__(self):
+        self.run_transport = None
+
+    def run(self, transport):
+        self.run_transport = transport
+
+
+def test_cli_configures_analytics_for_stdio_transport(monkeypatch):
+    calls = []
+    dummy_server = _DummyMCPServer()
+
+    monkeypatch.setattr(
+        simple_parsing,
+        "parse",
+        lambda _: SimpleNamespace(
+            transport="stdio",
+            host="localhost",
+            port=None,
+            wandb_api_key=None,
+        ),
+    )
+    monkeypatch.setattr(
+        analytics,
+        "configure_analytics_logging_for_transport",
+        lambda transport: calls.append(transport) or "stderr",
+    )
+    monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
+    monkeypatch.setattr(server, "validate_and_get_api_key", lambda args: None)
+    monkeypatch.setattr(server, "initialize_weave_tracing", lambda: False)
+    monkeypatch.setattr(server, "create_mcp_server", lambda *args: dummy_server)
+
+    server.cli()
+
+    assert calls == ["stdio"]
+    assert dummy_server.run_transport == "stdio"

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,0 +1,56 @@
+import importlib
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from wandb_mcp_server.server import register_tools
+
+
+WEAVE_TOOLS = {
+    "query_weave_traces_tool",
+    "count_weave_traces_tool",
+    "resolve_trace_roots_tool",
+    "infer_trace_schema_tool",
+    "summarize_evaluation_tool",
+}
+
+NON_WEAVE_TOOLS = {
+    "query_wandb_tool",
+    "create_wandb_report_tool",
+    "get_run_history_tool",
+    "list_artifact_versions_tool",
+    "compare_runs_tool",
+    "probe_project_tool",
+}
+
+
+def _registered_tool_names() -> set[str]:
+    mcp = FastMCP("test")
+    register_tools(mcp)
+    return set(mcp._tool_manager._tools)
+
+
+def test_weave_tools_registered_by_default():
+    os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+    import wandb_mcp_server.config as cfg
+
+    importlib.reload(cfg)
+    names = _registered_tool_names()
+
+    assert WEAVE_TOOLS.issubset(names)
+    assert NON_WEAVE_TOOLS.issubset(names)
+
+
+def test_weave_tools_can_be_disabled():
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = "false"
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+        importlib.reload(cfg)
+
+    assert WEAVE_TOOLS.isdisjoint(names)
+    assert NON_WEAVE_TOOLS.issubset(names)

--- a/uv.lock
+++ b/uv.lock
@@ -2144,7 +2144,7 @@ wheels = [
 
 [[package]]
 name = "wandb-mcp-server"
-version = "0.3.3"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -2195,7 +2195,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
     { name = "wandb", specifier = ">=0.25.1" },
-    { name = "wandb-workspaces", specifier = ">=0.1.12" },
+    { name = "wandb-workspaces", specifier = ">=0.3.9" },
     { name = "weave", specifier = ">=0.52.35" },
 ]
 provides-extras = ["test", "http"]
@@ -2208,15 +2208,15 @@ dev = [
 
 [[package]]
 name = "wandb-workspaces"
-version = "0.1.18"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/2c/dc9a134b7383b7555ebb2da2894f0d4c8ebee8e3bf944601f3122e8b4def/wandb_workspaces-0.1.18.tar.gz", hash = "sha256:3fcbfa391fd4d469dcf091ea897a8ed39c2688806a307d56df721e2f1689a337", size = 77294, upload-time = "2025-09-05T15:18:26.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/d3/3a5ebc8b969ec8d2391bb43e4a3d76ceaee2bfc11c9e9dc96b61577a9092/wandb_workspaces-0.3.9.tar.gz", hash = "sha256:d186faa7b0c4e6c33aecfea833e81ca0256d117b26f7e428f002c14cbf30601c", size = 210169, upload-time = "2026-03-31T15:23:20.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/75/14f5eb4ff53a6732637f000e7e6c14e055b0d69a9636689502d13a13b302/wandb_workspaces-0.1.18-py3-none-any.whl", hash = "sha256:ab4134cc7c0e33daf4dd70b67848a05bcd1ee21bad924b943edc8303fe789bdc", size = 87843, upload-time = "2025-09-05T15:18:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/112522e555b1fef7129e85065348d20dcb8761171b07614b5d3e95f86759/wandb_workspaces-0.3.9-py3-none-any.whl", hash = "sha256:79fbb9e899e5457f18446fd6a8c066a05709562ad9fe31b3d215ca4749a65f25", size = 100710, upload-time = "2026-03-31T15:23:18.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds hosted-mode noisy-neighbor guardrails for trace limits, cost sorting, count timeouts, and GraphQL pagination shape.
- Adds `WANDB_MCP_ENABLE_WEAVE_TOOLS` so deployments without Weave Trace can hide trace tools while keeping W&B Models/report/docs tools.
- Bumps the package metadata to `0.3.5`.

## Jira
- [WB-34823](https://coreweave.atlassian.net/browse/WB-34823): Hosted analytics and Dedicated observability.
- [WB-34824](https://coreweave.atlassian.net/browse/WB-34824): Weave-tool gating for deployments without trace.
- [WB-34054](https://coreweave.atlassian.net/browse/WB-34054): Client compatibility and stdio logging fixes.

## Test plan
- Runtime guardrail tests passed on PR #79.
- GraphQL hosted preflight tests passed on PR #80.
- Weave tool registration tests passed on PR #81.
- Package version consistency validated on PR #82.

Made with [Cursor](https://cursor.com)

[WB-34823]: https://coreweave.atlassian.net/browse/WB-34823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-34824]: https://coreweave.atlassian.net/browse/WB-34824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-34054]: https://coreweave.atlassian.net/browse/WB-34054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ