### PR TITLE
feat(analytics): enrich Datadog forwarder payloads

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -188,6 +188,23 @@ params there, and redaction reduces legal exposure if customer logs are
 subpoenaed, exported, or retained longer than needed. `standard` is the safe
 default. `strict` goes one step further for regulated customers.
 
+### Datadog params privacy
+
+Cloud Run uses `MCP_LOG_PRIVACY_LEVEL=off` so the W&B-managed BigQuery product
+analytics sink keeps its historical cohort fields. The Datadog HTTP forwarder is
+an operational sink, so it applies a separate params privacy level:
+`MCP_DATADOG_PARAM_PRIVACY_LEVEL`, defaulting to `standard`.
+
+This gives Cloud Run Datadog logs semantic parity with Helm/agent-ingested
+`ANALYTICS_EVENT` logs without forwarding raw free text. Cloud Run Datadog
+payloads include sanitized fields under `attributes.params.*`, corresponding to
+Helm's `custom.params.*` fields. Free-text values such as GraphQL queries,
+prompts, descriptions, report text, and messages are redacted to
+`<redacted: text len=N>` by default; secret-like keys are always redacted.
+
+Only use `MCP_DATADOG_PARAM_PRIVACY_LEVEL=off` for short-lived debugging in a
+controlled environment. Do not set it as a production default.
+
 ### Identifier hashing at `strict`
 
 `<h:sha256_prefix>` uses the first 12 hex chars of `sha256(value)`.

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -31,6 +31,7 @@ from wandb_mcp_server.utils import get_rich_logger
 logger = get_rich_logger(__name__)
 
 _DATADOG_EVENT_PREFIX = "mcp"
+_DATADOG_PARAM_PRIVACY_LEVEL_DEFAULT = "standard"
 
 
 def _build_retry_session() -> requests.Session:
@@ -45,6 +46,36 @@ def _build_retry_session() -> requests.Session:
     adapter = HTTPAdapter(max_retries=retry)
     session.mount("https://", adapter)
     return session
