### PR TITLE
fix(stdio): keep analytics off stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ When running the server locally, you can customize its behavior with command lin
 | `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
+| `MCP_ANALYTICS_DISABLED` | Disable structured MCP analytics events. Useful as a workaround for older stdio builds that wrote analytics to stdout. | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 
 #### Usage Examples
@@ -521,6 +522,13 @@ uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 # Or with API key as argument
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server --wandb_api_key your-api-key
 ```
+
+For stdio clients such as Claude Desktop, stdout is reserved for MCP JSON-RPC
+messages. The server routes logs and analytics to stderr in stdio mode so
+desktop clients do not parse diagnostics as protocol messages. If you are using
+an older version and see JSON-RPC parse warnings containing analytics fields
+such as `schema_version` or `event_type`, set `MCP_ANALYTICS_DISABLED=true` as
+a workaround.
 
 **HTTP Transport (for testing and development):**
 ```bash

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -123,15 +123,23 @@ It already uses its own `_StructuredJsonFormatter` ([`src/wandb_mcp_server/analy
 whose schema downstream GCP Cloud Logging -> BigQuery pipelines depend on. Touching
 it would silently break analytics ingestion.
 
+For MCP stdio transport, stdout is the JSON-RPC wire. The CLI reconfigures
+`wandb_mcp_server.analytics` to write structured analytics to stderr in stdio
+mode, while HTTP/container deployments keep stdout for Cloud Logging ingestion.
+If an older stdio build writes analytics JSON to stdout, set
+`MCP_ANALYTICS_DISABLED=true` to suppress analytics as a workaround.
+
 ### Defensive analytics propagation lock
 
 `analytics.py` sets `analytics_logger.propagate = False` at module import time so that
 the analytics record is emitted only by its own `_StructuredJsonFormatter` handler
-(stdout) and never reaches the root logger. However, when the server boots under
+and never reaches the root logger. In HTTP/container deployments this handler
+writes to stdout for Cloud Logging; in stdio deployments it writes to stderr so
+stdout remains pure MCP JSON-RPC. However, when the server boots under
 `uvicorn`, `logging.config.dictConfig` can reset propagation on existing loggers,
 silently re-enabling propagation. In that case every analytics event is emitted
-twice: once via the rich `_StructuredJsonFormatter` payload on stdout, and a
-minimal duplicate via the root `_JsonLogFormatter` on stderr.
+twice: once via the rich `_StructuredJsonFormatter` payload on the analytics
+stream, and a minimal duplicate via the root `_JsonLogFormatter` on stderr.
 
 To prevent this, `configure_process_logging()` re-asserts
 `logging.getLogger("wandb_mcp_server.analytics").propagate = False` after the
@@ -174,7 +182,7 @@ to BigQuery for product analytics. That pipeline depends on plaintext
 preserves this byte-for-byte.
 
 Customer K8s installs do NOT feed W&B's BigQuery; their analytics logger goes
-to stdout for the local Datadog Agent to collect into the customer's own
+to the container log stream for the local Datadog Agent to collect into the customer's own
 Datadog tenant. There's no business need to retain plaintext free-text
 params there, and redaction reduces legal exposure if customer logs are
 subpoenaed, exported, or retained longer than needed. `standard` is the safe

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -182,9 +182,62 @@ analytics_logger = logging.getLogger("wandb_mcp_server.analytics")
 analytics_logger.setLevel(logging.INFO)
 analytics_logger.propagate = False
 
