### PR TITLE
fix(analytics): preserve count tool session context

### DIFF
--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -123,6 +123,7 @@ _COUNT_EXECUTOR = ThreadPoolExecutor(
 
 def _count_traces_with_context(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -130,8 +131,10 @@ def _count_traces_with_context(
 ) -> int:
     """Run count_traces inside a worker while preserving the request API key."""
     from wandb_mcp_server.api_client import WandBApiManager
+    from wandb_mcp_server.session_manager import current_session_id
 
     token = WandBApiManager.set_context_api_key(api_key) if api_key else None
+    session_token = current_session_id.set(session_id) if session_id else None
     try:
         return count_traces(
             entity_name=entity_name,
@@ -140,12 +143,15 @@ def _count_traces_with_context(
             request_timeout=request_timeout,
         )
     finally:
+        if session_token is not None:
+            current_session_id.reset(session_token)
         if token is not None:
             WandBApiManager.reset_context_api_key(token)
 
 
 async def _count_traces_with_deadline(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -159,6 +165,7 @@ async def _count_traces_with_deadline(
         partial(
             _count_traces_with_context,
             api_key,
+            session_id,
             entity_name,
             project_name,
             filters,
@@ -174,6 +181,7 @@ async def _count_traces_with_deadline(
 
 async def _count_traces_or_none(
     api_key: Optional[str],
+    session_id: Optional[str],
     entity_name: str,
     project_name: str,
     filters: Dict[str, Any],
@@ -183,6 +191,7 @@ async def _count_traces_or_none(
     try:
         return await _count_traces_with_deadline(
             api_key,
+            session_id,
             entity_name,
             project_name,
             filters,
@@ -475,12 +484,16 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
         try:
             api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.session_manager import current_session_id
+
+            session_id = current_session_id.get()
             from wandb_mcp_server.config import MCP_TOOL_TIMEOUT_SECONDS
 
             count_deadline = min(10, MCP_TOOL_TIMEOUT_SECONDS)
             if detail_level != "schema" and effective_limit > 100 and not metadata_only:
                 pre_count = await _count_traces_or_none(
                     api_key,
+                    session_id,
                     entity_name,
                     project_name,
                     filters or {},
@@ -522,6 +535,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
             try:
                 matching_count = await _count_traces_or_none(
                     api_key,
+                    session_id,
                     entity_name=entity_name,
                     project_name=project_name,
                     filters=filters or {},
@@ -608,10 +622,14 @@ def register_tools(mcp_instance: FastMCP) -> None:
             root_filters["trace_roots_only"] = True
 
             api_key = WandBApiManager.get_api_key()
+            from wandb_mcp_server.session_manager import current_session_id
+
+            session_id = current_session_id.get()
             total_count, root_traces_count = await asyncio.wait_for(
                 asyncio.gather(
                     _count_traces_with_deadline(
                         api_key,
+                        session_id,
                         entity_name,
                         project_name,
                         filters or {},
@@ -619,6 +637,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                     ),
                     _count_traces_with_deadline(
                         api_key,
+                        session_id,
                         entity_name,
                         project_name,
                         root_filters,

--- a/tests/test_hosted_runtime_guardrails.py
+++ b/tests/test_hosted_runtime_guardrails.py
@@ -199,6 +199,31 @@ async def test_count_tool_passes_bounded_request_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_count_tool_preserves_session_context_in_executor(monkeypatch):
+    from wandb_mcp_server.session_manager import current_session_id
+
+    monkeypatch.setattr(cfg, "MCP_TOOL_TIMEOUT_SECONDS", 3)
+    monkeypatch.setattr(WandBApiManager, "get_api_key", staticmethod(lambda: "test-key"))
+    observed_session_ids = []
+
+    def capture_count(*args, **kwargs):
+        observed_session_ids.append(current_session_id.get())
+        return 2
+
+    monkeypatch.setattr(server, "count_traces", capture_count)
+
+    token = current_session_id.set("sess_test")
+    try:
+        tool = _registered_tools(monkeypatch)["count_weave_traces_tool"]
+        result = json.loads(await tool("entity", "project"))
+    finally:
+        current_session_id.reset(token)
+
+    assert result == {"total_count": 2, "root_traces_count": 2}
+    assert observed_session_ids == ["sess_test", "sess_test"]
+
+
+@pytest.mark.asyncio
 async def test_trace_query_preflight_timeout_does_not_block_main_query(monkeypatch):
     monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
     monkeypatch.setattr(cfg, "MCP_MAX_QUERY_LIMIT", 100)


### PR DESCRIPTION
## Summary
- Carry `current_session_id` into the count-traces executor thread so count tool analytics can be joined to the hosted MCP session.
- Add regression coverage for executor-side session context preservation.

## Test plan
- `uv run --no-sync pytest tests/test_hosted_runtime_guardrails.py tests/test_analytics.py tests/test_analytics_datadog.py tests/test_analytics_segment.py -v --tb=short`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`

## Notes
- Found during staging analytics verification: request/session analytics were stable after the Cloud Run wrapper patch, but count-traces analytics were emitted inside a worker thread without the request session context.

Made with [Cursor](https://cursor.com)