+
+
+def _datadog_safe_params(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return Datadog-safe analytics params.
+
+    Cloud Run keeps MCP_LOG_PRIVACY_LEVEL=off for product analytics, but Datadog
+    is an operational sink. Use standard redaction by default so free text is
+    summarized, secrets are redacted, and structured dimensions remain useful.
+    """
+    params = event.get("params")
+    if not params:
+        return {}
+
+    from wandb_mcp_server.analytics import AnalyticsTracker
+
+    privacy_level = os.environ.get(
+        "MCP_DATADOG_PARAM_PRIVACY_LEVEL",
+        _DATADOG_PARAM_PRIVACY_LEVEL_DEFAULT,
+    )
+    return AnalyticsTracker._sanitise_params(params, level=privacy_level)
+
+
+def _datadog_safe_labels(event: Dict[str, Any]) -> Dict[str, str]:
+    """Return low-cardinality labels safe for Datadog attributes."""
+    labels: Dict[str, str] = {"event_type": str(event.get("event_type", "unknown"))}
+    for key in ("tool_name", "mcp_tool_name", "success", "runtime_surface", "transport", "deployment_type"):
+        value = event.get(key)
+        if value is not None:
+            labels[key] = str(value)
+    return labels
 
 
 def map_to_datadog_log(
@@ -97,7 +128,16 @@ def map_to_datadog_log(
     if success is not None:
         tags.append(f"success:{str(success).lower()}")
 
-    attributes: Dict[str, Any] = {"event_type": event_type}
+    attributes: Dict[str, Any] = {
+        "event_type": event_type,
+        "schema_version": event.get("schema_version", "1.0"),
+    }
+    if success is not None:
+        attributes["success"] = success
+    for key in ("release_version", "timestamp"):
+        value = event.get(key)
+        if value is not None:
+            attributes[key] = value
     for key in (
         "runtime_surface",
         "transport",
@@ -113,6 +153,7 @@ def map_to_datadog_log(
 
     duration_ms = event.get("duration_ms")
     if duration_ms is not None:
+        attributes["duration_ms"] = duration_ms
         attributes["duration"] = int(duration_ms * 1_000_000)
 
     if event_type == "request":
@@ -136,7 +177,16 @@ def map_to_datadog_log(
 
     user_id = event.get("user_id")
     if user_id:
+        attributes["user_id"] = user_id
         attributes["usr"] = {"id": user_id}
+
+    safe_params = _datadog_safe_params(event)
+    if safe_params:
+        attributes["params"] = safe_params
+
+    labels = _datadog_safe_labels(event)
+    if labels:
+        attributes["labels"] = labels
 
     if event_type == "tool_call":
         tool_attrs: Dict[str, Any] = {}

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -176,6 +176,40 @@ class TestDatadogAttributes:
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
         assert entry["attributes"]["session_id"] == "sess_abc"
 
+    def test_tool_call_includes_raw_analytics_parity_fields(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            duration_ms=546.08,
+            release_version="0.3.5",
+            timestamp="2026-05-27T17:58:00+00:00",
+            params={
+                "entity_name": "wandb-applied-ai-team",
+                "project_name": "mcp-tests",
+                "run_id": "h0fm5qp5",
+                "samples": 20,
+            },
+            runtime_surface="cloud_run",
+            transport="http",
+            deployment_type="hosted",
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        attrs = entry["attributes"]
+
+        assert attrs["schema_version"] == "1.0"
+        assert attrs["release_version"] == "0.3.5"
+        assert attrs["timestamp"] == "2026-05-27T17:58:00+00:00"
+        assert attrs["tool_name"] == "get_run_history"
+        assert attrs["success"] is True
+        assert attrs["duration_ms"] == 546.08
+        assert attrs["params"]["entity_name"] == "wandb-applied-ai-team"
+        assert attrs["params"]["project_name"] == "mcp-tests"
+        assert attrs["params"]["run_id"] == "h0fm5qp5"
+        assert attrs["params"]["samples"] == 20
+        assert attrs["labels"]["tool_name"] == "get_run_history"
+        assert attrs["labels"]["event_type"] == "tool_call"
+
 
 # ---------------------------------------------------------------------------
 # map_to_datadog_log -- PII exclusion
@@ -185,16 +219,76 @@ class TestDatadogAttributes:
 class TestPIIExclusion:
     """Datadog must NOT receive params, api_key_hash, metadata, or email_domain."""
 
-    def test_params_excluded(self):
+    def test_params_are_sanitized_not_raw(self):
         event = _make_event(
             "tool_call",
             tool_name="query_traces",
             success=True,
-            params={"entity": "team", "project": "proj"},
+            params={"query": "query { viewer { username } }"},
         )
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
-        assert "team" not in entry["attributes"]
-        assert "params" not in entry["attributes"]
+        assert entry["attributes"]["params"]["query"] == "<redacted: text len=29>"
+
+    def test_params_redact_secrets(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="query_traces",
+            success=True,
+            params={"api_key": "secret", "Authorization": "Bearer token", "token": "x"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        assert entry["attributes"]["params"]["api_key"] == "<redacted>"
+        assert entry["attributes"]["params"]["Authorization"] == "<redacted>"
+        assert entry["attributes"]["params"]["token"] == "<redacted>"
+
+    def test_params_preserve_safe_dimensions(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={
+                "entity_name": "team",
+                "project_name": "project",
+                "run_id": "abc123",
+                "samples": 20,
+                "max_items": 100,
+            },
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        assert entry["attributes"]["params"] == {
+            "entity_name": "team",
+            "project_name": "project",
+            "run_id": "abc123",
+            "samples": 20,
+            "max_items": 100,
+        }
+
+    @patch.dict("os.environ", {"MCP_DATADOG_PARAM_PRIVACY_LEVEL": "strict"})
+    def test_params_can_hash_identifiers_at_strict(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={"entity_name": "team", "project_name": "project", "run_id": "abc123"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        params = entry["attributes"]["params"]
+        assert params["entity_name"].startswith("<h:")
+        assert params["project_name"].startswith("<h:")
+        assert params["run_id"].startswith("<h:")
+
+    def test_params_do_not_become_tags(self):
+        event = _make_event(
+            "tool_call",
+            tool_name="get_run_history",
+            success=True,
+            params={"entity_name": "team", "project_name": "project", "run_id": "abc123"},
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+        tags = entry["ddtags"]
+        assert "team" not in tags
+        assert "project" not in tags
+        assert "abc123" not in tags
 
     def test_api_key_hash_excluded(self):
         event = _make_event("user_session", session_id="s1", api_key_hash="abcdef1234567890")
@@ -516,7 +610,7 @@ class TestE2ETrackerToDatadog:
             assert entry["status"] == "info"
             assert entry["attributes"]["tool"]["name"] == "query_traces"
             assert entry["attributes"]["duration"] == 150_500_000
-            assert "params" not in entry["attributes"]
+            assert entry["attributes"]["params"]["entity"] == "team"
 
     @patch.dict(
         "os.environ",

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -103,7 +103,7 @@ class TestSuccessfulToolCall:
         assert "error" not in dd["attributes"]
         assert dd["attributes"]["duration"] >= 0
         assert dd["attributes"]["usr"]["id"] == "testuser"
-        assert "params" not in dd["attributes"]
+        assert dd["attributes"]["params"] == {"entity": "org", "project": "proj"}
 
     @pytest.mark.usefixtures("_enable_analytics")
     def test_success_segment_excludes_email_domain(self):
@@ -242,15 +242,20 @@ class TestDurationTracking:
 
 
 class TestDataSeparation:
-    """Segment and Datadog must receive different data per their purposes."""
+    """Segment and Datadog receive differently sanitized analytics data."""
 
     @pytest.mark.usefixtures("_enable_analytics")
-    def test_segment_gets_params_datadog_does_not(self):
+    def test_segment_gets_raw_params_datadog_gets_sanitized_params(self):
         from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 
         viewer = _mock_viewer()
         dd_fwd = get_datadog_forwarder()
-        params = {"entity_name": "wandb-smle", "project_name": "email-agent", "limit": 10}
+        params = {
+            "entity_name": "wandb-smle",
+            "project_name": "email-agent",
+            "limit": 10,
+            "query": "query { viewer { username } }",
+        }
 
         with patch.object(dd_fwd, "_post"):
             with track_tool_execution("query_traces", viewer, params):
@@ -259,10 +264,13 @@ class TestDataSeparation:
         seg = get_segment_forwarder().get_forwarded_payloads()[0]
         assert "params" in seg["properties"]
         assert seg["properties"]["params"]["entity_name"] == "wandb-smle"
+        assert seg["properties"]["params"]["query"] == "query { viewer { username } }"
 
         dd = dd_fwd.get_forwarded_payloads()[0]
-        assert "params" not in dd["attributes"]
-        assert "wandb-smle" not in str(dd["attributes"])
+        assert dd["attributes"]["params"]["entity_name"] == "wandb-smle"
+        assert dd["attributes"]["params"]["project_name"] == "email-agent"
+        assert dd["attributes"]["params"]["limit"] == 10
+        assert dd["attributes"]["params"]["query"] == "<redacted: text len=29>"
 
     @pytest.mark.usefixtures("_enable_analytics")
     def test_datadog_has_structured_severity_segment_does_not(self):


### PR DESCRIPTION
## Summary
- Add sanitized analytics params, labels, duration_ms, success, schema/release/timestamp, and user_id to Datadog forwarder attributes.
- Preserve existing Datadog-native fields while exposing Helm-like semantic fields under `custom.attributes.*` for Cloud Run.
- Default Datadog param privacy to `standard` via `MCP_DATADOG_PARAM_PRIVACY_LEVEL`, even when Cloud Run product analytics uses `MCP_LOG_PRIVACY_LEVEL=off`.

## Test plan
- `uv run --no-sync pytest tests/test_analytics_datadog.py tests/test_analytics.py tests/test_analytics_e2e.py -v --tb=short`
- `uv run --no-sync pytest tests/ -v --tb=short`
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`

## Notes
- Helm/agent ingestion remains unchanged; this gives Cloud Run semantic parity with Helm while keeping Datadog params sanitized.

Made with [Cursor](https://cursor.com)