-_handler = logging.StreamHandler(sys.stdout)
-_handler.setFormatter(_StructuredJsonFormatter())
-analytics_logger.addHandler(_handler)
+_ANALYTICS_STREAM_STDOUT = "stdout"
+_ANALYTICS_STREAM_STDERR = "stderr"
+_VALID_ANALYTICS_STREAMS = frozenset({_ANALYTICS_STREAM_STDOUT, _ANALYTICS_STREAM_STDERR})
+
+
+def _resolve_analytics_stream_name(stream: Optional[str] = None) -> str:
+    """Resolve the structured analytics log stream name."""
+    raw = stream or os.environ.get("MCP_ANALYTICS_LOG_STREAM", _ANALYTICS_STREAM_STDOUT)
+    stream_name = raw.strip().lower()
+    if stream_name in _VALID_ANALYTICS_STREAMS:
+        return stream_name
+
+    logger.warning(
+        "MCP_ANALYTICS_LOG_STREAM=%r is not one of %s; falling back to stdout.",
+        raw,
+        sorted(_VALID_ANALYTICS_STREAMS),
+    )
+    return _ANALYTICS_STREAM_STDOUT
+
+
+def configure_analytics_logging(stream: Optional[str] = None) -> str:
+    """Configure the structured analytics logger stream.
+
+    HTTP/container deployments keep stdout so Cloud Logging can parse analytics
+    JSON. Stdio transport must use stderr because stdout is the MCP JSON-RPC
+    wire and any non-protocol line corrupts clients like Claude Desktop.
+
+    Args:
+        stream: Optional explicit stream name, "stdout" or "stderr". If omitted,
+            MCP_ANALYTICS_LOG_STREAM is honored, then stdout is used.
+
+    Returns:
+        The resolved stream name.
+    """
+    stream_name = _resolve_analytics_stream_name(stream)
+    target_stream = sys.stderr if stream_name == _ANALYTICS_STREAM_STDERR else sys.stdout
+
+    analytics_logger.handlers.clear()
+    handler = logging.StreamHandler(target_stream)
+    handler.setFormatter(_StructuredJsonFormatter())
+    analytics_logger.addHandler(handler)
+    analytics_logger.setLevel(logging.INFO)
+    analytics_logger.propagate = False
+    return stream_name
+
+
+def configure_analytics_logging_for_transport(transport: str) -> str:
+    """Configure analytics output for an MCP transport."""
+    if os.environ.get("MCP_ANALYTICS_LOG_STREAM"):
+        return configure_analytics_logging()
+    if transport == "stdio":
+        return configure_analytics_logging(_ANALYTICS_STREAM_STDERR)
+    return configure_analytics_logging(_ANALYTICS_STREAM_STDOUT)
+
+
+configure_analytics_logging()
 
 _REQUIRED_BASE_FIELDS = frozenset({"schema_version", "event_type", "timestamp"})
 

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -1084,6 +1084,10 @@ def cli():
 
     args = simple_parsing.parse(ServerMCPArgs)
 
