### PR TITLE
feat(analytics): add canonical deployment dimensions

### DIFF
--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -21,6 +21,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from wandb_mcp_server.utils import get_rich_logger
 
@@ -266,6 +267,85 @@ def _utcnow_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Read a boolean environment variable."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_stripped(name: str) -> Optional[str]:
+    """Return a stripped environment value or None when unset/empty."""
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _safe_wandb_base_host() -> Optional[str]:
+    """Return a host-only W&B base URL dimension."""
+    raw = _env_stripped("WANDB_BASE_URL")
+    if not raw:
+        return None
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    return parsed.netloc or parsed.path or None
+
+
+def _resolve_transport() -> str:
+    """Resolve the MCP transport dimension."""
+    transport = (_env_stripped("MCP_TRANSPORT") or "unknown").lower()
+    if transport in {"stdio", "http", "streamable-http", "sse"}:
+        return "http" if transport == "streamable-http" else transport
+    return transport
+
+
+def _resolve_runtime_surface(transport: str) -> str:
+    """Resolve where the MCP server is running."""
+    explicit = _env_stripped("MCP_RUNTIME_SURFACE")
+    if explicit:
+        return explicit
+    if os.environ.get("K_SERVICE") or os.environ.get("K_REVISION"):
+        return "cloud_run"
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        return "helm_k8s"
+    if transport == "stdio":
+        return "local_stdio"
+    if transport == "http":
+        return "local_http"
+    return "unknown"
+
+
+def _resolve_deployment_type(runtime_surface: str, transport: str) -> str:
+    """Resolve the deployment type dimension."""
+    explicit = _env_stripped("MCP_DEPLOYMENT_TYPE")
+    if explicit:
+        return explicit
+    if _env_bool("MCP_HOSTED_MODE"):
+        return "hosted"
+    if runtime_surface.startswith("local") or transport == "stdio":
+        return "local"
+    return "unknown"
+
+
+def _deployment_context() -> Dict[str, Any]:
+    """Build low-cardinality deployment dimensions shared by all events."""
+    transport = _resolve_transport()
+    runtime_surface = _resolve_runtime_surface(transport)
+    context: Dict[str, Any] = {
+        "runtime_surface": runtime_surface,
+        "transport": transport,
+        "deployment_type": _resolve_deployment_type(runtime_surface, transport),
+        "environment": _env_stripped("ENVIRONMENT") or _env_stripped("DD_ENV") or "unknown",
+        "hosted_mode": _env_bool("MCP_HOSTED_MODE"),
+    }
+    wandb_base_host = _safe_wandb_base_host()
+    if wandb_base_host:
+        context["wandb_base_host"] = wandb_base_host
+    return context
+
+
 class AnalyticsTracker:
     """Emit structured analytics events for the MCP server.
 
@@ -410,6 +490,7 @@ class AnalyticsTracker:
             "event_type": event_type,
             "timestamp": _utcnow_iso(),
             "release_version": _resolve_release_version(),
+            **_deployment_context(),
         }
         deployment_id = os.environ.get("MCP_DEPLOYMENT_ID")
         if deployment_id:
@@ -517,6 +598,7 @@ class AnalyticsTracker:
         success: bool = True,
         error: Optional[str] = None,
         duration_ms: Optional[float] = None,
+        mcp_tool_name: Optional[str] = None,
     ) -> None:
         """Record an MCP tool invocation."""
         if not self.enabled:
@@ -537,14 +619,19 @@ class AnalyticsTracker:
                 "error": error,
                 "duration_ms": duration_ms,
             }
+            if mcp_tool_name:
+                event["mcp_tool_name"] = mcp_tool_name
+            labels = {
+                "event_type": "tool_call",
+                "tool_name": tool_name,
+                "email_domain": email_domain or "unknown",
+                "success": str(success),
+            }
+            if mcp_tool_name:
+                labels["mcp_tool_name"] = mcp_tool_name
             self._emit(
                 event,
-                {
-                    "event_type": "tool_call",
-                    "tool_name": tool_name,
-                    "email_domain": email_domain or "unknown",
-                    "success": str(success),
-                },
+                labels,
             )
         except Exception as exc:
             logger.warning(f"Failed to track tool call: {exc}")

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -83,14 +83,33 @@ def map_to_datadog_log(
         f"version:{dd_version}",
         f"event_type:{event_type}",
     ]
+    for key in ("runtime_surface", "transport", "deployment_type", "environment"):
+        value = event.get(key)
+        if value is not None:
+            tags.append(f"{key}:{value}")
     tool_name = event.get("tool_name")
     if tool_name:
         tags.append(f"tool_name:{tool_name}")
+    mcp_tool_name = event.get("mcp_tool_name")
+    if mcp_tool_name:
+        tags.append(f"mcp_tool_name:{mcp_tool_name}")
     success = event.get("success")
     if success is not None:
         tags.append(f"success:{str(success).lower()}")
 
     attributes: Dict[str, Any] = {"event_type": event_type}
+    for key in (
+        "runtime_surface",
+        "transport",
+        "deployment_type",
+        "environment",
+        "hosted_mode",
+        "deployment_id",
+        "wandb_base_host",
+    ):
+        value = event.get(key)
+        if value is not None:
+            attributes[key] = value
 
     duration_ms = event.get("duration_ms")
     if duration_ms is not None:
@@ -123,6 +142,10 @@ def map_to_datadog_log(
         tool_attrs: Dict[str, Any] = {}
         if tool_name:
             tool_attrs["name"] = tool_name
+            attributes["tool_name"] = tool_name
+        if mcp_tool_name:
+            tool_attrs["mcp_name"] = mcp_tool_name
+            attributes["mcp_tool_name"] = mcp_tool_name
         if success is not None:
             tool_attrs["success"] = success
         if tool_attrs:

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -51,9 +51,21 @@ _SESSION_PROPERTY_KEYS: List[str] = [
     "metadata",
 ]
 
+_BASE_PROPERTY_KEYS: List[str] = [
+    "release_version",
+    "deployment_id",
+    "runtime_surface",
+    "transport",
+    "deployment_type",
+    "environment",
+    "hosted_mode",
+    "wandb_base_host",
+]
+
 _TOOL_CALL_PROPERTY_KEYS: List[str] = [
     "session_id",
     "tool_name",
+    "mcp_tool_name",
     "params",
     "success",
     "error",
@@ -98,9 +110,7 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "schema_version": event.get("schema_version", "1.0"),
         "source": "wandb-mcp-server",
     }
-    if event.get("release_version"):
-        properties["release_version"] = event["release_version"]
-    for key in property_keys:
+    for key in [*_BASE_PROPERTY_KEYS, *property_keys]:
         if key in event:
             properties[key] = event[key]
 

--- a/src/wandb_mcp_server/mcp_tools/tools_utils.py
+++ b/src/wandb_mcp_server/mcp_tools/tools_utils.py
@@ -335,6 +335,7 @@ def track_tool_execution(
     tool_name: str,
     viewer: Any,
     params: Dict[str, Any],
+    mcp_tool_name: Optional[str] = None,
 ):
     """Context manager that wraps MCP tool execution with timing and error capture.
 
