### PR TITLE
fix(MCP): support structured report panel grids

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "simple-parsing>=0.1.7",
     "python-dotenv>=1.0.0",
     "tiktoken>=0.9.0",
-    "wandb-workspaces>=0.1.12",
+    "wandb-workspaces>=0.3.9",
     "requests>=2.31.0",
 ]
 

--- a/scripts/report_agent_harness.py
+++ b/scripts/report_agent_harness.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Seed a complex W&B project and validate agent-style report creation.
+
+This is a live harness for WB-34806. It creates a synthetic project with
+multiple runs, metric histories, and table-backed AP curves, then uses a small
+deterministic "agent" to emit the same `create_wandb_report_tool` payload shape
+an MCP client should use for a multi-section report.
+
+Requirements:
+    WANDB_API_KEY must be set in the environment or in `.env`.
+
+Usage:
+    uv run python scripts/report_agent_harness.py
+    uv run python scripts/report_agent_harness.py --env-file ../wandb-mcp-server/.env
+    uv run python scripts/report_agent_harness.py --panel-def-id cruise/bar_chart/v2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import wandb
+import wandb_workspaces.reports.v2 as wr
+from dotenv import load_dotenv
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.create_report import create_report
+
+OBJECT_CLASSES = ("CAR", "TRUCK", "MOTORCYCLE")
+TABLE_KEYS = {
+    "CAR": "car_ap_curve",
+    "TRUCK": "truck_ap_curve",
+    "MOTORCYCLE": "motorcycle_ap_curve",
+}
+
+
+@dataclass(frozen=True)
+class HarnessConfig:
+    """Runtime configuration for the live report harness."""
+
+    entity: str
+    project: str
+    run_count: int
+    panel_def_id: str
+    timeout_s: int
+    stamp: str
+
+
+@dataclass(frozen=True)
+class SeededRun:
+    """Synthetic run metadata needed by the agent harness."""
+
+    run_id: str
+    display_name: str
+    model_family: str
+
+
+class BasicReportAgent:
+    """Deterministic agent that emits a complex MCP report layout payload."""
+
+    def __init__(self, *, panel_def_id: str) -> None:
+        self.panel_def_id = panel_def_id
+
+    def build_panels(self, seeded_runs: list[SeededRun]) -> list[dict[str, Any]]:
+        """Build ordered report layout blocks from seeded run metadata."""
+        run_ids = [run.run_id for run in seeded_runs]
+        return [
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Scenario summary",
+            },
+            {
+                "type": "markdown",
+                "text": (
+                    "This synthetic report mimics an agent assembling a customer evaluation report "
+                    "with narrative text, shared runsets, native metric panels, and custom Vega panels."
+                ),
+            },
+            {
+                "type": "markdown_table",
+                "title": "Seeded runs",
+                "headers": ["Run ID", "Display name", "Model family"],
+                "rows": [[run.run_id, run.display_name, run.model_family] for run in seeded_runs],
+            },
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Training and evaluation metrics",
+            },
+            {
+                "type": "markdown",
+                "text": "These native panels share one deterministic runset filter across all seeded runs.",
+            },
+            {
+                "type": "panel_grid",
+                "run_ids": run_ids,
+                "hide_run_sets": False,
+                "panels": [
+                    {
+                        "type": "line",
+                        "x": "_step",
+                        "y": ["train/loss", "eval/mAP"],
+                        "title": "Loss and mAP over steps",
+                    },
+                    {
+                        "type": "bar",
+                        "metrics": ["summary/final_map", "summary/p95_latency_ms"],
+                        "title": "Final quality and latency",
+                    },
+                    {
+                        "type": "scatter",
+                        "x": "summary/p95_latency_ms",
+                        "y": "summary/final_map",
+                        "title": "Latency vs mAP",
+                    },
+                ],
+            },
+            {
+                "type": "heading",
+                "level": 2,
+                "text": "Average precision by class",
+            },
+            {
+                "type": "markdown",
+                "text": "Each custom Vega panel reads a table key from the same shared runset.",
+            },
+            {
+                "type": "panel_grid",
+                "run_ids": run_ids,
+                "hide_run_sets": False,
+                "panels": [self._class_ap_panel(class_name) for class_name in OBJECT_CLASSES],
+            },
+        ]
+
+    def _class_ap_panel(self, class_name: str) -> dict[str, Any]:
+        """Build a table-backed custom chart panel for one object class."""
+        return {
+            "type": "custom_chart_table",
+            "table_name": TABLE_KEYS[class_name],
+            "chart_name": self.panel_def_id,
+            "chart_fields": {"x": "threshold", "y": "ap"},
+            "chart_strings": {"title": f"{class_name} AP by confidence threshold"},
+        }
+
+
+def _env_first(*names: str, default: str) -> str:
+    """Return the first non-empty environment variable value."""
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return default
+
+
+def _parse_args() -> HarnessConfig:
+    """Parse CLI arguments and environment fallbacks."""
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument(
+        "--env-file",
+        default=os.getenv("MCP_REPORT_HARNESS_ENV_FILE", ""),
+        help="Optional .env file to load before reading W&B settings.",
+    )
+    pre_args, _ = pre_parser.parse_known_args()
+
+    load_dotenv()
+    if pre_args.env_file and not load_dotenv(pre_args.env_file, override=True):
+        pre_parser.error(f"Could not load --env-file {pre_args.env_file!r}")
+
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    parser = argparse.ArgumentParser(description=__doc__, parents=[pre_parser])
+    parser.add_argument(
+        "--entity",
+        default=_env_first(
+            "MCP_REPORT_TEST_ENTITY",
+            "MCP_LOGS_WANDB_ENTITY",
+            "WANDB_ENTITY",
+            default="wandb-applied-ai-team",
+        ),
+        help="W&B entity to seed.",
+    )
+    parser.add_argument(
+        "--project",
+        default=_env_first(
+            "MCP_REPORT_HARNESS_PROJECT",
+            "MCP_REPORT_TEST_PROJECT",
+            "MCP_LOGS_WANDB_PROJECT",
+            "WANDB_PROJECT",
+            default="wandb-mcp-report-agent-harness",
+        ),
+        help="W&B project to seed.",
+    )
+    parser.add_argument("--run-count", type=int, default=3, help="Number of synthetic runs to create.")
+    parser.add_argument(
+        "--panel-def-id",
+        default=os.getenv("MCP_REPORT_HARNESS_PANEL_DEF_ID", "wandb/line/v0"),
+        help="Vega panelDefId to persist for custom charts.",
+    )
+    parser.add_argument("--timeout-s", type=int, default=90, help="Seconds to wait for table summaries.")
+    args = parser.parse_args()
+    if args.run_count < 2:
+        parser.error("--run-count must be at least 2")
+    return HarnessConfig(
+        entity=args.entity,
+        project=args.project,
+        run_count=args.run_count,
+        panel_def_id=args.panel_def_id,
+        timeout_s=args.timeout_s,
+        stamp=stamp,
+    )
+
+
+def _setup_wandb_context() -> str:
+    """Load credentials for W&B SDK calls and MCP report creation."""
+    api_key = os.getenv("WANDB_API_KEY", "")
+    if not api_key:
+        print("ERROR: WANDB_API_KEY is not set in the environment or .env.", file=sys.stderr)
+        sys.exit(1)
+    WandBApiManager.set_context_api_key(api_key)
+    return api_key
+
+
+def _seed_mock_project(config: HarnessConfig) -> list[SeededRun]:
+    """Create synthetic runs with metrics and table-backed AP curves."""
+    seeded_runs: list[SeededRun] = []
+    model_families = ("baseline", "candidate", "experimental", "ablation")
+    for run_index in range(config.run_count):
+        model_family = model_families[run_index % len(model_families)]
+        display_name = f"agent-harness-{model_family}-{config.stamp}"
+        with wandb.init(
+            entity=config.entity,
+            project=config.project,
+            name=display_name,
+            job_type="mcp-report-agent-harness",
+            tags=["mcp-generated", "report-layout-harness", config.stamp],
+            config={
+                "model_family": model_family,
+                "dataset": "synthetic-urban-perception",
+                "seed": 9000 + run_index,
+            },
+        ) as run:
+            final_map = 0.64 + run_index * 0.045
+            p95_latency = 42 - run_index * 3.5
+            for step in range(12):
+                progress = step / 11
+                run.log(
+                    {
+                        "train/loss": round(1.25 - progress * (0.48 + run_index * 0.06), 4),
+                        "eval/mAP": round(0.38 + progress * (final_map - 0.38), 4),
+                        "summary/p95_latency_ms": round(p95_latency + (1 - progress) * 4.0, 4),
+                    },
+                    step=step,
+                )
+
+            for class_index, class_name in enumerate(OBJECT_CLASSES):
+                run.log({TABLE_KEYS[class_name]: _ap_curve_table(run_index, class_index)})
+
+            run.summary["summary/final_map"] = round(final_map, 4)
+            run.summary["summary/p95_latency_ms"] = round(p95_latency, 4)
+            run.summary["summary/report_harness_stamp"] = config.stamp
+            seeded_runs.append(
+                SeededRun(
+                    run_id=run.id,
+                    display_name=display_name,
+                    model_family=model_family,
+                )
+            )
+    return seeded_runs
+
+
+def _ap_curve_table(run_index: int, class_index: int) -> wandb.Table:
+    """Create one synthetic AP curve table."""
+    rows = []
+    class_name = OBJECT_CLASSES[class_index]
+    for threshold_index in range(7):
+        threshold = round(0.2 + threshold_index * 0.1, 2)
+        ap = 0.48 + run_index * 0.05 + class_index * 0.025 + threshold_index * 0.018
+        precision = 0.72 + run_index * 0.025 + threshold_index * 0.02
+        recall = 0.92 - threshold_index * 0.055 + run_index * 0.01
+        rows.append(
+            [
+                threshold,
+                round(min(ap, 0.98), 4),
+                round(min(precision, 0.99), 4),
+                round(max(recall, 0.1), 4),
+                class_name,
+            ]
+        )
+    return wandb.Table(
+        columns=["threshold", "ap", "precision", "recall", "class_name"],
+        data=rows,
+    )
+
+
+def _wait_for_tables(api_key: str, config: HarnessConfig, seeded_runs: list[SeededRun]) -> None:
+    """Wait until table-backed chart inputs are queryable from run summaries."""
+    api = wandb.Api(api_key=api_key)
+    deadline = time.monotonic() + config.timeout_s
+    pending = {(run.run_id, table_key) for run in seeded_runs for table_key in TABLE_KEYS.values()}
+    last_seen: dict[str, list[str]] = {}
+
+    while pending and time.monotonic() < deadline:
+        for run in seeded_runs:
+            api_run = api.run(f"{config.entity}/{config.project}/{run.run_id}")
+            summary = dict(api_run.summary)
+            last_seen[run.run_id] = sorted(summary.keys())
+            for table_key in TABLE_KEYS.values():
+                table_ref = summary.get(table_key)
+                if getattr(table_ref, "get", lambda *_: None)("_type") == "table-file":
+                    pending.discard((run.run_id, table_key))
+        if pending:
+            time.sleep(2)
+
+    if pending:
+        raise AssertionError(
+            f"Timed out waiting for table summaries. Pending={sorted(pending)} Last summary keys={last_seen}"
+        )
+
+
+def _create_agent_report(config: HarnessConfig, seeded_runs: list[SeededRun]) -> str:
+    """Create a report using the same MCP implementation exposed to agents."""
+    agent = BasicReportAgent(panel_def_id=config.panel_def_id)
+    result = create_report(
+        entity_name=config.entity,
+        project_name=config.project,
+        title=f"MCP agent report harness {config.stamp}",
+        description="Synthetic validation report for structured MCP report assembly.",
+        markdown_report_text=(
+            "# MCP agent report harness\n\n"
+            "[TOC]\n\n"
+            "This report was generated by a deterministic local harness that mimics an agent using only MCP inputs."
+        ),
+        panels=agent.build_panels(seeded_runs),
+    )
+    return result["url"]
+
+
+def _validate_report(report_url: str, config: HarnessConfig, seeded_runs: list[SeededRun]) -> None:
+    """Reload the saved report and validate the Reports v2 structure."""
+    report_model = wr.Report.from_url(report_url, as_model=True)
+    panel_grids = [block for block in report_model.spec.blocks if getattr(block, "type", None) == "panel-grid"]
+    if len(panel_grids) != 2:
+        raise AssertionError(f"Expected 2 panel grids, found {len(panel_grids)}")
+
+    run_ids = [run.run_id for run in seeded_runs]
+    for index, grid in enumerate(panel_grids):
+        if len(grid.metadata.run_sets) != 1:
+            raise AssertionError(f"Grid {index} should have exactly one runset")
+        runset_json = grid.metadata.run_sets[0].model_dump_json(by_alias=True, exclude_none=True)
+        for run_id in run_ids:
+            if run_id not in runset_json:
+                raise AssertionError(f"Run ID {run_id} missing from grid {index} runset filter")
+        if '"name"' not in runset_json:
+            raise AssertionError(f"Grid {index} runset filter is not keyed by run name: {runset_json}")
+
+    custom_grid = panel_grids[1]
+    custom_panels = [
+        panel
+        for panel in custom_grid.metadata.panel_bank_section_config.panels
+        if getattr(getattr(panel, "config", None), "panel_def_id", None)
+    ]
+    if len(custom_panels) != len(OBJECT_CLASSES):
+        raise AssertionError(f"Expected {len(OBJECT_CLASSES)} custom panels, found {len(custom_panels)}")
+
+    panel_def_ids = [panel.config.panel_def_id for panel in custom_panels]
+    if panel_def_ids != [config.panel_def_id] * len(OBJECT_CLASSES):
+        raise AssertionError(f"Unexpected panelDefIds: {panel_def_ids}")
+
+    report_json = report_model.model_dump_json(by_alias=True, exclude_none=True)
+    for table_key in TABLE_KEYS.values():
+        if table_key not in report_json:
+            raise AssertionError(f"Table key {table_key!r} missing from saved report viewspec")
+
+
+def main() -> int:
+    """Run the live harness and return a process exit code."""
+    config = _parse_args()
+    api_key = _setup_wandb_context()
+
+    print(f"Seeding {config.run_count} runs in {config.entity}/{config.project}")
+    seeded_runs = _seed_mock_project(config)
+    print("Seeded run IDs:", ", ".join(run.run_id for run in seeded_runs))
+
+    print("Waiting for AP curve tables to appear in run summaries")
+    _wait_for_tables(api_key, config, seeded_runs)
+
+    print("Creating report through create_report() with an agent-style layout payload")
+    report_url = _create_agent_report(config, seeded_runs)
+    print(f"Report URL: {report_url}")
+
+    print("Reloading report and validating saved Reports v2 structure")
+    _validate_report(report_url, config, seeded_runs)
+    print("Harness validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -5,6 +5,7 @@ This version eliminates the singleton contamination vulnerability and uses only 
 """
 
 from typing import Any, Dict, List, Optional, Union
+import json
 import re
 
 import wandb_workspaces.reports.v2 as wr
@@ -97,7 +98,7 @@ Args:
     title: str, Title of the W&B Report - required
     description: str, Optional brief description of the report
     markdown_report_text: str, Well-structured markdown content for the report body
-    panels: list of dict, optional - Chart panels to add after the markdown content.
+    panels: list of dict, optional - Chart panels or ordered layout blocks to add after the markdown content.
         Each dict specifies a chart type and configuration:
         - {"type": "line", "x": "_step", "y": ["loss", "val_loss"], "title": "Training Loss"}
           Creates a LinePlot tracking metrics over steps.
@@ -113,8 +114,17 @@ Args:
            "chart_name": "wandb/line/v0", "chart_fields": {"x": "recall", "y": "precision"},
            "chart_strings": {"title": "PR Curve"}, "hide_run_sets": true}
           Creates a CustomChart from a W&B Table or summary table key via CustomChart.from_table().
+        - {"type": "heading", "level": 2, "text": "Average precision by class"}
+          Adds an H1/H2/H3 report heading at this position.
+        - {"type": "markdown", "text": "These charts share the same filtered runset."}
+          Adds markdown narrative at this position.
+        - {"type": "panel_grid", "run_ids": ["run_a", "run_b"], "hide_run_sets": false,
+           "panels": [{...chart panel...}, {...chart panel...}]}
+          Creates one PanelGrid whose child panels share a single Runset.
         Use custom_chart_table for PR curves, ROC curves, confusion matrices, and other table-backed Vega charts.
-        Panels are additive to markdown content. If omitted, report is markdown-only.
+        If panels only contains chart specs, the tool appends them under a Charts heading for backward compatibility.
+        If panels contains heading, markdown, or panel_grid blocks, the list is treated as an ordered layout and no
+        automatic Charts heading is added. If omitted, report is markdown-only.
 
 <custom_chart_panel_guide>
 Use native panel types for ordinary run metrics:
@@ -150,6 +160,31 @@ If the chart data is computed inside MCP rather than already stored as a W&B
 Table, call log_analysis_to_wandb first, then reference the logged run/table
 from this report tool.
 </custom_chart_panel_guide>
+
+<report_layout_guide>
+Use panel_grid when multiple panels should share one run selector / Runset. This is the correct structure for
+reports such as H2 / markdown / panel-grid / H2 / markdown / panel-grid:
+{
+  "type": "panel_grid",
+  "run_ids": ["run_a", "run_b"],
+  "hide_run_sets": false,
+  "panels": [
+    {"type": "custom_chart", "query": {"summaryTable": {"tableKey": "car_ap"}},
+     "chart_name": "cruise/bar_chart/v2", "chart_fields": {"x": "threshold", "y": "ap"},
+     "chart_strings": {"title": "CAR AP"}},
+    {"type": "custom_chart", "query": {"summaryTable": {"tableKey": "truck_ap"}},
+     "chart_name": "cruise/bar_chart/v2", "chart_fields": {"x": "threshold", "y": "ap"},
+     "chart_strings": {"title": "TRUCK AP"}}
+  ]
+}
+
+Runset scoping:
+- run_ids means W&B internal run keys (Python SDK run.id / GraphQL Run.name), not display names.
+- run_ids are converted to deterministic Reports v2 filters, for example name in ["run_a", "run_b"].
+- filters may be passed as a Reports v2 expression string and wins over generated run_ids filters.
+- runset_query may be passed for explicit search behavior. Do not use custom_chart query for run filtering.
+- chart_name maps to the Vega panelDefId such as wandb/line/v0 or cruise/bar_chart/v2. Put visible titles in chart_strings.
+</report_layout_guide>
 
 <manual_validation_recipe>
 To validate a table-backed custom chart manually:
@@ -262,9 +297,15 @@ def create_report(
             report.blocks = [security_notice] + blocks
 
             if panels:
-                panel_blocks = _build_panel_blocks(panels, entity_name, project_name)
+                layout_mode = _is_layout_mode(panels)
+                panel_blocks = (
+                    _build_layout_blocks(panels, entity_name, project_name)
+                    if layout_mode
+                    else _build_panel_blocks(panels, entity_name, project_name)
+                )
                 if panel_blocks:
-                    report.blocks.append(wr.H2("Charts"))
+                    if not layout_mode:
+                        report.blocks.append(wr.H2("Charts"))
                     report.blocks.extend(panel_blocks)
 
             report.save()
@@ -314,6 +355,12 @@ _KNOWN_PANEL_TYPES = {
     "custom_chart_table",
 }
 
+_LAYOUT_BLOCK_TYPES = {
+    "heading",
+    "markdown",
+    "panel_grid",
+}
+
 
 def _build_panel_block(
     panel_spec: Dict[str, Any],
@@ -322,12 +369,11 @@ def _build_panel_block(
 ):
     """Build one report block for a panel spec."""
     panel_type = panel_spec.get("type", "").lower()
-    if panel_type in {"line", "bar", "scatter", "run_comparison", "markdown_table", "markdown_panel"}:
-        return _build_native_panel(panel_spec, entity_name, project_name)
-    if panel_type == "custom_chart":
-        return _build_custom_chart_panel(panel_spec, entity_name, project_name)
-    if panel_type == "custom_chart_table":
-        return _build_custom_chart_from_table_panel(panel_spec, entity_name, project_name)
+    if panel_type == "markdown_table":
+        return _build_markdown_table_block(panel_spec)
+    panel = _build_panel_object(panel_spec)
+    if panel is not None:
+        return _build_panel_grid(panel_spec, _build_runset(panel_spec, entity_name, project_name), panel)
     return None
 
 
@@ -338,18 +384,53 @@ def _build_runset(
     *,
     include_run_ids: bool = False,
 ):
-    """Build a Runset, preserving the query= workaround used by current panels."""
+    """Build a Reports v2 Runset from MCP JSON-safe runset fields."""
+    runset_spec = panel_spec.get("runset", {})
+    if runset_spec is None:
+        runset_spec = {}
+    if not isinstance(runset_spec, dict):
+        raise ValueError("runset must be an object")
+
+    filters = panel_spec.get("filters", runset_spec.get("filters"))
+    if filters is not None and not isinstance(filters, str):
+        raise ValueError("filters must be a Reports v2 expression string")
+
     run_id = panel_spec.get("analysis_run_id")
-    if run_id:
-        # Use query= instead of filters= because wandb-workspaces
-        # ast.literal_eval chokes on dict-based JSON filter strings.
-        return wr.Runset(entity=entity_name, project=project_name, query=run_id)
+    if not filters and run_id:
+        filters = _run_ids_filter([run_id])
 
-    run_ids = panel_spec.get("run_ids", [])
-    if include_run_ids and run_ids:
-        return wr.Runset(entity=entity_name, project=project_name, query=" ".join(run_ids))
+    run_ids = panel_spec.get("run_ids", runset_spec.get("run_ids", []))
+    if not filters and run_ids:
+        filters = _run_ids_filter(run_ids)
 
-    return wr.Runset(entity=entity_name, project=project_name)
+    query = panel_spec.get("runset_query", runset_spec.get("query", ""))
+    if query is None:
+        query = ""
+    if not isinstance(query, str):
+        raise ValueError("runset query must be a string")
+
+    kwargs = {"entity": entity_name, "project": project_name}
+    if query:
+        kwargs["query"] = query
+    if filters:
+        kwargs["filters"] = filters
+    return wr.Runset(**kwargs)
+
+
+def _run_ids_filter(run_ids: List[str]) -> str:
+    """Return a deterministic Reports v2 filter expression for run keys."""
+    if isinstance(run_ids, str) or not isinstance(run_ids, list):
+        raise ValueError("run_ids must be a list of W&B internal run keys")
+    normalized = []
+    for run_id in run_ids:
+        if not isinstance(run_id, str) or not run_id:
+            raise ValueError("run_ids must contain non-empty strings")
+        normalized.append(run_id)
+    if not normalized:
+        return ""
+    if len(normalized) == 1:
+        return f"name == {json.dumps(normalized[0])}"
+    return f"name in {json.dumps(normalized)}"
 
 
 def _build_panel_grid(panel_spec: Dict[str, Any], runset, panel):
@@ -361,99 +442,90 @@ def _build_panel_grid(panel_spec: Dict[str, Any], runset, panel):
     )
 
 
-def _build_native_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
-    """Build existing native/markdown panel types."""
+def _build_panel_object(panel_spec: Dict[str, Any]):
+    """Build one wandb_workspaces panel object without wrapping it in a grid."""
     panel_type = panel_spec.get("type", "").lower()
     panel_title = panel_spec.get("title", "")
-    runset = _build_runset(panel_spec, entity_name, project_name)
 
     if panel_type == "line":
         x_key = panel_spec.get("x", "_step")
         y_keys = panel_spec.get("y", [])
         if not y_keys:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.LinePlot(x=x_key, y=y_keys, title=panel_title))
+        return wr.LinePlot(x=x_key, y=y_keys, title=panel_title)
 
     if panel_type == "bar":
         metrics = panel_spec.get("metrics", [])
         if not metrics:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.BarPlot(metrics=metrics, title=panel_title))
+        return wr.BarPlot(metrics=metrics, title=panel_title)
 
     if panel_type == "scatter":
         x_key = panel_spec.get("x", "")
         y_key = panel_spec.get("y", "")
         if not x_key or not y_key:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.ScatterPlot(x=x_key, y=y_key, title=panel_title))
+        return wr.ScatterPlot(x=x_key, y=y_key, title=panel_title)
 
     if panel_type == "run_comparison":
         metrics = panel_spec.get("metrics", [])
-        run_ids = panel_spec.get("run_ids", [])
         if not metrics:
             return None
-        if run_ids and not panel_spec.get("analysis_run_id"):
-            comp_runset = wr.Runset(entity=entity_name, project=project_name, query=" ".join(run_ids))
-        else:
-            comp_runset = runset
-        return _build_panel_grid(panel_spec, comp_runset, wr.LinePlot(x="_step", y=metrics, title=panel_title))
+        return wr.LinePlot(x="_step", y=metrics, title=panel_title)
 
     if panel_type == "markdown_table":
-        headers = panel_spec.get("headers", [])
-        rows = panel_spec.get("rows", [])
-        if not headers or not rows:
-            return None
-        md = f"### {panel_title}\n\n" if panel_title else ""
-        md += "| " + " | ".join(str(h) for h in headers) + " |\n"
-        md += "| " + " | ".join(["---"] * len(headers)) + " |\n"
-        for row in rows:
-            md += "| " + " | ".join(str(v) for v in row) + " |\n"
-        return wr.MarkdownBlock(md)
+        return None
 
     if panel_type == "markdown_panel":
         markdown = panel_spec.get("markdown", "")
         if not markdown:
             return None
-        return _build_panel_grid(panel_spec, runset, wr.MarkdownPanel(markdown=markdown))
+        return wr.MarkdownPanel(markdown=markdown)
+
+    if panel_type == "custom_chart":
+        return _build_custom_chart_object(panel_spec)
+
+    if panel_type == "custom_chart_table":
+        return _build_custom_chart_from_table_object(panel_spec)
 
     return None
 
 
-def _build_custom_chart_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
+def _build_markdown_table_block(panel_spec: Dict[str, Any]):
+    """Build a report-level MarkdownBlock table."""
+    panel_title = panel_spec.get("title", "")
+    headers = panel_spec.get("headers", [])
+    rows = panel_spec.get("rows", [])
+    if not headers or not rows:
+        return None
+    md = f"### {panel_title}\n\n" if panel_title else ""
+    md += "| " + " | ".join(str(h) for h in headers) + " |\n"
+    md += "| " + " | ".join(["---"] * len(headers)) + " |\n"
+    for row in rows:
+        md += "| " + " | ".join(str(v) for v in row) + " |\n"
+    return wr.MarkdownBlock(md)
+
+
+def _build_custom_chart_object(panel_spec: Dict[str, Any]):
     """Build a CustomChart from an explicit workspaces query."""
     query = _required_dict(panel_spec, "query")
     chart_fields = _required_dict(panel_spec, "chart_fields")
     chart_strings = _optional_dict(panel_spec, "chart_strings")
     chart_name = _required_string(panel_spec, "chart_name")
-    runset = _build_runset(panel_spec, entity_name, project_name, include_run_ids=True)
-    chart = wr.CustomChart(
+    return wr.CustomChart(
         query=query,
         chart_name=chart_name,
         chart_fields=chart_fields,
         chart_strings=chart_strings,
     )
-    return _build_panel_grid(panel_spec, runset, chart)
 
 
-def _build_custom_chart_from_table_panel(
-    panel_spec: Dict[str, Any],
-    entity_name: str,
-    project_name: str,
-):
+def _build_custom_chart_from_table_object(panel_spec: Dict[str, Any]):
     """Build a CustomChart backed by a W&B Table or summary table key."""
     table_name = _required_string(panel_spec, "table_name")
     chart_fields = _required_dict(panel_spec, "chart_fields")
     chart_strings = _optional_dict(panel_spec, "chart_strings")
-    chart_name = panel_spec.get("chart_name") or panel_spec.get("title") or ""
-    runset = _build_runset(panel_spec, entity_name, project_name, include_run_ids=True)
+    chart_name = panel_spec.get("chart_name") or ""
     chart = wr.CustomChart.from_table(
         table_name,
         chart_fields=chart_fields,
@@ -461,7 +533,86 @@ def _build_custom_chart_from_table_panel(
     )
     if chart_name:
         chart.chart_name = chart_name
-    return _build_panel_grid(panel_spec, runset, chart)
+    return chart
+
+
+def _is_layout_mode(panels: List[Dict[str, Any]]) -> bool:
+    """Return True when panels contains ordered report layout blocks."""
+    return any(panel.get("type", "").lower() in _LAYOUT_BLOCK_TYPES for panel in panels)
+
+
+def _build_layout_blocks(
+    panels: List[Dict[str, Any]],
+    entity_name: str,
+    project_name: str,
+) -> List:
+    """Build ordered report blocks from layout-mode panel specs."""
+    blocks = []
+    for panel_spec in panels:
+        panel_type = panel_spec.get("type", "").lower()
+        panel_title = panel_spec.get("title") or panel_spec.get("text", "")
+        try:
+            block = _build_layout_block(panel_spec, entity_name, project_name)
+            if block is None:
+                if panel_type not in _KNOWN_PANEL_TYPES and panel_type not in _LAYOUT_BLOCK_TYPES:
+                    logger.warning(f"Unknown panel type: {panel_type}")
+                continue
+            if isinstance(block, list):
+                blocks.extend(block)
+            else:
+                blocks.append(block)
+        except Exception as e:
+            logger.warning(f"Failed to build layout block '{panel_title}': {e}", exc_info=True)
+            blocks.append(wr.P(f"*Panel '{panel_title}' could not be rendered.*"))
+    return blocks
+
+
+def _build_layout_block(
+    panel_spec: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+):
+    """Build one ordered layout block."""
+    panel_type = panel_spec.get("type", "").lower()
+    if panel_type == "heading":
+        text = _required_string(panel_spec, "text")
+        level = panel_spec.get("level", 2)
+        if level == 1:
+            return wr.H1(text)
+        if level == 3:
+            return wr.H3(text)
+        return wr.H2(text)
+    if panel_type == "markdown":
+        text = _required_string(panel_spec, "text")
+        return parse_markdown_to_blocks(text)
+    if panel_type == "panel_grid":
+        return _build_panel_grid_block(panel_spec, entity_name, project_name)
+    return _build_panel_block(panel_spec, entity_name, project_name)
+
+
+def _build_panel_grid_block(
+    panel_spec: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+):
+    """Build one PanelGrid with a shared Runset and multiple child panels."""
+    child_specs = panel_spec.get("panels", [])
+    if not isinstance(child_specs, list) or not child_specs:
+        raise ValueError("panel_grid panels must be a non-empty list")
+    panel_objects = []
+    for child_spec in child_specs:
+        if not isinstance(child_spec, dict):
+            raise ValueError("panel_grid child panels must be objects")
+        child = _build_panel_object(child_spec)
+        if child is not None:
+            panel_objects.append(child)
+    if not panel_objects:
+        return None
+    return wr.PanelGrid(
+        runsets=[_build_runset(panel_spec, entity_name, project_name)],
+        hide_run_sets=bool(panel_spec.get("hide_run_sets", False)),
+        panels=panel_objects,
+    )
 
 
 def _required_string(panel_spec: Dict[str, Any], key: str) -> str:

--- a/tests/test_create_report_panels.py
+++ b/tests/test_create_report_panels.py
@@ -1,13 +1,17 @@
 """Tests for the panels parameter on create_wandb_report_tool."""
 
+import importlib
 from unittest.mock import MagicMock, patch
 
 
 from wandb_mcp_server.mcp_tools.create_report import (
     CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
+    _build_layout_blocks,
     _build_panel_blocks,
     create_report,
 )
+
+create_report_module = importlib.import_module("wandb_mcp_server.mcp_tools.create_report")
 
 
 class TestCreateReportPanelsDescription:
@@ -60,12 +64,12 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert len(blocks) == 1
-        assert mock_wr.Runset.call_count == 2
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name in ["r1", "r2"]')
         mock_wr.LinePlot.assert_called_once()
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
-    def test_analysis_run_id_uses_query_not_filters(self, mock_wr):
-        """Runset for analysis_run_id must use query= to avoid ast.Dict crash."""
+    def test_analysis_run_id_uses_deterministic_filter(self, mock_wr):
+        """Runset for analysis_run_id uses persisted Reports v2 filters."""
         mock_wr.PanelGrid = MagicMock()
         mock_wr.BarPlot = MagicMock()
         mock_wr.Runset = MagicMock()
@@ -74,12 +78,12 @@ class TestBuildPanelBlocks:
         _build_panel_blocks(panels, "entity", "project")
 
         runset_call = mock_wr.Runset.call_args
-        assert runset_call[1].get("query") == "abc123"
-        assert "filters" not in runset_call[1]
+        assert runset_call[1].get("filters") == 'name == "abc123"'
+        assert "query" not in runset_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
-    def test_run_comparison_uses_query_not_filters(self, mock_wr):
-        """run_comparison with run_ids must use query= to avoid ast.Dict crash."""
+    def test_run_comparison_uses_deterministic_filter(self, mock_wr):
+        """run_comparison with run_ids uses a deterministic Reports v2 filter."""
         mock_wr.PanelGrid = MagicMock()
         mock_wr.LinePlot = MagicMock()
         mock_wr.Runset = MagicMock()
@@ -87,9 +91,9 @@ class TestBuildPanelBlocks:
         panels = [{"type": "run_comparison", "metrics": ["loss"], "run_ids": ["r1", "r2"], "title": "Compare"}]
         _build_panel_blocks(panels, "entity", "project")
 
-        comp_call = mock_wr.Runset.call_args_list[1]
-        assert comp_call[1].get("query") == "r1 r2"
-        assert "filters" not in comp_call[1]
+        comp_call = mock_wr.Runset.call_args
+        assert comp_call[1].get("filters") == 'name in ["r1", "r2"]'
+        assert "query" not in comp_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_empty_panels_list(self, mock_wr):
@@ -182,7 +186,7 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert len(blocks) == 1
-        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", query="abc123")
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name == "abc123"')
         mock_wr.CustomChart.assert_called_once_with(
             query={"summaryTable": {"tableKey": "pr_curve_table"}},
             chart_name="wandb/line/v0",
@@ -252,6 +256,100 @@ class TestBuildPanelBlocks:
         blocks = _build_panel_blocks(panels, "entity", "project")
 
         assert blocks == ["markdown", "grid:line", "grid:custom"]
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_explicit_filters_win_over_run_ids(self, mock_wr):
+        mock_wr.PanelGrid = MagicMock()
+        mock_wr.LinePlot = MagicMock()
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        panels = [
+            {
+                "type": "line",
+                "x": "_step",
+                "y": ["loss"],
+                "title": "Loss",
+                "run_ids": ["ignored"],
+                "filters": 'displayName == "Customer Run"',
+            }
+        ]
+
+        _build_panel_blocks(panels, "entity", "project")
+
+        mock_wr.Runset.assert_called_once_with(
+            entity="entity",
+            project="project",
+            filters='displayName == "Customer Run"',
+        )
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_explicit_runset_query_is_search_passthrough(self, mock_wr):
+        mock_wr.PanelGrid = MagicMock()
+        mock_wr.LinePlot = MagicMock()
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        panels = [{"type": "line", "x": "_step", "y": ["loss"], "runset_query": "baseline"}]
+
+        _build_panel_blocks(panels, "entity", "project")
+
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", query="baseline")
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_panel_grid_groups_multiple_custom_charts(self, mock_wr):
+        mock_wr.H2 = MagicMock(side_effect=lambda text: f"H2:{text}")
+        mock_wr.P = MagicMock(side_effect=lambda text: f"P:{text}")
+        mock_wr.MarkdownBlock = MagicMock(side_effect=lambda text: f"Markdown:{text}")
+        mock_wr.PanelGrid = MagicMock(return_value="PanelGrid")
+        mock_wr.CustomChart = MagicMock(side_effect=lambda **kw: f"Custom:{kw['chart_strings']['title']}")
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        blocks = _build_layout_blocks(
+            [
+                {"type": "heading", "level": 2, "text": "Average precision by class"},
+                {"type": "markdown", "text": "These panels share the same filtered runset."},
+                {
+                    "type": "panel_grid",
+                    "run_ids": ["run_a", "run_b"],
+                    "panels": [
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "car_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "CAR AP"},
+                        },
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "truck_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "TRUCK AP"},
+                        },
+                        {
+                            "type": "custom_chart",
+                            "query": {"summaryTable": {"tableKey": "motorcycle_ap"}},
+                            "chart_name": "cruise/bar_chart/v2",
+                            "chart_fields": {"x": "threshold", "y": "ap"},
+                            "chart_strings": {"title": "MOTORCYCLE AP"},
+                        },
+                    ],
+                },
+            ],
+            "entity",
+            "project",
+        )
+
+        assert blocks == [
+            "H2:Average precision by class",
+            "P:These panels share the same filtered runset.",
+            "PanelGrid",
+        ]
+        mock_wr.Runset.assert_called_once_with(entity="entity", project="project", filters='name in ["run_a", "run_b"]')
+        mock_wr.PanelGrid.assert_called_once_with(
+            runsets=["Runset"],
+            hide_run_sets=False,
+            panels=["Custom:CAR AP", "Custom:TRUCK AP", "Custom:MOTORCYCLE AP"],
+        )
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_markdown_table_with_unicode_titles(self, mock_wr):
@@ -373,3 +471,110 @@ class TestCreateReportWithPanels:
         assert "MCP Server" in str(blocks[0])
         assert "H2:Charts" in blocks
         assert blocks[-1] == "PanelGrid"
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    @patch("wandb_mcp_server.api_client.WandBApiManager")
+    def test_create_report_with_ordered_layout_does_not_add_charts_heading(self, mock_api_mgr, mock_wr):
+        mock_api_mgr.get_api_key.return_value = "fake_key"
+        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
+
+        mock_report = MagicMock()
+        mock_report.url = "https://wandb.ai/report/layout"
+        mock_wr.Report.return_value = mock_report
+        mock_wr.P = MagicMock(side_effect=lambda text: f"P:{text}")
+        mock_wr.H2 = MagicMock(side_effect=lambda text: f"H2:{text}")
+        mock_wr.MarkdownBlock = MagicMock(side_effect=lambda text: f"Markdown:{text}")
+        mock_wr.PanelGrid = MagicMock(side_effect=lambda **kw: "PanelGrid")
+        mock_wr.LinePlot = MagicMock(return_value="LinePlot")
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        create_report(
+            "entity",
+            "project",
+            "Layout Report",
+            markdown_report_text="Hello world",
+            panels=[
+                {"type": "heading", "level": 2, "text": "Section"},
+                {"type": "markdown", "text": "Section intro"},
+                {"type": "panel_grid", "run_ids": ["run_a"], "panels": [{"type": "line", "y": ["loss"]}]},
+            ],
+        )
+
+        blocks = mock_report.blocks
+        assert "H2:Charts" not in blocks
+        assert blocks[-3:] == ["H2:Section", "P:Section intro", "PanelGrid"]
+
+
+class TestRealWorkspacesReportObjects:
+    @patch("wandb_mcp_server.api_client.WandBApiManager")
+    def test_agent_style_layout_serializes_panel_grid_and_runset_filter(self, mock_api_mgr):
+        """Build the same report shape an agent should send and inspect Reports v2 objects."""
+        mock_api_mgr.get_api_key.return_value = "fake_key"
+        mock_api_mgr.get_api.return_value = MagicMock(viewer={"username": "test-user"})
+
+        fake_api = MagicMock()
+        fake_api.client.app_url = "https://wandb.ai"
+        fake_api.client.execute.return_value = {"project": {"internalId": "project-internal-id"}}
+        captured_reports = []
+
+        def fake_save(report, *args, **kwargs):
+            captured_reports.append(report)
+            report.id = "report-id"
+
+        with (
+            patch.object(create_report_module.wr.Report, "save", fake_save),
+            patch("wandb_workspaces.reports.v2.interface._get_api", return_value=fake_api),
+        ):
+            result = create_report(
+                "entity",
+                "project",
+                "Agent Report",
+                markdown_report_text="# Agent Report\n\n[TOC]",
+                panels=[
+                    {"type": "heading", "level": 2, "text": "Average precision by class"},
+                    {"type": "markdown", "text": "These panels share the same filtered runset."},
+                    {
+                        "type": "panel_grid",
+                        "run_ids": ["run_a", "run_b"],
+                        "hide_run_sets": False,
+                        "panels": [
+                            {
+                                "type": "custom_chart",
+                                "query": {"summaryTable": {"tableKey": "car_ap"}},
+                                "chart_name": "cruise/bar_chart/v2",
+                                "chart_fields": {"x": "threshold", "y": "ap"},
+                                "chart_strings": {"title": "CAR AP"},
+                            },
+                            {
+                                "type": "custom_chart",
+                                "query": {"summaryTable": {"tableKey": "truck_ap"}},
+                                "chart_name": "cruise/bar_chart/v2",
+                                "chart_fields": {"x": "threshold", "y": "ap"},
+                                "chart_strings": {"title": "TRUCK AP"},
+                            },
+                        ],
+                    },
+                ],
+            )
+            report_model = captured_reports[0]._to_model()
+
+        assert result["url"] == "https://wandb.ai/entity/project/reports/Agent-Report--report-id"
+        panel_grids = [block for block in report_model.spec.blocks if getattr(block, "type", None) == "panel-grid"]
+        assert len(panel_grids) == 1
+
+        panel_grid = panel_grids[0]
+        runset = panel_grid.metadata.run_sets[0]
+        assert runset.search.query == ""
+        filters = runset.filters.filters[0].filters
+        assert len(filters) == 1
+        assert filters[0].key.name == "name"
+        assert filters[0].op == "IN"
+        assert filters[0].value == ["run_a", "run_b"]
+
+        panels = panel_grid.metadata.panel_bank_section_config.panels
+        assert len(panels) == 2
+        assert [panel.config.panel_def_id for panel in panels] == [
+            "cruise/bar_chart/v2",
+            "cruise/bar_chart/v2",
+        ]
+        assert [panel.config.string_settings["title"] for panel in panels] == ["CAR AP", "TRUCK AP"]

--- a/tests/test_report_improvements.py
+++ b/tests/test_report_improvements.py
@@ -123,8 +123,8 @@ class TestAnalysisRunId:
 
         assert len(blocks) == 1
         runset_call = mock_wr.Runset.call_args
-        assert runset_call[1]["query"] == "abc123"
-        assert "filters" not in runset_call[1]
+        assert runset_call[1]["filters"] == 'name == "abc123"'
+        assert "query" not in runset_call[1]
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_no_analysis_run_id_uses_default_runset(self, mock_wr):
@@ -161,5 +161,5 @@ class TestRunComparisonFix:
 
         assert len(blocks) == 1
         filtered_runset_call = mock_wr.Runset.call_args_list[-1]
-        assert filtered_runset_call[1]["query"] == "r1 r2"
-        assert "filters" not in filtered_runset_call[1]
+        assert filtered_runset_call[1]["filters"] == 'name in ["r1", "r2"]'
+        assert "query" not in filtered_runset_call[1]

--- a/uv.lock
+++ b/uv.lock
@@ -2195,7 +2195,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
     { name = "wandb", specifier = ">=0.25.1" },
-    { name = "wandb-workspaces", specifier = ">=0.1.12" },
+    { name = "wandb-workspaces", specifier = ">=0.3.9" },
     { name = "weave", specifier = ">=0.52.35" },
 ]
 provides-extras = ["test", "http"]
@@ -2208,15 +2208,15 @@ dev = [
 
 [[package]]
 name = "wandb-workspaces"
-version = "0.1.18"
+version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/2c/dc9a134b7383b7555ebb2da2894f0d4c8ebee8e3bf944601f3122e8b4def/wandb_workspaces-0.1.18.tar.gz", hash = "sha256:3fcbfa391fd4d469dcf091ea897a8ed39c2688806a307d56df721e2f1689a337", size = 77294, upload-time = "2025-09-05T15:18:26.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/d3/3a5ebc8b969ec8d2391bb43e4a3d76ceaee2bfc11c9e9dc96b61577a9092/wandb_workspaces-0.3.9.tar.gz", hash = "sha256:d186faa7b0c4e6c33aecfea833e81ca0256d117b26f7e428f002c14cbf30601c", size = 210169, upload-time = "2026-03-31T15:23:20.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/75/14f5eb4ff53a6732637f000e7e6c14e055b0d69a9636689502d13a13b302/wandb_workspaces-0.1.18-py3-none-any.whl", hash = "sha256:ab4134cc7c0e33daf4dd70b67848a05bcd1ee21bad924b943edc8303fe789bdc", size = 87843, upload-time = "2025-09-05T15:18:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/112522e555b1fef7129e85065348d20dcb8761171b07614b5d3e95f86759/wandb_workspaces-0.3.9-py3-none-any.whl", hash = "sha256:79fbb9e899e5457f18446fd6a8c066a05709562ad9fe31b3d215ca4749a65f25", size = 100710, upload-time = "2026-03-31T15:23:18.934Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `wandb-workspaces` to `>=0.3.9` so report creation uses the latest Reports v2 API.
- Adds ordered report layout blocks (`heading`, `markdown`, `panel_grid`) so agents can build multi-section reports without scripts.
- Switches generated `run_ids` / `analysis_run_id` scoping to deterministic Reports v2 filters while preserving explicit search query passthrough.

## Changes
- Preserves legacy flat `panels` behavior with an automatic `Charts` heading.
- Supports one shared `Runset` across multiple panels in a `panel_grid`.
- Documents `chart_name` as Vega `panelDefId` and clarifies internal run key semantics for `run_ids`.
- Adds mock and real `wandb_workspaces` object tests for agent-authored report payloads.

## Jira link
- https://coreweave.atlassian.net/browse/WB-34806

## Test plan
- `uv run pytest tests/test_create_report_panels.py tests/test_report_improvements.py tests/test_markdown_parsing.py -v --tb=short`
- `uv run ruff check src/ tests/`

Made with [Cursor](https://cursor.com)