### PR TITLE
fix(hosted): harden GraphQL preflight for production query shapes

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -557,6 +557,21 @@ class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
         self.rewrites: list[str] = []
         self.rejections: list[str] = []
 
+    def enter_variable_definition(self, node, key, parent, path, ancestors):
+        if not isinstance(node, gql_ast.VariableDefinitionNode):
+            return
+        if not _HOSTED_LIMIT_VARIABLE_RE.match(node.variable.name.value):
+            return
+        if not isinstance(node.default_value, gql_ast.IntValueNode):
+            return
+
+        requested = int(node.default_value.value)
+        if requested <= self.max_first:
+            return
+
+        node.default_value = gql_ast.IntValueNode(value=str(self.max_first))
+        self.rewrites.append(f"Clamped ${node.variable.name.value} default from {requested} to {self.max_first}")
+
     def enter_field(self, node, key, parent, path, ancestors):
         if not isinstance(node, gql_ast.FieldNode):
             return
@@ -597,13 +612,10 @@ class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
                     self.rewrites.append(f"Clamped {'/'.join(current_path)} first from {requested} to {self.max_first}")
 
         if not has_first:
-            existing_args.append(
-                gql_ast.ArgumentNode(
-                    name=gql_ast.NameNode(value="first"),
-                    value=gql_ast.IntValueNode(value=str(self.max_first)),
-                )
+            self.rejections.append(
+                "Hosted GraphQL paginated collections must include a first argument so the initial request "
+                f"can be bounded: {'/'.join(current_path)}"
             )
-            self.rewrites.append(f"Added first={self.max_first} to {'/'.join(current_path)}")
 
         node.arguments = tuple(existing_args)
         self.connection_depth += 1

--- a/tests/test_hosted_gql_production_errors.py
+++ b/tests/test_hosted_gql_production_errors.py
@@ -1,0 +1,263 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from graphql import parse
+from graphql.language.printer import print_ast
+
+import wandb_mcp_server.api_client as api_client
+import wandb_mcp_server.config as cfg
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+
+
+class DummyToolContext:
+    def __init__(self):
+        self.errors = []
+
+    def mark_error(self, error):
+        self.errors.append(error)
+
+
+class FakeClient:
+    def __init__(self, response=None):
+        self.response = response or {
+            "project": {
+                "runs": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        self.executions = []
+
+    def execute(self, document, variable_values=None):
+        self.executions.append((print_ast(document), dict(variable_values or {})))
+        return self.response
+
+
+class FakeApi:
+    def __init__(self, client):
+        self.client = client
+        self.viewer = SimpleNamespace(username="tester")
+
+
+def _install_fake_api(monkeypatch, client):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
+    monkeypatch.setattr(gql_tool, "gql", parse)
+
+    @contextmanager
+    def fake_track_tool_execution(*args, **kwargs):
+        yield DummyToolContext()
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_track_tool_execution)
+
+
+def _enable_hosted(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS", 100)
+    monkeypatch.setattr(cfg, "MCP_MAX_GQL_ITEMS_PER_PAGE", 50)
+
+
+def test_malformed_natural_language_query_fails_before_execute(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        "Show the latest runs in this project with summary metrics",
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    assert "Failed to validate initial query" in result["errors"][0]["message"]
+    assert client.executions == []
+
+
+def test_scalar_selection_error_is_not_rewritten(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Field "tags" must not have a selection since type "[String!]" has no subfields.'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              tags { name }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "tags {" in executed_query
+    assert "first: 10" in executed_query
+    assert result == upstream_error
+
+
+def test_sampled_history_scalar_error_is_not_rewritten(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Field "sampledHistory" must not have a selection since type "[JSON!]!" has no subfields.'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 10) {
+          edges {
+            node {
+              id
+              sampledHistory { step }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "sampledHistory {" in executed_query
+    assert "first: 10" in executed_query
+    assert result == upstream_error
+
+
+def test_ambiguous_connection_without_first_is_rejected_before_execute(
+    monkeypatch,
+):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query ProjectViews($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        views {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert "must include a first argument" in result["errors"][0]["message"]
+    assert client.executions == []
+
+
+def test_existing_first_on_ambiguous_connection_is_not_changed(monkeypatch):
+    _enable_hosted(monkeypatch)
+    upstream_error = {
+        "errors": [
+            {
+                "message": ('Unknown argument "first" on field "views" of type "Project".'),
+            }
+        ]
+    }
+    client = FakeClient(response=upstream_error)
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query ProjectViews($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        views(first: 10) {
+          edges { node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+    )
+
+    executed_query, _ = client.executions[0]
+    assert "views(first: 10)" in executed_query
+    assert result == upstream_error
+
+
+def test_valid_run_query_still_clamps_literal_first(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) {
+        runs(first: 100000) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+        max_items=500,
+        items_per_page=500,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "runs(first: 50)" in executed_query
+    assert "100000" not in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result
+
+
+def test_variable_default_first_is_clamped_before_execute(monkeypatch):
+    _enable_hosted(monkeypatch)
+    client = FakeClient()
+    _install_fake_api(monkeypatch, client)
+    query = """
+    query Runs($entity: String!, $project: String!, $first: Int = 100000) {
+      project(name: $project, entityName: $entity) {
+        runs(first: $first) {
+          edges { node { id name } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        variables={"entity": "entity", "project": "project"},
+        max_items=500,
+        items_per_page=500,
+    )
+
+    executed_query, variables = client.executions[0]
+    assert "$first: Int = 50" in executed_query
+    assert variables["limit"] == 50
+    assert "errors" not in result


### PR DESCRIPTION
## Summary
- Stop hosted GraphQL preflight from inventing `first` on connection-shaped fields that omitted it, avoiding new `Unknown argument "first"` failures for ambiguous production query shapes.
- Clamp limit-shaped GraphQL variable defaults before the first upstream execute.
- Add Datadog-derived production replay tests covering malformed input, scalar selection mistakes, ambiguous connections, and valid hosted clamping.

## Test plan
- `uv run --no-sync pytest tests/test_hosted_gql_guardrails.py tests/test_hosted_gql_production_errors.py -v --tb=short`
- `uv run --no-sync pytest tests/test_hosted_gql_guardrails.py tests/test_hosted_gql_production_errors.py tests/test_hosted_runtime_guardrails.py tests/test_tool_registration.py -v --tb=short`
- `uv run --no-sync pytest tests/ -v --tb=short`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`

## Release note
This should land into `staging/0.3.5` before release PR #83 merges to `main`.

Made with [Cursor](https://cursor.com)