@@ -381,6 +382,7 @@ def track_tool_execution(
                 success=ctx.success,
                 error=ctx.error,
                 duration_ms=duration_ms,
+                mcp_tool_name=mcp_tool_name,
             )
         except Exception:
             _tools_logger.debug(f"Analytics tracking failed for {tool_name}")

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -353,6 +353,45 @@ class TestSchemaVersion:
         t._emit({"event_type": "test"}, {})
         assert capture.event is None
 
+    @patch.dict(
+        "os.environ",
+        {
+            "MCP_RUNTIME_SURFACE": "cloud_run",
+            "MCP_TRANSPORT": "http",
+            "MCP_DEPLOYMENT_TYPE": "hosted",
+            "ENVIRONMENT": "production",
+            "MCP_HOSTED_MODE": "true",
+            "WANDB_BASE_URL": "https://api.wandb.ai",
+        },
+        clear=False,
+    )
+    def test_base_event_has_deployment_dimensions(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_gql",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event is not None
+        assert capture.event["runtime_surface"] == "cloud_run"
+        assert capture.event["transport"] == "http"
+        assert capture.event["deployment_type"] == "hosted"
+        assert capture.event["environment"] == "production"
+        assert capture.event["hosted_mode"] is True
+        assert capture.event["wandb_base_host"] == "api.wandb.ai"
+
+    @patch.dict("os.environ", {"MCP_TRANSPORT": "stdio"}, clear=False)
+    def test_base_event_infers_local_stdio(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_gql",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event is not None
+        assert capture.event["runtime_surface"] == "local_stdio"
+        assert capture.event["deployment_type"] == "local"
+
 
 # -- track_user_session -------------------------------------------------------
 
@@ -449,6 +488,18 @@ class TestTrackToolCall:
             duration_ms=123.4,
         )
         assert capture.event["duration_ms"] == 123.4
+
+    def test_mcp_tool_name_recorded_when_available(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_paginated_wandb_gql",
+            mcp_tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="v",
+        )
+
+        assert capture.event["tool_name"] == "query_paginated_wandb_gql"
+        assert capture.event["mcp_tool_name"] == "query_wandb_tool"
+        assert capture.labels["mcp_tool_name"] == "query_wandb_tool"
 
     def test_labels_include_tool_name(self, capture):
         AnalyticsTracker(enabled=True).track_tool_call(

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -143,11 +143,33 @@ class TestDatadogAttributes:
         assert "usr" not in entry["attributes"]
 
     def test_tool_attributes(self):
-        event = _make_event("tool_call", tool_name="count_traces", success=True)
+        event = _make_event(
+            "tool_call",
+            tool_name="count_traces",
+            mcp_tool_name="count_weave_traces_tool",
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+            environment="production",
+            hosted_mode=True,
+            success=True,
+        )
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
         tool = entry["attributes"]["tool"]
         assert tool["name"] == "count_traces"
+        assert tool["mcp_name"] == "count_weave_traces_tool"
         assert tool["success"] is True
+        assert entry["attributes"]["tool_name"] == "count_traces"
+        assert entry["attributes"]["mcp_tool_name"] == "count_weave_traces_tool"
+        assert entry["attributes"]["runtime_surface"] == "cloud_run"
+        assert entry["attributes"]["transport"] == "http"
+        assert entry["attributes"]["deployment_type"] == "hosted"
+        assert entry["attributes"]["environment"] == "production"
+        assert entry["attributes"]["hosted_mode"] is True
+        assert "runtime_surface:cloud_run" in entry["ddtags"]
+        assert "transport:http" in entry["ddtags"]
+        assert "deployment_type:hosted" in entry["ddtags"]
+        assert "mcp_tool_name:count_weave_traces_tool" in entry["ddtags"]
 
     def test_session_id_forwarded(self):
         event = _make_event("tool_call", tool_name="x", success=True, session_id="sess_abc")

--- a/tests/test_analytics_segment.py
+++ b/tests/test_analytics_segment.py
@@ -53,6 +53,12 @@ class TestMapToSegmentTrack:
             "tool_call",
             session_id="s1",
             tool_name="query_wandb_gql",
+            mcp_tool_name="query_wandb_tool",
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+            environment="production",
+            hosted_mode=True,
             params={"entity": "team"},
             success=True,
         )
@@ -61,6 +67,12 @@ class TestMapToSegmentTrack:
         assert result["userId"] == "alice"
         assert result["event"] == f"{SEGMENT_EVENT_PREFIX}.tool_call"
         assert result["properties"]["tool_name"] == "query_wandb_gql"
+        assert result["properties"]["mcp_tool_name"] == "query_wandb_tool"
+        assert result["properties"]["runtime_surface"] == "cloud_run"
+        assert result["properties"]["transport"] == "http"
+        assert result["properties"]["deployment_type"] == "hosted"
+        assert result["properties"]["environment"] == "production"
+        assert result["properties"]["hosted_mode"] is True
         assert result["properties"]["source"] == "wandb-mcp-server"
         assert result["properties"]["schema_version"] == "1.0"
 
@@ -76,10 +88,16 @@ class TestMapToSegmentTrack:
             session_id="sess",
             email_domain="wandb.com",
             api_key_hash="abcd1234",
+            runtime_surface="local_stdio",
+            transport="stdio",
+            deployment_type="local",
         )
         result = map_to_segment_track(event)
         assert result["event"] == f"{SEGMENT_EVENT_PREFIX}.session_start"
         assert result["properties"]["email_domain"] == "wandb.com"
+        assert result["properties"]["runtime_surface"] == "local_stdio"
+        assert result["properties"]["transport"] == "stdio"
+        assert result["properties"]["deployment_type"] == "local"
 
     def test_request_basic(self):
         event = self._make_event(


### PR DESCRIPTION
## Summary
- Add low-cardinality deployment/runtime dimensions to all MCP analytics events.
- Forward the new dimensions through Segment/Gorilla and Datadog mappings.
- Add top-level Datadog tool fields while preserving the existing nested `tool.name` shape.

## Test plan
- `uv run --no-sync pytest tests/test_analytics.py tests/test_analytics_segment.py tests/test_analytics_datadog.py tests/test_analytics_e2e.py tests/test_log_format.py -v --tb=short`
- `uv run --no-sync pytest tests/ -v --tb=short`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`

## Release note
This should land into `staging/0.3.5` before staging deploy validation.

Made with [Cursor](https://cursor.com)