+    from wandb_mcp_server.analytics import configure_analytics_logging_for_transport
+
+    configure_analytics_logging_for_transport(args.transport)
+
     # Configure W&B logging behavior
     configure_wandb_logging()
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -4,6 +4,8 @@ Rewritten from Nico's PR #2 with improved datetime handling and
 cleaner param sanitisation.
 """
 
+import io
+import json
 import logging
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
@@ -14,6 +16,9 @@ import pytest
 from wandb_mcp_server.analytics import (
     SCHEMA_VERSION,
     AnalyticsTracker,
+    analytics_logger,
+    configure_analytics_logging,
+    configure_analytics_logging_for_transport,
     get_analytics_tracker,
     reset_analytics_tracker,
 )
@@ -22,8 +27,10 @@ from wandb_mcp_server.analytics import (
 @pytest.fixture(autouse=True)
 def _reset():
     reset_analytics_tracker()
+    configure_analytics_logging("stdout")
     yield
     reset_analytics_tracker()
+    configure_analytics_logging("stdout")
 
 
 class _EventCapture(logging.Filter):
@@ -69,6 +76,113 @@ class TestEnableDisable:
     @patch.dict("os.environ", {"MCP_ANALYTICS_DISABLED": "false"})
     def test_env_false_keeps_enabled(self):
         assert AnalyticsTracker(enabled=True).enabled is True
+
+
+# -- Analytics log stream ----------------------------------------------------
+
+
+class TestAnalyticsLogStream:
+    def test_configure_analytics_logging_uses_stdout(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging("stdout") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+            duration_ms=1.0,
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_configure_analytics_logging_uses_stderr(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging("stderr") == "stderr"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="get_run_history",
+            session_id="s",
+            viewer_info="viewer",
+            duration_ms=1.0,
+        )
+
+        assert stdout.getvalue() == ""
+        payload = json.loads(stderr.getvalue())
+        assert payload["message"] == "ANALYTICS_EVENT"
+        assert payload["event_type"] == "tool_call"
+        assert payload["tool_name"] == "get_run_history"
+        assert payload["duration_ms"] == 1.0
+
+    def test_configure_analytics_logging_for_stdio_uses_stderr(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging_for_transport("stdio") == "stderr"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="get_run_history",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert stdout.getvalue() == ""
+        assert "ANALYTICS_EVENT" in stderr.getvalue()
+
+    def test_configure_analytics_logging_for_http_uses_stdout(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        assert configure_analytics_logging_for_transport("http") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_explicit_stream_env_overrides_transport(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+        monkeypatch.setenv("MCP_ANALYTICS_LOG_STREAM", "stdout")
+
+        assert configure_analytics_logging_for_transport("stdio") == "stdout"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert "ANALYTICS_EVENT" in stdout.getvalue()
+        assert stderr.getvalue() == ""
+
+    def test_reconfiguration_replaces_handler_instead_of_duplicating(self, monkeypatch):
+        stdout = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+
+        configure_analytics_logging("stdout")
+        configure_analytics_logging("stdout")
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert len(analytics_logger.handlers) == 1
+        assert stdout.getvalue().count("ANALYTICS_EVENT") == 1
 
 
 # -- Email domain extraction --------------------------------------------------

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+import simple_parsing
+
+from wandb_mcp_server import analytics
+from wandb_mcp_server import server
+
+
+class _DummyMCPServer:
+    def __init__(self):
+        self.run_transport = None
+
+    def run(self, transport):
+        self.run_transport = transport
+
+
+def test_cli_configures_analytics_for_stdio_transport(monkeypatch):
+    calls = []
+    dummy_server = _DummyMCPServer()
+
+    monkeypatch.setattr(
+        simple_parsing,
+        "parse",
+        lambda _: SimpleNamespace(
+            transport="stdio",
+            host="localhost",
+            port=None,
+            wandb_api_key=None,
+        ),
+    )
+    monkeypatch.setattr(
+        analytics,
+        "configure_analytics_logging_for_transport",
+        lambda transport: calls.append(transport) or "stderr",
+    )
+    monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
+    monkeypatch.setattr(server, "validate_and_get_api_key", lambda args: None)
+    monkeypatch.setattr(server, "initialize_weave_tracing", lambda: False)
+    monkeypatch.setattr(server, "create_mcp_server", lambda *args: dummy_server)
+
+    server.cli()
+
+    assert calls == ["stdio"]
+    assert dummy_server.run_transport == "stdio"


### PR DESCRIPTION
## Summary
- Route structured analytics to stderr when the CLI is running with stdio transport, keeping stdout reserved for MCP JSON-RPC frames.
- Preserve stdout analytics for HTTP/container deployments so Cloud Logging and downstream analytics ingestion continue to work.
- Document the older-version workaround and add regression coverage for stream selection, duplicate handler prevention, and CLI wiring.

## Test plan
- `uv run --no-sync pytest tests/test_analytics.py tests/test_log_format.py tests/test_server_cli.py -v --tb=short`
- `uv run --no-sync pytest tests/ -v --tb=short`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`

## Notes
- Draft PR while we decide whether to include this in the current 0.3.5 train.
- No tool behavior changes beyond analytics stream routing.

Made with [Cursor](https://cursor.com)