### PR TITLE
feat: add read-only Automations tools (list_wandb_automations + list_wandb_integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Query and analyze your Weights & Biases data using natural language through the 
 </details>
 
 <details>
-<summary><strong>Available Tools</strong> (14 tools)</summary>
+<summary><strong>Available Tools</strong> (16 tools)</summary>
 
 | Tool | Description | Example Query |
 |------|-------------|---------------|
@@ -51,6 +51,8 @@ Query and analyze your Weights & Biases data using natural language through the 
 | **list_artifact_versions_tool** | List versions of an artifact collection | *"Show versions of my model artifact"* |
 | **get_artifact_details_tool** | Get full details of an artifact version | *"What's in model-v2 artifact?"* |
 | **compare_artifact_versions_tool** | Diff two artifact versions | *"Compare model v1 vs v2"* |
+| **list_wandb_automations_tool** | List W&B Automations (artifact, run-state, run-metric triggers) | *"What automations alert my team on Slack?"* |
+| **list_wandb_integrations_tool** | List Slack and webhook integrations | *"Which Slack channels can my automations target?"* |
 
 **Schema-first workflow:** Call `infer_trace_schema_tool` first to discover fields, then `query_weave_traces_tool` with precise columns and `detail_level`:
 - `"schema"` -- structural fields only (fast browsing)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Query and analyze your Weights & Biases data using natural language through the 
 | **list_artifact_versions_tool** | List versions of an artifact collection | *"Show versions of my model artifact"* |
 | **get_artifact_details_tool** | Get full details of an artifact version | *"What's in model-v2 artifact?"* |
 | **compare_artifact_versions_tool** | Diff two artifact versions | *"Compare model v1 vs v2"* |
-| **list_wandb_automations_tool** | List W&B Automations (artifact, run-state, run-metric triggers) | *"What automations alert my team on Slack?"* |
-| **list_wandb_integrations_tool** | List Slack and webhook integrations | *"Which Slack channels can my automations target?"* |
+| **list_wandb_automations_tool** | List W&B Automations | *"What automations alert on run metrics or status for my team's runs?"* |
+| **list_wandb_integrations_tool** | List registered integrations for W&B automations (e.g. Slack, webhook) | *"Which Slack channels can my automations target?"* |
 
 **Schema-first workflow:** Call `infer_trace_schema_tool` first to discover fields, then `query_weave_traces_tool` with precise columns and `detail_level`:
 - `"schema"` -- structural fields only (fast browsing)
@@ -68,13 +68,13 @@ Query and analyze your Weights & Biases data using natural language through the 
 <details>
 <summary><strong>Usage Tips</strong> (best practices)</summary>
 
-**→ Provide your W&B project and entity name**  
+**→ Provide your W&B project and entity name**
 LLMs are not mind readers, ensure you specify the W&B Entity and W&B Project to the LLM.
 
-**→ Avoid asking overly broad questions**  
+**→ Avoid asking overly broad questions**
 Questions such as "what is my best evaluation?" are probably overly broad and you'll get to an answer faster by refining your question to be more specific such as: "what eval had the highest f1 score?"
 
-**→ Ensure all data was retrieved**  
+**→ Ensure all data was retrieved**
 When asking broad, general questions such as "what are my best performing runs/evaluations?" it's always a good idea to ask the LLM to check that it retrieved all the available runs. The MCP tools are designed to fetch the correct amount of data, but sometimes there can be a tendency from the LLMs to only retrieve the latest runs or the last N runs.
 
 </details>
@@ -96,7 +96,7 @@ We recommend using our **hosted server** at `https://mcp.withwandb.com` - no ins
   * Click on the button above to automatically add the config to Cursor
   * Then add your WANDB_API_KEY in the respective field `Bearer YOUR_API_KEY` and connect
 
-For manual or local installation, see [Option 2](#general-installation-guide) below. 
+For manual or local installation, see [Option 2](#general-installation-guide) below.
 </details>
 
 ### OpenAI Response API
@@ -216,7 +216,7 @@ If adding the W&B connector from the Le Chat connector directory returns an `int
 <details>
 <summary>Configuration setup</summary>
 
-Add to your Claude config file. Claude desktop currently doesn't support remote MCPs to be added so we're adding the local MCP. Be careful to add the full path to `uv` for the command because Claude Desktop potentially doesn't find your `uv` installation otherwise. 
+Add to your Claude config file. Claude desktop currently doesn't support remote MCPs to be added so we're adding the local MCP. Be careful to add the full path to `uv` for the command because Claude Desktop potentially doesn't find your `uv` installation otherwise.
 
 ```bash
 # macOS
@@ -247,7 +247,7 @@ notepad %APPDATA%\Claude\claude_desktop_config.json
 Restart Claude Desktop to activate.
 </details>
 
-We're working on adding OAuth support so that we can integrate with ChatGPT. 
+We're working on adding OAuth support so that we can integrate with ChatGPT.
 
 ---
 
@@ -315,7 +315,7 @@ Add to your MCP client config (for detailed client-specific configs see below):
 }
 ```
 
-### Cursor 
+### Cursor
 1. Open Cursor Settings (`⌘,` or `Ctrl,`)
 2. Navigate to **Features** → **Model Context Protocol**
 3. Click **"Install from Registry"** or **"Add MCP Server"**
@@ -323,8 +323,8 @@ Add to your MCP client config (for detailed client-specific configs see below):
    - **Name**: `wandb`
    - **URL**: `https://mcp.withwandb.com/mcp`
    - **API Key**: Your W&B API key
-  
-Manual hosted config in `mcp.json`: 
+
+Manual hosted config in `mcp.json`:
 ```
 "wandb": {
   "transport": "http",
@@ -367,8 +367,8 @@ Add `--scope user` for global config.
 claude mcp add wandb -e WANDB_API_KEY=your-api-key -e WANDB_BASE_URL=your-base-url -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
 
-### Claude Desktop 
-Same as above. 
+### Claude Desktop
+Same as above.
 ```bash
 # macOS
 open ~/Library/Application\ Support/Claude/claude_desktop_config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ add_to_client = "wandb_mcp_server.add_to_client:add_to_client_cli"
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.1",
+    "pytest-mock>=3.14.0",
     "litellm>=1.67.2,<=1.82.6",
     "anthropic>=0.50.0",
     "pytest-xdist>=3.6.1",

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -304,7 +304,7 @@ def list_integrations(
     with track_tool_execution("list_integrations", api.viewer, params) as ctx:
         max_items = _clamp(max_items, 1, MAX_ITEMS_CEIL)
 
-        if kind and (kind not in _VALID_INTEGRATION_KINDS):
+        if kind is not None and kind not in _VALID_INTEGRATION_KINDS:
             ctx.mark_error(f"invalid kind: {kind!r}")
 
             msg = f"kind must be one of {sorted(_VALID_INTEGRATION_KINDS)} or null, got {kind!r}"

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -8,7 +8,7 @@ public ``wandb.Api`` interface introduced in wandb 0.19.11.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
@@ -22,7 +22,13 @@ MAX_ITEMS_CEILING = 200
 # Valid integration_type values for list_integrations.
 _SLACK = "slack"
 _WEBHOOK = "webhook"
-_VALID_INTEGRATION_TYPES = {_SLACK, _WEBHOOK}
+_VALID_INTEGRATION_TYPES = frozenset({_SLACK, _WEBHOOK})
+
+# wandb backend `__typename` strings used to discriminate the Integration union.
+# See wandb/automations/_generated/fragments.py: SlackIntegrationFields,
+# WebhookIntegrationFields.
+_TYPENAME_SLACK_INTEGRATION = "SlackIntegration"
+_TYPENAME_WEBHOOK_INTEGRATION = "GenericWebhookIntegration"
 
 
 # ---------------------------------------------------------------------------
@@ -56,9 +62,13 @@ instead (or in addition).
   the response sets truncated=true.
 - Each returned automation has:
     id, name, enabled, description, created_at, updated_at,
-    scope:  {type, name, ...}     -- PROJECT or ARTIFACT_COLLECTION
-    event:  {type, summary}       -- e.g. RUN_METRIC threshold, ADD_ARTIFACT_ALIAS
+    scope:  {type, id, name}      -- PROJECT or ARTIFACT_COLLECTION
+    event:  {type, filter}        -- e.g. RUN_METRIC threshold, ADD_ARTIFACT_ALIAS
     action: {type, ...}           -- NOTIFICATION (Slack), GENERIC_WEBHOOK, NO_OP
+- The wandb GraphQL schema only stores the scope's id + name; it does NOT
+  return the parent project/entity on the scope itself. If you need that
+  context, use the `entity` you passed in (for the scope) and look up the
+  project separately.
 - This tool is read-only. It cannot create, modify, or delete automations.
 </critical_info>
 
@@ -82,105 +92,150 @@ JSON with:
 """
 
 
-def _serialize_scope(scope: Any) -> Dict[str, Any]:
-    """Flatten an AutomationScope (ProjectScope or ArtifactCollectionScope) to a dict.
+def _serialize_scope(scope: Any) -> dict[str, Any]:
+    """Flatten an AutomationScope to ``{type, id, name}``.
 
-    Uses getattr with defaults so any future scope-type addition still serializes
-    without raising. The ``scope_type`` field is set by the SDK on every scope
-    subclass (see wandb/wandb/automations/scopes.py).
+    The wandb GraphQL fragments only carry ``id`` and ``name`` on scopes
+    (see ``wandb/automations/_generated/fragments.py:ProjectScopeFields``,
+    ``ArtifactSequenceScopeFields``, ``ArtifactPortfolioScopeFields``).
+    ``scope_type`` is the public enum (``PROJECT`` or ``ARTIFACT_COLLECTION``)
+    added by ``wandb.automations.scopes``.
     """
-    scope_type = getattr(scope, "scope_type", None)
-    out: Dict[str, Any] = {
-        "type": getattr(scope_type, "value", str(scope_type)) if scope_type is not None else None,
-        "name": getattr(scope, "name", None),
+    return {
+        "type": scope.scope_type.value,
+        "id": scope.id,
+        "name": scope.name,
     }
-    # ProjectScope carries entity/project info directly; ArtifactCollection scopes
-    # carry it on a nested project field. Try both flat and nested locations.
-    project = getattr(scope, "project", None)
-    if project is not None and not isinstance(project, str):
-        out["project"] = getattr(project, "name", None)
-        out["entity"] = getattr(project, "entity_name", None) or getattr(project, "entity", None)
-    else:
-        out["project"] = project
-        out["entity"] = getattr(scope, "entity_name", None) or getattr(scope, "entity", None)
-    return out
 
 
-def _serialize_event(event: Any) -> Dict[str, Any]:
-    """Flatten a SavedEvent into a small dict with type + human-readable summary."""
-    event_type = getattr(event, "event_type", None)
-    type_str = getattr(event_type, "value", str(event_type)) if event_type is not None else None
+def _serialize_metric_filter(metric: Any) -> dict[str, Any]:
+    """Flatten the inner metric filter from a RunMetricFilter wrapper.
 
-    # The filter on a SavedEvent is either a _WrappedSavedEventFilter (mutation
-    # events) or a RunMetricFilter / RunStateFilter. For each, prefer the
-    # built-in __repr__ on the innermost metric/state filter, which produces a
-    # compact human-readable string (see _filters/run_metrics.py:147-150).
-    summary: Optional[str] = None
-    filt = getattr(event, "filter", None)
-    try:
-        inner_metric = getattr(filt, "metric", None)
-        inner_state = getattr(filt, "state", None)
-        if inner_metric is not None:
-            inner = (
-                getattr(inner_metric, "threshold_filter", None)
-                or getattr(inner_metric, "change_filter", None)
-                or getattr(inner_metric, "zscore_filter", None)
-                or inner_metric
-            )
-            summary = repr(inner).strip("'")
-        elif inner_state is not None:
-            summary = repr(inner_state).strip("'")
-        elif filt is not None:
-            summary = repr(filt).strip("'")
-    except Exception:
-        summary = None
+    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants
+    (``_WrappedMetricThresholdFilter`` / ``_WrappedMetricChangeFilter`` /
+    ``_WrappedMetricZScoreFilter``); each defines exactly one of the
+    ``threshold_filter`` / ``change_filter`` / ``zscore_filter`` attributes.
+    We discriminate by attribute presence rather than reaching into wandb's
+    private union types.
+    """
+    if (inner := getattr(metric, "threshold_filter", None)) is not None:
+        return {
+            "kind": "threshold",
+            "metric": inner.name,
+            "agg": inner.agg.value if inner.agg else None,
+            "window": inner.window,
+            "cmp": inner.cmp,
+            "threshold": inner.threshold,
+        }
+    if (inner := getattr(metric, "change_filter", None)) is not None:
+        return {
+            "kind": "change",
+            "metric": inner.name,
+            "agg": inner.agg.value if inner.agg else None,
+            "current_window": inner.window,
+            "prior_window": inner.prior_window,
+            "change_type": inner.change_type.value,
+            "change_dir": inner.change_dir.value,
+            "threshold": inner.threshold,
+        }
+    if (inner := getattr(metric, "zscore_filter", None)) is not None:
+        return {
+            "kind": "zscore",
+            "metric": inner.name,
+            "window": inner.window,
+            "change_dir": inner.change_dir.value,
+            "threshold": inner.threshold,
+        }
+    return {"kind": "unknown"}
 
-    return {"type": type_str, "summary": summary}
+
+def _serialize_state_filter(state: Any) -> dict[str, Any]:
+    """Flatten a run-state filter to ``{states: [...]}``.
+
+    ``StateFilter`` (from wandb.automations._filters.run_states) carries an
+    in-list of states. We expose them as plain strings for easy LLM use.
+    """
+    states = getattr(state, "states", None)
+    if states is None:
+        # Older saved automations may store the state differently; fall back to repr.
+        return {"summary": repr(state)}
+    return {"states": [s.value if hasattr(s, "value") else str(s) for s in states]}
 
 
-def _serialize_action(action: Any) -> Dict[str, Any]:
-    """Flatten a SavedAction into a dict with type + the fields agents need."""
-    action_type = getattr(action, "action_type", None)
-    type_str = getattr(action_type, "value", str(action_type)) if action_type is not None else None
-    out: Dict[str, Any] = {"type": type_str}
+def _serialize_event(event: Any) -> dict[str, Any]:
+    """Flatten a SavedEvent to ``{type, filter}``.
+
+    ``event.filter`` is one of:
+    - ``_WrappedSavedEventFilter`` for mutation events (CREATE_ARTIFACT etc.),
+      whose ``.filter`` is a MongoLikeFilter -- we just expose it as a brief
+      string summary, since the structure is open-ended.
+    - ``RunMetricFilter`` for RUN_METRIC* events, whose ``.metric`` holds the
+      typed threshold/change/zscore filter we flatten via _serialize_metric_filter.
+    - ``RunStateFilter`` for RUN_STATE events, whose ``.state`` holds the
+      state filter we flatten via _serialize_state_filter.
+    """
+    type_str = event.event_type.value
+    raw_filter = event.filter
+
+    metric = getattr(raw_filter, "metric", None)
+    if metric is not None:
+        return {"type": type_str, "filter": _serialize_metric_filter(metric)}
+
+    state = getattr(raw_filter, "state", None)
+    if state is not None:
+        return {"type": type_str, "filter": _serialize_state_filter(state)}
+
+    # Mutation-event filter (And()/MongoLikeFilter) -- no public structured shape.
+    return {"type": type_str, "filter": {"summary": repr(raw_filter)}}
+
+
+def _serialize_action(action: Any) -> dict[str, Any]:
+    """Flatten a SavedAction to ``{type, ...}``.
+
+    Saved actions are a discriminated union on ``action_type``
+    (``NOTIFICATION`` / ``GENERIC_WEBHOOK`` / ``NO_OP`` / ``QUEUE_JOB``).
+    NOTIFICATION carries title/message/severity; GENERIC_WEBHOOK carries
+    request_payload; both reference an integration by id.
+    """
+    type_str = action.action_type.value
+    out: dict[str, Any] = {"type": type_str}
 
     integration = getattr(action, "integration", None)
     if integration is not None:
-        out["integration_id"] = getattr(integration, "id", None)
+        out["integration_id"] = integration.id
 
-    # NOTIFICATION (Slack) carries title/message/severity; webhook does not.
     if type_str == "NOTIFICATION":
-        out["title"] = getattr(action, "title", None)
-        out["message"] = getattr(action, "message", None)
-        severity = getattr(action, "severity", None)
-        out["severity"] = getattr(severity, "value", str(severity)) if severity is not None else None
+        out["title"] = action.title
+        out["message"] = action.message
+        out["severity"] = action.severity.value if action.severity else None
+    elif type_str == "GENERIC_WEBHOOK":
+        # request_payload is JSON-encoded on the wire; the SDK already
+        # parses it back into a dict via JsonEncoded[dict[str, Any]].
+        out["request_payload"] = getattr(action, "request_payload", None)
+
     return out
 
 
-def _serialize_automation(automation: Any) -> Dict[str, Any]:
-    """Flatten an Automation pydantic object into a JSON-safe dict."""
-    created_at = getattr(automation, "created_at", None)
-    updated_at = getattr(automation, "updated_at", None)
+def _serialize_automation(automation: Any) -> dict[str, Any]:
+    """Flatten an Automation pydantic object to a JSON-safe dict."""
+    created_at = automation.created_at
+    updated_at = automation.updated_at
     return {
-        "id": getattr(automation, "id", None),
-        "name": getattr(automation, "name", None),
-        "enabled": getattr(automation, "enabled", None),
-        "description": getattr(automation, "description", None),
-        "created_at": created_at.isoformat()
-        if hasattr(created_at, "isoformat")
-        else (str(created_at) if created_at is not None else None),
-        "updated_at": updated_at.isoformat()
-        if hasattr(updated_at, "isoformat")
-        else (str(updated_at) if updated_at is not None else None),
-        "scope": _serialize_scope(getattr(automation, "scope", None)),
-        "event": _serialize_event(getattr(automation, "event", None)),
-        "action": _serialize_action(getattr(automation, "action", None)),
+        "id": automation.id,
+        "name": automation.name,
+        "enabled": automation.enabled,
+        "description": automation.description,
+        "created_at": created_at.isoformat(),
+        "updated_at": updated_at.isoformat() if updated_at is not None else None,
+        "scope": _serialize_scope(automation.scope),
+        "event": _serialize_event(automation.event),
+        "action": _serialize_action(automation.action),
     }
 
 
 def list_automations(
-    entity: Optional[str] = None,
-    name: Optional[str] = None,
+    entity: str | None = None,
+    name: str | None = None,
     max_items: int = DEFAULT_MAX_ITEMS,
 ) -> str:
     """List W&B Automations accessible with the current API key."""
@@ -194,13 +249,13 @@ def list_automations(
         max_items = min(max_items, MAX_ITEMS_CEILING)
 
         try:
-            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            kwargs: dict[str, Any] = {"per_page": min(max_items, 100)}
             if entity is not None:
                 kwargs["entity"] = entity
             if name is not None:
                 kwargs["name"] = name
 
-            automations: List[Dict[str, Any]] = []
+            automations: list[dict[str, Any]] = []
             truncated = False
             for auto in api.automations(**kwargs):
                 if len(automations) >= max_items:
@@ -274,38 +329,39 @@ JSON with:
 """
 
 
-def _serialize_integration(integration: Any) -> Dict[str, Any]:
-    """Flatten a SlackIntegration or WebhookIntegration into a JSON-safe dict.
+def _serialize_integration(integration: Any) -> dict[str, Any]:
+    """Flatten a SlackIntegration or WebhookIntegration to a JSON-safe dict.
 
-    The two integration kinds are discriminated by the GraphQL ``__typename``
-    field, exposed in the SDK as ``typename__``. Slack integrations carry
-    team_name + channel_name; webhook integrations carry name + url_endpoint.
+    The Integration union is discriminated by the GraphQL ``__typename``
+    field, exposed on the SDK pydantic models as ``typename__``. Both
+    variants share ``id``; Slack adds ``team_name`` / ``channel_name``,
+    webhook adds ``name`` / ``url_endpoint``.
     """
-    typename = getattr(integration, "typename__", None)
-    if typename == "SlackIntegration":
+    typename = integration.typename__
+    if typename == _TYPENAME_SLACK_INTEGRATION:
         return {
-            "id": getattr(integration, "id", None),
+            "id": integration.id,
             "type": _SLACK,
-            "team_name": getattr(integration, "team_name", None),
-            "channel_name": getattr(integration, "channel_name", None),
+            "team_name": integration.team_name,
+            "channel_name": integration.channel_name,
         }
-    if typename == "GenericWebhookIntegration":
+    if typename == _TYPENAME_WEBHOOK_INTEGRATION:
         return {
-            "id": getattr(integration, "id", None),
+            "id": integration.id,
             "type": _WEBHOOK,
-            "name": getattr(integration, "name", None),
-            "url_endpoint": getattr(integration, "url_endpoint", None),
+            "name": integration.name,
+            "url_endpoint": integration.url_endpoint,
         }
-    # Fallback for unknown future integration kinds: surface what we can.
-    return {
-        "id": getattr(integration, "id", None),
-        "type": typename or "unknown",
-    }
+    # Forward-compat: surface unknown kinds with at least an id + raw typename
+    # rather than dropping or erroring, so future integration kinds added on
+    # the server side don't break this tool. ``id`` is on every Integration
+    # subclass in the generated fragments.
+    return {"id": integration.id, "type": typename}
 
 
 def list_integrations(
-    entity: Optional[str] = None,
-    integration_type: Optional[str] = None,
+    entity: str | None = None,
+    integration_type: str | None = None,
     max_items: int = DEFAULT_MAX_ITEMS,
 ) -> str:
     """List Slack and/or webhook integrations for an entity."""
@@ -331,7 +387,7 @@ def list_integrations(
             )
 
         try:
-            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            kwargs: dict[str, Any] = {"per_page": min(max_items, 100)}
             if entity is not None:
                 kwargs["entity"] = entity
 
@@ -342,7 +398,7 @@ def list_integrations(
             else:
                 source = api.integrations(**kwargs)
 
-            integrations: List[Dict[str, Any]] = []
+            integrations: list[dict[str, Any]] = []
             truncated = False
             for item in source:
                 if len(integrations) >= max_items:

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -65,18 +65,18 @@ LIST_AUTOMATIONS_TOOL_DESCRIPTION = dedent(
     <critical_info>
     - entity=None lists every automation the authenticated viewer can see across
     all of their teams. Pass entity="<team-or-user>" to scope to one entity.
-    - The optional name filter is an exact match (not regex/substring).
+    - The optional name filter is an exact match (not regex or substring).
     - Results are capped by max_items (default 50, ceiling 200). When more exist,
     the response sets truncated=true.
-    - Each returned automation has:
-        id, name, enabled, description, created_at, updated_at,
-        scope:  {type, id, name}      -- PROJECT or ARTIFACT_COLLECTION
-        event:  {type, filter}        -- structured per event type
-        action: {type, ...}           -- NOTIFICATION (Slack), GENERIC_WEBHOOK, NO_OP
-    - The wandb GraphQL schema only stores the scope's id + name; it does NOT
-    return the parent project/entity on the scope itself. If you need that
-    context, use the `entity` you passed in (for the scope) and look up the
-    project separately.
+    - Each returned automation has these fields: id, name, enabled, description,
+    created_at, updated_at, scope, event, action.
+    - scope is {type, id, name} where type is PROJECT or ARTIFACT_COLLECTION.
+    - event is {type, filter} where filter shape depends on the event type.
+    - action is {type, ...} with extra fields per action type (NOTIFICATION for
+    Slack, GENERIC_WEBHOOK for webhooks, NO_OP for placeholders).
+    - The scope only includes id and name. The parent project and entity are
+    not on the scope. If you need them, use the `entity` you passed to this
+    tool and look up the project separately.
     - This tool is read-only. It cannot create, modify, or delete automations.
     </critical_info>
 
@@ -88,7 +88,7 @@ LIST_AUTOMATIONS_TOOL_DESCRIPTION = dedent(
     name : str, optional
         Exact-match filter on the automation's name.
     max_items : int, optional
-        Maximum automations to return. Default: 50, max: 200.
+        Maximum automations to return. Default 50, ceiling 200.
 
     Returns
     -------
@@ -120,9 +120,9 @@ def _jsonify_scope(scope: ProjectScope | ArtifactCollectionScope) -> dict[str, A
 def _jsonify_metric_filter(metric_filter: Any) -> dict[str, Any]:
     """Flatten the inner metric filter from a RunMetricFilter wrapper.
 
-    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants;
-    each carries its own ``event_type`` discriminator and exposes exactly
-    one of the threshold / change / zscore sub-filter attributes. We
+    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants.
+    Each carries its own ``event_type`` discriminator and exposes exactly
+    one of the threshold, change, or zscore sub-filter attributes. We
     discriminate via the upstream-defined enum value rather than poking at
     attribute presence.
     """
@@ -159,10 +159,10 @@ def _jsonify_event(event: SavedEvent) -> dict[str, Any]:
 def _jsonify_action(action: SavedAction) -> dict[str, Any]:
     """Flatten a SavedAction to a JSON-safe dict.
 
-    Discriminated on the public ``ActionType`` enum. Each variant emits
-    exactly the fields that the wandb SDK guarantees on its pydantic class
-    (SavedNotificationAction / SavedWebhookAction / SavedNoOpAction); no
-    cross-variant attribute access is needed.
+    Match-cases on the public ``Saved*Action`` pydantic types
+    (SavedNotificationAction, SavedWebhookAction, SavedNoOpAction). Each
+    arm emits only the fields its variant guarantees, so we never reach
+    for an attribute the variant does not define.
     """
     from wandb.automations.actions import SavedNoOpAction, SavedNotificationAction, SavedWebhookAction
 
@@ -228,7 +228,7 @@ LIST_INTEGRATIONS_TOOL_DESCRIPTION = dedent("""\
     List W&B integrations (Slack channels and webhooks) for an entity.
 
     Integrations are the destinations that W&B Automations send notifications to.
-    A SlackIntegration represents a connected Slack channel; a WebhookIntegration
+    A SlackIntegration represents a connected Slack channel. A WebhookIntegration
     represents a configured outbound webhook URL. An Automation action references
     exactly one integration by id.
 
@@ -243,13 +243,12 @@ LIST_INTEGRATIONS_TOOL_DESCRIPTION = dedent("""\
     </when_to_use>
 
     <critical_info>
-    - Integrations are configured at the entity (team) level via the W&B UI; this
-    tool only lists existing integrations, it does not create them.
+    - Integrations are configured at the entity (team) level via the W&B UI.
+    This tool only lists existing integrations. It does not create them.
     - entity=None defaults to the authenticated viewer's default entity.
-    - kind filters: "slack" returns only Slack integrations,
-    "webhook" returns only generic webhook integrations, omit/null returns both.
+    - kind is "slack" (Slack only), "webhook" (webhook only), or null (both).
     - Each returned record always has {id, type}. Slack adds {team_name,
-    channel_name}; webhook adds {name, url_endpoint}.
+    channel_name}. Webhook adds {name, url_endpoint}.
     </critical_info>
 
     Parameters
@@ -259,7 +258,7 @@ LIST_INTEGRATIONS_TOOL_DESCRIPTION = dedent("""\
     kind : "slack" | "webhook" | None
         Omit to return both kinds.
     max_items : int, optional
-        Maximum integrations to return. Default: 50, max: 200.
+        Maximum integrations to return. Default 50, ceiling 200.
 
     Returns
     -------
@@ -276,7 +275,7 @@ def _jsonify_integration(integration: Integration) -> dict[str, Any]:
     """Flatten a Slack or Webhook integration to a JSON-safe dict.
 
     Discriminated via ``isinstance`` against the public wandb pydantic
-    classes -- pydantic v2 returns concrete subclass instances for
+    classes. pydantic v2 returns concrete subclass instances for
     discriminated unions, so this is the canonical way to branch.
     The wildcard arm keeps the tool forward-compatible with future
     integration kinds the server may add.
@@ -318,7 +317,7 @@ def list_integrations(
                     iterator = api.slack_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
                 case "webhook":
                     iterator = api.webhook_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
-                case _:  # None -- already validated above
+                case _:  # None (already validated above)
                     iterator = api.integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
 
             integrations = list(map(_jsonify_integration, islice(iterator, max_items)))

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -145,7 +145,7 @@ def _jsonify_event(event: SavedEvent) -> dict[str, Any]:
     that we surface as a brief string ``summary`` since the SDK doesn't
     expose a stable structured shape for it.
     """
-    from wandb.automations.events import RunMetricFilter, RunStateFilter
+    from wandb.automations.events import RunMetricFilter, RunStateFilter, SavedEvent
 
     match event:
         case SavedEvent(event_type=type_, filter=RunMetricFilter(metric=metric_filter)):

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -8,269 +8,211 @@ public ``wandb.Api`` interface introduced in wandb 0.19.11.
 from __future__ import annotations
 
 import json
-from typing import Any
+from collections.abc import Collection, Iterator
+from itertools import islice
+from textwrap import dedent
+from typing import TYPE_CHECKING, Any, Final, Literal, get_args
+
+from pydantic import PositiveInt
+from wandb.automations import EventType, SlackIntegration, WebhookIntegration
 
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 
+if TYPE_CHECKING:
+    from wandb.automations import ArtifactCollectionScope, Automation, Integration, ProjectScope
+    from wandb.automations.actions import SavedAction
+    from wandb.automations.events import SavedEvent
+
 logger = get_rich_logger(__name__)
 
-DEFAULT_MAX_ITEMS = 50
-MAX_ITEMS_CEILING = 200
+MAX_ITEMS_DEFAULT: Final[int] = 50
+MAX_ITEMS_CEIL: Final[int] = 200
 
-# Valid integration_type values for list_integrations.
-_SLACK = "slack"
-_WEBHOOK = "webhook"
-_VALID_INTEGRATION_TYPES = frozenset({_SLACK, _WEBHOOK})
+# Public literal type so MCP clients see the allowed values for the ``kind`` parameter.
+IntegrationKind = Literal["slack", "webhook"]
+_VALID_INTEGRATION_KINDS: Final[Collection[IntegrationKind]] = frozenset(get_args(IntegrationKind))
 
-# wandb backend `__typename` strings used to discriminate the Integration union.
-# See wandb/automations/_generated/fragments.py: SlackIntegrationFields,
-# WebhookIntegrationFields.
-_TYPENAME_SLACK_INTEGRATION = "SlackIntegration"
-_TYPENAME_WEBHOOK_INTEGRATION = "GenericWebhookIntegration"
+_DUMP_KWARGS: Final[dict[str, Any]] = dict(mode="json", by_alias=False, round_trip=True)
 
 
 # ---------------------------------------------------------------------------
 # Tool 1 -- list_automations
 # ---------------------------------------------------------------------------
 
-LIST_AUTOMATIONS_TOOL_DESCRIPTION = """List W&B Automations the current API key can access.
+LIST_AUTOMATIONS_TOOL_DESCRIPTION = dedent(
+    """\
+    List W&B Automations the current API key can access.
 
-Automations are user-configured rules that fire actions (Slack notification or
-generic webhook) when events happen in W&B: a new artifact is created, an
-alias is added, a model artifact is linked to a registry collection, a run
-metric crosses a threshold or changes significantly, or a run changes state.
+    Automations are user-configured rules that fire actions (Slack notification or
+    generic webhook) when events happen in W&B: a new artifact is created, an
+    alias is added, a model artifact is linked to a registry collection, a run
+    metric crosses a threshold or changes significantly, or a run changes state.
 
-<when_to_use>
-Call this tool when the user asks about:
-- "What automations / alerts / triggers / webhooks do we have?"
-- "Is there an automation that fires when X happens?"
-- "Audit automations on my project / team"
-- "Which automations send to Slack channel #foo?"
+    <when_to_use>
+    Call this tool when the user asks about:
+    - "What automations / alerts / triggers / webhooks do we have?"
+    - "Is there an automation that fires when X happens?"
+    - "Audit automations on my project / team"
+    - "Which automations send to Slack channel #foo?"
 
-If the user wants to know the available Slack channels or webhook URLs that
-existing or new automations can target, call list_wandb_integrations_tool
-instead (or in addition).
-</when_to_use>
+    If the user wants to know the available Slack channels or webhook URLs that
+    existing or new automations can target, call list_wandb_integrations_tool
+    instead (or in addition).
+    </when_to_use>
 
-<critical_info>
-- entity=None lists every automation the authenticated viewer can see across
-  all of their teams. Pass entity="<team-or-user>" to scope to one entity.
-- The optional name filter is an exact match (not regex/substring).
-- Results are capped by max_items (default 50, ceiling 200). When more exist,
-  the response sets truncated=true.
-- Each returned automation has:
-    id, name, enabled, description, created_at, updated_at,
-    scope:  {type, id, name}      -- PROJECT or ARTIFACT_COLLECTION
-    event:  {type, filter}        -- e.g. RUN_METRIC threshold, ADD_ARTIFACT_ALIAS
-    action: {type, ...}           -- NOTIFICATION (Slack), GENERIC_WEBHOOK, NO_OP
-- The wandb GraphQL schema only stores the scope's id + name; it does NOT
-  return the parent project/entity on the scope itself. If you need that
-  context, use the `entity` you passed in (for the scope) and look up the
-  project separately.
-- This tool is read-only. It cannot create, modify, or delete automations.
-</critical_info>
+    <critical_info>
+    - entity=None lists every automation the authenticated viewer can see across
+    all of their teams. Pass entity="<team-or-user>" to scope to one entity.
+    - The optional name filter is an exact match (not regex/substring).
+    - Results are capped by max_items (default 50, ceiling 200). When more exist,
+    the response sets truncated=true.
+    - Each returned automation has:
+        id, name, enabled, description, created_at, updated_at,
+        scope:  {type, id, name}      -- PROJECT or ARTIFACT_COLLECTION
+        event:  {type, filter}        -- structured per event type
+        action: {type, ...}           -- NOTIFICATION (Slack), GENERIC_WEBHOOK, NO_OP
+    - The wandb GraphQL schema only stores the scope's id + name; it does NOT
+    return the parent project/entity on the scope itself. If you need that
+    context, use the `entity` you passed in (for the scope) and look up the
+    project separately.
+    - This tool is read-only. It cannot create, modify, or delete automations.
+    </critical_info>
 
-Parameters
-----------
-entity : str, optional
-    W&B entity (team or user) to filter by. If omitted, returns every
-    automation the authenticated viewer has access to.
-name : str, optional
-    Exact-match filter on the automation's name.
-max_items : int, optional
-    Maximum automations to return. Default: 50, max: 200.
+    Parameters
+    ----------
+    entity : str, optional
+        W&B entity (team or user) to filter by. If omitted, returns every
+        automation the authenticated viewer has access to.
+    name : str, optional
+        Exact-match filter on the automation's name.
+    max_items : int, optional
+        Maximum automations to return. Default: 50, max: 200.
 
-Returns
--------
-JSON with:
-  - automations: list of automation objects (see fields above)
-  - count: number of automations returned
-  - entity: the entity filter applied (or null)
-  - truncated: whether more automations exist beyond max_items
-"""
+    Returns
+    -------
+    JSON with:
+    - automations: list of automation objects (see fields above)
+    - count: number of automations returned
+    - entity: the entity filter applied (or null)
+    - truncated: whether more automations exist beyond max_items
+    """
+)
 
 
-def _serialize_scope(scope: Any) -> dict[str, Any]:
+def _clamp(value: int, floor: int, ceil: int, /) -> int:
+    return max(floor, min(value, ceil))
+
+
+def _jsonify_scope(scope: ProjectScope | ArtifactCollectionScope) -> dict[str, Any]:
     """Flatten an AutomationScope to ``{type, id, name}``.
 
     The wandb GraphQL fragments only carry ``id`` and ``name`` on scopes
-    (see ``wandb/automations/_generated/fragments.py:ProjectScopeFields``,
-    ``ArtifactSequenceScopeFields``, ``ArtifactPortfolioScopeFields``).
-    ``scope_type`` is the public enum (``PROJECT`` or ``ARTIFACT_COLLECTION``)
-    added by ``wandb.automations.scopes``.
+    (see ``wandb/automations/_generated/fragments.py``: ProjectScopeFields,
+    ArtifactSequenceScopeFields, ArtifactPortfolioScopeFields). The public
+    ``scope_type`` enum (PROJECT | ARTIFACT_COLLECTION) lets agents branch
+    on it without parsing GraphQL typename strings.
     """
-    return {
-        "type": scope.scope_type.value,
-        "id": scope.id,
-        "name": scope.name,
-    }
+    return {"type": scope.scope_type.value, "id": scope.id, "name": scope.name}
 
 
-def _serialize_metric_filter(metric: Any) -> dict[str, Any]:
+def _jsonify_metric_filter(metric_filter: Any) -> dict[str, Any]:
     """Flatten the inner metric filter from a RunMetricFilter wrapper.
 
-    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants
-    (``_WrappedMetricThresholdFilter`` / ``_WrappedMetricChangeFilter`` /
-    ``_WrappedMetricZScoreFilter``); each defines exactly one of the
-    ``threshold_filter`` / ``change_filter`` / ``zscore_filter`` attributes.
-    We discriminate by attribute presence rather than reaching into wandb's
-    private union types.
+    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants;
+    each carries its own ``event_type`` discriminator and exposes exactly
+    one of the threshold / change / zscore sub-filter attributes. We
+    discriminate via the upstream-defined enum value rather than poking at
+    attribute presence.
     """
-    if (inner := getattr(metric, "threshold_filter", None)) is not None:
-        return {
-            "kind": "threshold",
-            "metric": inner.name,
-            "agg": inner.agg.value if inner.agg else None,
-            "window": inner.window,
-            "cmp": inner.cmp,
-            "threshold": inner.threshold,
-        }
-    if (inner := getattr(metric, "change_filter", None)) is not None:
-        return {
-            "kind": "change",
-            "metric": inner.name,
-            "agg": inner.agg.value if inner.agg else None,
-            "current_window": inner.window,
-            "prior_window": inner.prior_window,
-            "change_type": inner.change_type.value,
-            "change_dir": inner.change_dir.value,
-            "threshold": inner.threshold,
-        }
-    if (inner := getattr(metric, "zscore_filter", None)) is not None:
-        return {
-            "kind": "zscore",
-            "metric": inner.name,
-            "window": inner.window,
-            "change_dir": inner.change_dir.value,
-            "threshold": inner.threshold,
-        }
-    return {"kind": "unknown"}
+    match metric_filter:
+        case object(event_type=EventType.RUN_METRIC_THRESHOLD, threshold_filter=threshold_filter):
+            return {"kind": "threshold"} | threshold_filter.model_dump(**_DUMP_KWARGS)
+        case object(event_type=EventType.RUN_METRIC_CHANGE, change_filter=change_filter):
+            return {"kind": "change"} | change_filter.model_dump(**_DUMP_KWARGS)
+        case object(event_type=EventType.RUN_METRIC_ZSCORE, zscore_filter=zscore_filter):
+            return {"kind": "zscore"} | zscore_filter.model_dump(**_DUMP_KWARGS)
+        case _:
+            return {"kind": "unknown"}
 
 
-def _serialize_state_filter(state: Any) -> dict[str, Any]:
-    """Flatten a run-state filter to ``{states: [...]}``.
-
-    ``StateFilter`` (from wandb.automations._filters.run_states) carries an
-    in-list of states. We expose them as plain strings for easy LLM use.
-    """
-    states = getattr(state, "states", None)
-    if states is None:
-        # Older saved automations may store the state differently; fall back to repr.
-        return {"summary": repr(state)}
-    return {"states": [s.value if hasattr(s, "value") else str(s) for s in states]}
-
-
-def _serialize_event(event: Any) -> dict[str, Any]:
+def _jsonify_event(event: SavedEvent) -> dict[str, Any]:
     """Flatten a SavedEvent to ``{type, filter}``.
 
-    ``event.filter`` is one of:
-    - ``_WrappedSavedEventFilter`` for mutation events (CREATE_ARTIFACT etc.),
-      whose ``.filter`` is a MongoLikeFilter -- we just expose it as a brief
-      string summary, since the structure is open-ended.
-    - ``RunMetricFilter`` for RUN_METRIC* events, whose ``.metric`` holds the
-      typed threshold/change/zscore filter we flatten via _serialize_metric_filter.
-    - ``RunStateFilter`` for RUN_STATE events, whose ``.state`` holds the
-      state filter we flatten via _serialize_state_filter.
+    The filter shape is structured for run-metric and run-state events.
+    Mutation events (CREATE_ARTIFACT etc.) carry an open-ended MongoLikeFilter
+    that we surface as a brief string ``summary`` since the SDK doesn't
+    expose a stable structured shape for it.
     """
-    type_str = event.event_type.value
-    raw_filter = event.filter
+    from wandb.automations.events import RunMetricFilter, RunStateFilter
 
-    metric = getattr(raw_filter, "metric", None)
-    if metric is not None:
-        return {"type": type_str, "filter": _serialize_metric_filter(metric)}
-
-    state = getattr(raw_filter, "state", None)
-    if state is not None:
-        return {"type": type_str, "filter": _serialize_state_filter(state)}
-
-    # Mutation-event filter (And()/MongoLikeFilter) -- no public structured shape.
-    return {"type": type_str, "filter": {"summary": repr(raw_filter)}}
+    match event:
+        case SavedEvent(event_type=type_, filter=RunMetricFilter(metric=metric_filter)):
+            return {"type": type_.value, "filter": _jsonify_metric_filter(metric_filter)}
+        case SavedEvent(event_type=type_, filter=RunStateFilter(state=state_filter)):
+            return {"type": type_.value, "filter": state_filter.model_dump(**_DUMP_KWARGS)}
+        case _:
+            return {"type": event.event_type.value, "filter": {"summary": repr(event.filter)}}
 
 
-def _serialize_action(action: Any) -> dict[str, Any]:
-    """Flatten a SavedAction to ``{type, ...}``.
+def _jsonify_action(action: SavedAction) -> dict[str, Any]:
+    """Flatten a SavedAction to a JSON-safe dict.
 
-    Saved actions are a discriminated union on ``action_type``
-    (``NOTIFICATION`` / ``GENERIC_WEBHOOK`` / ``NO_OP`` / ``QUEUE_JOB``).
-    NOTIFICATION carries title/message/severity; GENERIC_WEBHOOK carries
-    request_payload; both reference an integration by id.
+    Discriminated on the public ``ActionType`` enum. Each variant emits
+    exactly the fields that the wandb SDK guarantees on its pydantic class
+    (SavedNotificationAction / SavedWebhookAction / SavedNoOpAction); no
+    cross-variant attribute access is needed.
     """
-    type_str = action.action_type.value
-    out: dict[str, Any] = {"type": type_str}
+    from wandb.automations.actions import SavedNoOpAction, SavedNotificationAction, SavedWebhookAction
 
-    integration = getattr(action, "integration", None)
-    if integration is not None:
-        out["integration_id"] = integration.id
-
-    if type_str == "NOTIFICATION":
-        out["title"] = action.title
-        out["message"] = action.message
-        out["severity"] = action.severity.value if action.severity else None
-    elif type_str == "GENERIC_WEBHOOK":
-        # request_payload is JSON-encoded on the wire; the SDK already
-        # parses it back into a dict via JsonEncoded[dict[str, Any]].
-        out["request_payload"] = getattr(action, "request_payload", None)
-
-    return out
+    match action:
+        case SavedNotificationAction(action_type=type_, integration=integration):
+            jsonable = action.model_dump(include={"title", "message", "severity"}, **_DUMP_KWARGS)
+            return {"type": type_.value, "integration_id": integration.id} | jsonable
+        case SavedWebhookAction(action_type=type_, integration=integration):
+            jsonable = action.model_dump(include={"request_payload"}, **_DUMP_KWARGS)
+            return {"type": type_.value, "integration_id": integration.id} | jsonable
+        case SavedNoOpAction(action_type=type_):
+            return {"type": type_.value}
+        case _:
+            # QUEUE_JOB / PUSH_NOTIFICATION are currently excluded from the public create API, but they may appear on saved automations. Only expose the type.
+            return {"type": action.action_type.value}
 
 
-def _serialize_automation(automation: Any) -> dict[str, Any]:
+def _jsonify_automation(automation: Automation) -> dict[str, Any]:
     """Flatten an Automation pydantic object to a JSON-safe dict."""
-    created_at = automation.created_at
-    updated_at = automation.updated_at
-    return {
-        "id": automation.id,
-        "name": automation.name,
-        "enabled": automation.enabled,
-        "description": automation.description,
-        "created_at": created_at.isoformat(),
-        "updated_at": updated_at.isoformat() if updated_at is not None else None,
-        "scope": _serialize_scope(automation.scope),
-        "event": _serialize_event(automation.event),
-        "action": _serialize_action(automation.action),
-    }
+    jsonable = automation.model_dump(exclude={"scope", "event", "action"}, **_DUMP_KWARGS)
+    jsonable_scope = _jsonify_scope(automation.scope)
+    jsonable_event = _jsonify_event(automation.event)
+    jsonable_action = _jsonify_action(automation.action)
+    return jsonable | {"scope": jsonable_scope, "event": jsonable_event, "action": jsonable_action}
 
 
 def list_automations(
     entity: str | None = None,
     name: str | None = None,
-    max_items: int = DEFAULT_MAX_ITEMS,
+    max_items: PositiveInt = MAX_ITEMS_DEFAULT,
 ) -> str:
     """List W&B Automations accessible with the current API key."""
+    params = locals()  # Must be first so it only picks up the function args
 
     api = WandBApiManager.get_api()
-    with track_tool_execution(
-        "list_automations",
-        api.viewer,
-        {"entity": entity, "name": name, "max_items": max_items},
-    ) as ctx:
-        max_items = min(max_items, MAX_ITEMS_CEILING)
+    with track_tool_execution("list_automations", api.viewer, params) as ctx:
+        max_items = _clamp(max_items, 1, MAX_ITEMS_CEIL)
 
         try:
-            kwargs: dict[str, Any] = {"per_page": min(max_items, 100)}
-            if entity is not None:
-                kwargs["entity"] = entity
-            if name is not None:
-                kwargs["name"] = name
+            iterator = api.automations(entity=entity, name=name, per_page=_clamp(max_items, 1, 100))
+            automations = list(map(_jsonify_automation, islice(iterator, max_items)))
+            truncated = next(iterator, None) is not None
 
-            automations: list[dict[str, Any]] = []
-            truncated = False
-            for auto in api.automations(**kwargs):
-                if len(automations) >= max_items:
-                    truncated = True
-                    break
-                automations.append(_serialize_automation(auto))
-
-            return json.dumps(
-                {
-                    "automations": automations,
-                    "count": len(automations),
-                    "entity": entity,
-                    "truncated": truncated,
-                }
-            )
+            result = {
+                "automations": automations,
+                "count": len(automations),
+                "entity": entity,
+                "truncated": truncated,
+            }
+            return json.dumps(result)
 
         except Exception as e:
             logger.error(f"Error in list_automations: {e}", exc_info=True)
@@ -282,139 +224,114 @@ def list_automations(
 # Tool 2 -- list_integrations
 # ---------------------------------------------------------------------------
 
-LIST_INTEGRATIONS_TOOL_DESCRIPTION = """List W&B integrations (Slack channels and webhooks) for an entity.
+LIST_INTEGRATIONS_TOOL_DESCRIPTION = dedent("""\
+    List W&B integrations (Slack channels and webhooks) for an entity.
 
-Integrations are the destinations that W&B Automations send notifications to.
-A SlackIntegration represents a connected Slack channel; a WebhookIntegration
-represents a configured outbound webhook URL. An Automation action references
-exactly one integration by id.
+    Integrations are the destinations that W&B Automations send notifications to.
+    A SlackIntegration represents a connected Slack channel; a WebhookIntegration
+    represents a configured outbound webhook URL. An Automation action references
+    exactly one integration by id.
 
-<when_to_use>
-Call this tool when the user asks about:
-- "What Slack channels / webhooks can I send alerts to?"
-- "Which integrations are set up for my team?"
-- "List the webhooks configured on entity X"
+    <when_to_use>
+    Call this tool when the user asks about:
+    - "What Slack channels / webhooks can I send alerts to?"
+    - "Which integrations are set up for my team?"
+    - "List the webhooks configured on entity X"
 
-You should also call this BEFORE creating an automation (a future tool) when
-you need an integration_id to pass into the action.
-</when_to_use>
+    You should also call this BEFORE creating an automation (a future tool) when
+    you need an integration_id to pass into the action.
+    </when_to_use>
 
-<critical_info>
-- Integrations are configured at the entity (team) level via the W&B UI; this
-  tool only lists existing integrations, it does not create them.
-- entity=None defaults to the authenticated viewer's default entity.
-- integration_type filters: "slack" returns only Slack integrations,
-  "webhook" returns only generic webhook integrations, omit/null returns both.
-- Each returned record always has {id, type}. Slack adds {team_name,
-  channel_name}; webhook adds {name, url_endpoint}.
-</critical_info>
+    <critical_info>
+    - Integrations are configured at the entity (team) level via the W&B UI; this
+    tool only lists existing integrations, it does not create them.
+    - entity=None defaults to the authenticated viewer's default entity.
+    - kind filters: "slack" returns only Slack integrations,
+    "webhook" returns only generic webhook integrations, omit/null returns both.
+    - Each returned record always has {id, type}. Slack adds {team_name,
+    channel_name}; webhook adds {name, url_endpoint}.
+    </critical_info>
 
-Parameters
-----------
-entity : str, optional
-    W&B entity (team or user). Omit to use the viewer's default entity.
-integration_type : str, optional
-    "slack" or "webhook". Omit to return both kinds.
-max_items : int, optional
-    Maximum integrations to return. Default: 50, max: 200.
+    Parameters
+    ----------
+    entity : str, optional
+        W&B entity (team or user). Omit to use the viewer's default entity.
+    kind : "slack" | "webhook" | None
+        Omit to return both kinds.
+    max_items : int, optional
+        Maximum integrations to return. Default: 50, max: 200.
 
-Returns
--------
-JSON with:
-  - integrations: list of integration objects
-  - count: number of integrations returned
-  - entity: the entity filter applied (or null)
-  - integration_type: the type filter applied (or null)
-  - truncated: whether more integrations exist beyond max_items
-"""
+    Returns
+    -------
+    JSON with:
+    - integrations: list of integration objects
+    - count: number of integrations returned
+    - entity: the entity filter applied (or null)
+    - kind: the type filter applied (or null)
+    - truncated: whether more integrations exist beyond max_items
+    """)
 
 
-def _serialize_integration(integration: Any) -> dict[str, Any]:
-    """Flatten a SlackIntegration or WebhookIntegration to a JSON-safe dict.
+def _jsonify_integration(integration: Integration) -> dict[str, Any]:
+    """Flatten a Slack or Webhook integration to a JSON-safe dict.
 
-    The Integration union is discriminated by the GraphQL ``__typename``
-    field, exposed on the SDK pydantic models as ``typename__``. Both
-    variants share ``id``; Slack adds ``team_name`` / ``channel_name``,
-    webhook adds ``name`` / ``url_endpoint``.
+    Discriminated via ``isinstance`` against the public wandb pydantic
+    classes -- pydantic v2 returns concrete subclass instances for
+    discriminated unions, so this is the canonical way to branch.
+    The wildcard arm keeps the tool forward-compatible with future
+    integration kinds the server may add.
     """
-    typename = integration.typename__
-    if typename == _TYPENAME_SLACK_INTEGRATION:
-        return {
-            "id": integration.id,
-            "type": _SLACK,
-            "team_name": integration.team_name,
-            "channel_name": integration.channel_name,
-        }
-    if typename == _TYPENAME_WEBHOOK_INTEGRATION:
-        return {
-            "id": integration.id,
-            "type": _WEBHOOK,
-            "name": integration.name,
-            "url_endpoint": integration.url_endpoint,
-        }
-    # Forward-compat: surface unknown kinds with at least an id + raw typename
-    # rather than dropping or erroring, so future integration kinds added on
-    # the server side don't break this tool. ``id`` is on every Integration
-    # subclass in the generated fragments.
-    return {"id": integration.id, "type": typename}
+    match integration:
+        case SlackIntegration():
+            jsonable = integration.model_dump(include={"id", "team_name", "channel_name"}, **_DUMP_KWARGS)
+            return {"type": "slack"} | jsonable
+        case WebhookIntegration():
+            jsonable = integration.model_dump(include={"id", "name", "url_endpoint"}, **_DUMP_KWARGS)
+            return {"type": "webhook"} | jsonable
+        case _:
+            jsonable = integration.model_dump(include={"id"}, **_DUMP_KWARGS)
+            return {"type": integration.typename__} | jsonable
 
 
 def list_integrations(
     entity: str | None = None,
-    integration_type: str | None = None,
-    max_items: int = DEFAULT_MAX_ITEMS,
+    kind: IntegrationKind | str | None = None,
+    max_items: int = MAX_ITEMS_DEFAULT,
 ) -> str:
     """List Slack and/or webhook integrations for an entity."""
+    params = locals()  # Must be first so it only picks up the function args
 
     api = WandBApiManager.get_api()
-    with track_tool_execution(
-        "list_integrations",
-        api.viewer,
-        {"entity": entity, "integration_type": integration_type, "max_items": max_items},
-    ) as ctx:
-        max_items = min(max_items, MAX_ITEMS_CEILING)
+    with track_tool_execution("list_integrations", api.viewer, params) as ctx:
+        max_items = _clamp(max_items, 1, MAX_ITEMS_CEIL)
 
-        if integration_type is not None and integration_type not in _VALID_INTEGRATION_TYPES:
-            ctx.mark_error(f"invalid integration_type: {integration_type!r}")
-            return json.dumps(
-                {
-                    "error": "invalid_input",
-                    "message": (
-                        f"integration_type must be one of {sorted(_VALID_INTEGRATION_TYPES)} or null, "
-                        f"got {integration_type!r}"
-                    ),
-                }
-            )
+        if kind and (kind not in _VALID_INTEGRATION_KINDS):
+            ctx.mark_error(f"invalid kind: {kind!r}")
+
+            msg = f"kind must be one of {sorted(_VALID_INTEGRATION_KINDS)} or null, got {kind!r}"
+            return json.dumps({"error": "invalid_input", "message": msg})
 
         try:
-            kwargs: dict[str, Any] = {"per_page": min(max_items, 100)}
-            if entity is not None:
-                kwargs["entity"] = entity
+            iterator: Iterator[Integration]
+            match kind:
+                case "slack":
+                    iterator = api.slack_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
+                case "webhook":
+                    iterator = api.webhook_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
+                case _:  # None -- already validated above
+                    iterator = api.integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
 
-            if integration_type == _SLACK:
-                source = api.slack_integrations(**kwargs)
-            elif integration_type == _WEBHOOK:
-                source = api.webhook_integrations(**kwargs)
-            else:
-                source = api.integrations(**kwargs)
+            integrations = list(map(_jsonify_integration, islice(iterator, max_items)))
+            truncated = next(iterator, None) is not None
 
-            integrations: list[dict[str, Any]] = []
-            truncated = False
-            for item in source:
-                if len(integrations) >= max_items:
-                    truncated = True
-                    break
-                integrations.append(_serialize_integration(item))
-
-            return json.dumps(
-                {
-                    "integrations": integrations,
-                    "count": len(integrations),
-                    "entity": entity,
-                    "integration_type": integration_type,
-                    "truncated": truncated,
-                }
-            )
+            result = {
+                "integrations": integrations,
+                "count": len(integrations),
+                "entity": entity,
+                "kind": kind,
+                "truncated": truncated,
+            }
+            return json.dumps(result)
 
         except Exception as e:
             logger.error(f"Error in list_integrations: {e}", exc_info=True)

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -1,0 +1,366 @@
+"""List W&B Automations and the integrations they can target.
+
+Provides two read-only tools for discovering Automations and the
+Slack/webhook integrations that Automation actions reference, via the
+public ``wandb.Api`` interface introduced in wandb 0.19.11.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+logger = get_rich_logger(__name__)
+
+DEFAULT_MAX_ITEMS = 50
+MAX_ITEMS_CEILING = 200
+
+# Valid integration_type values for list_integrations.
+_SLACK = "slack"
+_WEBHOOK = "webhook"
+_VALID_INTEGRATION_TYPES = {_SLACK, _WEBHOOK}
+
+
+# ---------------------------------------------------------------------------
+# Tool 1 -- list_automations
+# ---------------------------------------------------------------------------
+
+LIST_AUTOMATIONS_TOOL_DESCRIPTION = """List W&B Automations the current API key can access.
+
+Automations are user-configured rules that fire actions (Slack notification or
+generic webhook) when events happen in W&B: a new artifact is created, an
+alias is added, a model artifact is linked to a registry collection, a run
+metric crosses a threshold or changes significantly, or a run changes state.
+
+<when_to_use>
+Call this tool when the user asks about:
+- "What automations / alerts / triggers / webhooks do we have?"
+- "Is there an automation that fires when X happens?"
+- "Audit automations on my project / team"
+- "Which automations send to Slack channel #foo?"
+
+If the user wants to know the available Slack channels or webhook URLs that
+existing or new automations can target, call list_wandb_integrations_tool
+instead (or in addition).
+</when_to_use>
+
+<critical_info>
+- entity=None lists every automation the authenticated viewer can see across
+  all of their teams. Pass entity="<team-or-user>" to scope to one entity.
+- The optional name filter is an exact match (not regex/substring).
+- Results are capped by max_items (default 50, ceiling 200). When more exist,
+  the response sets truncated=true.
+- Each returned automation has:
+    id, name, enabled, description, created_at, updated_at,
+    scope:  {type, name, ...}     -- PROJECT or ARTIFACT_COLLECTION
+    event:  {type, summary}       -- e.g. RUN_METRIC threshold, ADD_ARTIFACT_ALIAS
+    action: {type, ...}           -- NOTIFICATION (Slack), GENERIC_WEBHOOK, NO_OP
+- This tool is read-only. It cannot create, modify, or delete automations.
+</critical_info>
+
+Parameters
+----------
+entity : str, optional
+    W&B entity (team or user) to filter by. If omitted, returns every
+    automation the authenticated viewer has access to.
+name : str, optional
+    Exact-match filter on the automation's name.
+max_items : int, optional
+    Maximum automations to return. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - automations: list of automation objects (see fields above)
+  - count: number of automations returned
+  - entity: the entity filter applied (or null)
+  - truncated: whether more automations exist beyond max_items
+"""
+
+
+def _serialize_scope(scope: Any) -> Dict[str, Any]:
+    """Flatten an AutomationScope (ProjectScope or ArtifactCollectionScope) to a dict.
+
+    Uses getattr with defaults so any future scope-type addition still serializes
+    without raising. The ``scope_type`` field is set by the SDK on every scope
+    subclass (see wandb/wandb/automations/scopes.py).
+    """
+    scope_type = getattr(scope, "scope_type", None)
+    out: Dict[str, Any] = {
+        "type": getattr(scope_type, "value", str(scope_type)) if scope_type is not None else None,
+        "name": getattr(scope, "name", None),
+    }
+    # ProjectScope carries entity/project info directly; ArtifactCollection scopes
+    # carry it on a nested project field. Try both flat and nested locations.
+    project = getattr(scope, "project", None)
+    if project is not None and not isinstance(project, str):
+        out["project"] = getattr(project, "name", None)
+        out["entity"] = getattr(project, "entity_name", None) or getattr(project, "entity", None)
+    else:
+        out["project"] = project
+        out["entity"] = getattr(scope, "entity_name", None) or getattr(scope, "entity", None)
+    return out
+
+
+def _serialize_event(event: Any) -> Dict[str, Any]:
+    """Flatten a SavedEvent into a small dict with type + human-readable summary."""
+    event_type = getattr(event, "event_type", None)
+    type_str = getattr(event_type, "value", str(event_type)) if event_type is not None else None
+
+    # The filter on a SavedEvent is either a _WrappedSavedEventFilter (mutation
+    # events) or a RunMetricFilter / RunStateFilter. For each, prefer the
+    # built-in __repr__ on the innermost metric/state filter, which produces a
+    # compact human-readable string (see _filters/run_metrics.py:147-150).
+    summary: Optional[str] = None
+    filt = getattr(event, "filter", None)
+    try:
+        inner_metric = getattr(filt, "metric", None)
+        inner_state = getattr(filt, "state", None)
+        if inner_metric is not None:
+            inner = (
+                getattr(inner_metric, "threshold_filter", None)
+                or getattr(inner_metric, "change_filter", None)
+                or getattr(inner_metric, "zscore_filter", None)
+                or inner_metric
+            )
+            summary = repr(inner).strip("'")
+        elif inner_state is not None:
+            summary = repr(inner_state).strip("'")
+        elif filt is not None:
+            summary = repr(filt).strip("'")
+    except Exception:
+        summary = None
+
+    return {"type": type_str, "summary": summary}
+
+
+def _serialize_action(action: Any) -> Dict[str, Any]:
+    """Flatten a SavedAction into a dict with type + the fields agents need."""
+    action_type = getattr(action, "action_type", None)
+    type_str = getattr(action_type, "value", str(action_type)) if action_type is not None else None
+    out: Dict[str, Any] = {"type": type_str}
+
+    integration = getattr(action, "integration", None)
+    if integration is not None:
+        out["integration_id"] = getattr(integration, "id", None)
+
+    # NOTIFICATION (Slack) carries title/message/severity; webhook does not.
+    if type_str == "NOTIFICATION":
+        out["title"] = getattr(action, "title", None)
+        out["message"] = getattr(action, "message", None)
+        severity = getattr(action, "severity", None)
+        out["severity"] = getattr(severity, "value", str(severity)) if severity is not None else None
+    return out
+
+
+def _serialize_automation(automation: Any) -> Dict[str, Any]:
+    """Flatten an Automation pydantic object into a JSON-safe dict."""
+    created_at = getattr(automation, "created_at", None)
+    updated_at = getattr(automation, "updated_at", None)
+    return {
+        "id": getattr(automation, "id", None),
+        "name": getattr(automation, "name", None),
+        "enabled": getattr(automation, "enabled", None),
+        "description": getattr(automation, "description", None),
+        "created_at": created_at.isoformat()
+        if hasattr(created_at, "isoformat")
+        else (str(created_at) if created_at is not None else None),
+        "updated_at": updated_at.isoformat()
+        if hasattr(updated_at, "isoformat")
+        else (str(updated_at) if updated_at is not None else None),
+        "scope": _serialize_scope(getattr(automation, "scope", None)),
+        "event": _serialize_event(getattr(automation, "event", None)),
+        "action": _serialize_action(getattr(automation, "action", None)),
+    }
+
+
+def list_automations(
+    entity: Optional[str] = None,
+    name: Optional[str] = None,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> str:
+    """List W&B Automations accessible with the current API key."""
+
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "list_automations",
+        api.viewer,
+        {"entity": entity, "name": name, "max_items": max_items},
+    ) as ctx:
+        max_items = min(max_items, MAX_ITEMS_CEILING)
+
+        try:
+            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            if entity is not None:
+                kwargs["entity"] = entity
+            if name is not None:
+                kwargs["name"] = name
+
+            automations: List[Dict[str, Any]] = []
+            truncated = False
+            for auto in api.automations(**kwargs):
+                if len(automations) >= max_items:
+                    truncated = True
+                    break
+                automations.append(_serialize_automation(auto))
+
+            return json.dumps(
+                {
+                    "automations": automations,
+                    "count": len(automations),
+                    "entity": entity,
+                    "truncated": truncated,
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Error in list_automations: {e}", exc_info=True)
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Tool 2 -- list_integrations
+# ---------------------------------------------------------------------------
+
+LIST_INTEGRATIONS_TOOL_DESCRIPTION = """List W&B integrations (Slack channels and webhooks) for an entity.
+
+Integrations are the destinations that W&B Automations send notifications to.
+A SlackIntegration represents a connected Slack channel; a WebhookIntegration
+represents a configured outbound webhook URL. An Automation action references
+exactly one integration by id.
+
+<when_to_use>
+Call this tool when the user asks about:
+- "What Slack channels / webhooks can I send alerts to?"
+- "Which integrations are set up for my team?"
+- "List the webhooks configured on entity X"
+
+You should also call this BEFORE creating an automation (a future tool) when
+you need an integration_id to pass into the action.
+</when_to_use>
+
+<critical_info>
+- Integrations are configured at the entity (team) level via the W&B UI; this
+  tool only lists existing integrations, it does not create them.
+- entity=None defaults to the authenticated viewer's default entity.
+- integration_type filters: "slack" returns only Slack integrations,
+  "webhook" returns only generic webhook integrations, omit/null returns both.
+- Each returned record always has {id, type}. Slack adds {team_name,
+  channel_name}; webhook adds {name, url_endpoint}.
+</critical_info>
+
+Parameters
+----------
+entity : str, optional
+    W&B entity (team or user). Omit to use the viewer's default entity.
+integration_type : str, optional
+    "slack" or "webhook". Omit to return both kinds.
+max_items : int, optional
+    Maximum integrations to return. Default: 50, max: 200.
+
+Returns
+-------
+JSON with:
+  - integrations: list of integration objects
+  - count: number of integrations returned
+  - entity: the entity filter applied (or null)
+  - integration_type: the type filter applied (or null)
+  - truncated: whether more integrations exist beyond max_items
+"""
+
+
+def _serialize_integration(integration: Any) -> Dict[str, Any]:
+    """Flatten a SlackIntegration or WebhookIntegration into a JSON-safe dict.
+
+    The two integration kinds are discriminated by the GraphQL ``__typename``
+    field, exposed in the SDK as ``typename__``. Slack integrations carry
+    team_name + channel_name; webhook integrations carry name + url_endpoint.
+    """
+    typename = getattr(integration, "typename__", None)
+    if typename == "SlackIntegration":
+        return {
+            "id": getattr(integration, "id", None),
+            "type": _SLACK,
+            "team_name": getattr(integration, "team_name", None),
+            "channel_name": getattr(integration, "channel_name", None),
+        }
+    if typename == "GenericWebhookIntegration":
+        return {
+            "id": getattr(integration, "id", None),
+            "type": _WEBHOOK,
+            "name": getattr(integration, "name", None),
+            "url_endpoint": getattr(integration, "url_endpoint", None),
+        }
+    # Fallback for unknown future integration kinds: surface what we can.
+    return {
+        "id": getattr(integration, "id", None),
+        "type": typename or "unknown",
+    }
+
+
+def list_integrations(
+    entity: Optional[str] = None,
+    integration_type: Optional[str] = None,
+    max_items: int = DEFAULT_MAX_ITEMS,
+) -> str:
+    """List Slack and/or webhook integrations for an entity."""
+
+    api = WandBApiManager.get_api()
+    with track_tool_execution(
+        "list_integrations",
+        api.viewer,
+        {"entity": entity, "integration_type": integration_type, "max_items": max_items},
+    ) as ctx:
+        max_items = min(max_items, MAX_ITEMS_CEILING)
+
+        if integration_type is not None and integration_type not in _VALID_INTEGRATION_TYPES:
+            ctx.mark_error(f"invalid integration_type: {integration_type!r}")
+            return json.dumps(
+                {
+                    "error": "invalid_input",
+                    "message": (
+                        f"integration_type must be one of {sorted(_VALID_INTEGRATION_TYPES)} or null, "
+                        f"got {integration_type!r}"
+                    ),
+                }
+            )
+
+        try:
+            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            if entity is not None:
+                kwargs["entity"] = entity
+
+            if integration_type == _SLACK:
+                source = api.slack_integrations(**kwargs)
+            elif integration_type == _WEBHOOK:
+                source = api.webhook_integrations(**kwargs)
+            else:
+                source = api.integrations(**kwargs)
+
+            integrations: List[Dict[str, Any]] = []
+            truncated = False
+            for item in source:
+                if len(integrations) >= max_items:
+                    truncated = True
+                    break
+                integrations.append(_serialize_integration(item))
+
+            return json.dumps(
+                {
+                    "integrations": integrations,
+                    "count": len(integrations),
+                    "entity": entity,
+                    "integration_type": integration_type,
+                    "truncated": truncated,
+                }
+            )
+
+        except Exception as e:
+            logger.error(f"Error in list_integrations: {e}", exc_info=True)
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "api_error", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -70,6 +70,12 @@ from wandb_mcp_server.mcp_tools.query_artifacts import (
     COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
     compare_artifact_versions,
 )
+from wandb_mcp_server.mcp_tools.automations import (
+    LIST_AUTOMATIONS_TOOL_DESCRIPTION,
+    list_automations,
+    LIST_INTEGRATIONS_TOOL_DESCRIPTION,
+    list_integrations,
+)
 
 # wandbot removed -- zero usage across 400+ benchmark runs, superseded by search_wandb_docs_tool
 from wandb_mcp_server.mcp_tools.query_weave import (
@@ -373,7 +379,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
     """
     Register all W&B MCP tools on the given FastMCP instance.
 
-    Available tools (20):
+    Available tools (22):
     - query_weave_traces_tool: Query LLM traces with filtering and pagination
     - count_weave_traces_tool: Efficiently count traces without returning data
     - resolve_trace_roots_tool: Batch-resolve root spans for child trace_ids
@@ -394,6 +400,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
     - summarize_evaluation_tool: Aggregate Weave evaluation results
     - diagnose_run_tool: Automatic training health check
     - probe_project_tool: Run-side schema and structure discovery
+    - list_wandb_automations_tool: List W&B Automations (rules that trigger
+      notifications/webhooks on artifact, run-state, or run-metric events)
+    - list_wandb_integrations_tool: List Slack and webhook integrations
+      available as targets for Automation actions
 
     Args:
         mcp_instance: The FastMCP instance to register tools on
@@ -763,6 +773,24 @@ def register_tools(mcp_instance: FastMCP) -> None:
     ) -> str:
         """List projects for a W&B entity."""
         return list_entity_projects(entity=entity, max_projects=max_projects)
+
+    @mcp_instance.tool(description=LIST_AUTOMATIONS_TOOL_DESCRIPTION)
+    def list_wandb_automations_tool(
+        entity: Optional[str] = None,
+        name: Optional[str] = None,
+        max_items: int = 50,
+    ) -> str:
+        """List W&B Automations accessible with the current API key."""
+        return list_automations(entity=entity, name=name, max_items=max_items)
+
+    @mcp_instance.tool(description=LIST_INTEGRATIONS_TOOL_DESCRIPTION)
+    def list_wandb_integrations_tool(
+        entity: Optional[str] = None,
+        integration_type: Optional[str] = None,
+        max_items: int = 50,
+    ) -> str:
+        """List Slack and webhook integrations for a W&B entity."""
+        return list_integrations(entity=entity, integration_type=integration_type, max_items=max_items)
 
     from wandb_mcp_server.mcp_tools.infer_schema import (
         INFER_TRACE_SCHEMA_TOOL_DESCRIPTION,

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -19,7 +19,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import wandb
 from dotenv import load_dotenv
@@ -84,8 +84,7 @@ from wandb_mcp_server.mcp_tools.query_weave import (
 )
 from wandb_mcp_server.utils import ServerMCPArgs, get_rich_logger, get_server_args
 
-if TYPE_CHECKING:
-    from pydantic import PositiveInt
+from pydantic import PositiveInt
 
 # Export key functions for HF Spaces app
 __all__ = [

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -19,11 +19,12 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import wandb
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
 from wandb_mcp_server.config import WANDB_BASE_URL
 
 # Import Weave for tracing MCP tool calls
@@ -35,6 +36,20 @@ except ImportError:
     weave = None
     WEAVE_AVAILABLE = False
 
+from wandb_mcp_server.mcp_tools.automations import (
+    LIST_AUTOMATIONS_TOOL_DESCRIPTION,
+    LIST_INTEGRATIONS_TOOL_DESCRIPTION,
+    list_automations,
+    list_integrations,
+)
+from wandb_mcp_server.mcp_tools.count_traces import (
+    COUNT_WEAVE_TRACES_TOOL_DESCRIPTION,
+    count_traces,
+)
+from wandb_mcp_server.mcp_tools.create_report import (
+    CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
+    create_report,
+)
 from wandb_mcp_server.mcp_tools.list_entities import (
     LIST_ENTITIES_TOOL_DESCRIPTION,
     list_entities,
@@ -43,38 +58,23 @@ from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import (
     LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION,
     list_entity_projects,
 )
-from wandb_mcp_server.mcp_tools.create_report import (
-    CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
-    create_report,
+from wandb_mcp_server.mcp_tools.query_artifacts import (
+    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    compare_artifact_versions,
+    get_artifact_details,
+    list_artifact_versions,
 )
-from wandb_mcp_server.mcp_tools.count_traces import (
-    COUNT_WEAVE_TRACES_TOOL_DESCRIPTION,
-    count_traces,
+from wandb_mcp_server.mcp_tools.query_registry import (
+    LIST_REGISTRIES_TOOL_DESCRIPTION,
+    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+    list_registries,
+    list_registry_collections,
 )
 from wandb_mcp_server.mcp_tools.query_wandb_gql import (
     QUERY_WANDB_GQL_TOOL_DESCRIPTION,
     query_paginated_wandb_gql,
-)
-
-from wandb_mcp_server.mcp_tools.query_registry import (
-    LIST_REGISTRIES_TOOL_DESCRIPTION,
-    list_registries,
-    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
-    list_registry_collections,
-)
-from wandb_mcp_server.mcp_tools.query_artifacts import (
-    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
-    list_artifact_versions,
-    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
-    get_artifact_details,
-    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
-    compare_artifact_versions,
-)
-from wandb_mcp_server.mcp_tools.automations import (
-    LIST_AUTOMATIONS_TOOL_DESCRIPTION,
-    list_automations,
-    LIST_INTEGRATIONS_TOOL_DESCRIPTION,
-    list_integrations,
 )
 
 # wandbot removed -- zero usage across 400+ benchmark runs, superseded by search_wandb_docs_tool
@@ -82,7 +82,10 @@ from wandb_mcp_server.mcp_tools.query_weave import (
     QUERY_WEAVE_TRACES_TOOL_DESCRIPTION,
     query_paginated_weave_traces,
 )
-from wandb_mcp_server.utils import get_rich_logger, get_server_args, ServerMCPArgs
+from wandb_mcp_server.utils import ServerMCPArgs, get_rich_logger, get_server_args
+
+if TYPE_CHECKING:
+    from pydantic import PositiveInt
 
 # Export key functions for HF Spaces app
 __all__ = [
@@ -738,6 +741,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         scalars: Optional[Dict[str, float]] = None,
     ) -> str:
         from concurrent.futures import ThreadPoolExecutor
+
         from wandb_mcp_server.api_client import WandBApiManager
 
         try:
@@ -785,12 +789,12 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
     @mcp_instance.tool(description=LIST_INTEGRATIONS_TOOL_DESCRIPTION)
     def list_wandb_integrations_tool(
-        entity: Optional[str] = None,
-        integration_type: Optional[str] = None,
-        max_items: int = 50,
+        entity: str | None = None,
+        kind: str | None = None,
+        max_items: PositiveInt = 50,
     ) -> str:
         """List Slack and webhook integrations for a W&B entity."""
-        return list_integrations(entity=entity, integration_type=integration_type, max_items=max_items)
+        return list_integrations(entity=entity, kind=kind, max_items=max_items)
 
     from wandb_mcp_server.mcp_tools.infer_schema import (
         INFER_TRACE_SCHEMA_TOOL_DESCRIPTION,

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -675,6 +675,19 @@ class TestListIntegrations:
         mock_api.slack_integrations.assert_not_called()
         mock_api.webhook_integrations.assert_not_called()
 
+    def test_empty_string_kind_is_invalid(self, mock_api):
+        """Regression: empty string is falsy in Python so a naive truthy check
+        would silently treat ``kind=""`` as ``None`` and return both kinds.
+        It must be rejected like any other non-allowed value.
+        """
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(kind=""))
+        assert result["error"] == "invalid_input"
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
+
     def test_empty(self, mock_api):
         mock_api.integrations.return_value = iter([])
 

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,0 +1,507 @@
+"""Mock-based unit tests for the list_automations and list_integrations tools.
+
+These tests stand in for the wandb SDK -- they exercise the flattening logic
+in mcp_tools/automations.py against fake Automation / Integration objects
+shaped like the pydantic models in wandb/wandb/automations/. No live wandb
+API calls.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build fake wandb-SDK-shaped objects
+# ---------------------------------------------------------------------------
+
+
+def _enum(value):
+    """Build a fake enum-like object whose .value matches the SDK's LenientStrEnum."""
+    return SimpleNamespace(value=value)
+
+
+def _project_scope(entity="my-team", project="my-project"):
+    return SimpleNamespace(
+        scope_type=_enum("PROJECT"),
+        name=project,
+        project=SimpleNamespace(name=project, entity_name=entity),
+    )
+
+
+def _collection_scope(entity="my-team", project="my-project", collection="my-models"):
+    # ArtifactSequenceScope / ArtifactPortfolioScope shape: name on the scope
+    # itself, project/entity on a nested project ref.
+    return SimpleNamespace(
+        scope_type=_enum("ARTIFACT_COLLECTION"),
+        name=collection,
+        project=SimpleNamespace(name=project, entity_name=entity),
+    )
+
+
+def _threshold_event():
+    # Mirrors the wrapping in events.py: RunMetricFilter.metric.threshold_filter
+    inner = MagicMock()
+    inner.__repr__ = lambda self: "'MAX(acc) > 0.9'"  # mimics MetricThresholdFilter.__repr__
+    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=inner, change_filter=None, zscore_filter=None))
+    return SimpleNamespace(event_type=_enum("RUN_METRIC"), filter=filt)
+
+
+def _change_event():
+    inner = MagicMock()
+    inner.__repr__ = lambda self: "'AVG(loss) decreases 10.00%'"
+    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=None, change_filter=inner, zscore_filter=None))
+    return SimpleNamespace(event_type=_enum("RUN_METRIC_CHANGE"), filter=filt)
+
+
+def _zscore_event():
+    inner = MagicMock()
+    inner.__repr__ = lambda self: "'abs(zscore(\"loss\")) > 3.0'"
+    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=None, change_filter=None, zscore_filter=inner))
+    return SimpleNamespace(event_type=_enum("RUN_METRIC_ZSCORE"), filter=filt)
+
+
+def _run_state_event():
+    state = MagicMock()
+    state.__repr__ = lambda self: "'state in [finished, failed]'"
+    filt = SimpleNamespace(metric=None, state=state)
+    return SimpleNamespace(event_type=_enum("RUN_STATE"), filter=filt)
+
+
+def _create_artifact_event():
+    # Mutation events use _WrappedSavedEventFilter -> no .metric / .state.
+    filt = MagicMock()
+    filt.metric = None
+    filt.state = None
+    filt.__repr__ = lambda self: "And()"
+    return SimpleNamespace(event_type=_enum("CREATE_ARTIFACT"), filter=filt)
+
+
+def _notification_action(integration_id="int_slack_1", title="t", message="m", severity="INFO"):
+    return SimpleNamespace(
+        action_type=_enum("NOTIFICATION"),
+        integration=SimpleNamespace(id=integration_id),
+        title=title,
+        message=message,
+        severity=_enum(severity),
+    )
+
+
+def _webhook_action(integration_id="int_webhook_1"):
+    return SimpleNamespace(
+        action_type=_enum("GENERIC_WEBHOOK"),
+        integration=SimpleNamespace(id=integration_id),
+    )
+
+
+def _no_op_action():
+    return SimpleNamespace(action_type=_enum("NO_OP"), integration=None)
+
+
+def _automation(
+    *,
+    id="auto_1",
+    name="my-automation",
+    enabled=True,
+    description="desc",
+    scope=None,
+    event=None,
+    action=None,
+):
+    return SimpleNamespace(
+        id=id,
+        name=name,
+        enabled=enabled,
+        description=description,
+        created_at=datetime(2026, 1, 1, 12, 0, 0),
+        updated_at=datetime(2026, 5, 1, 12, 0, 0),
+        scope=scope or _project_scope(),
+        event=event or _threshold_event(),
+        action=action or _notification_action(),
+    )
+
+
+def _slack_integration(id="int_slack_1", team="acme", channel="alerts"):
+    return SimpleNamespace(
+        typename__="SlackIntegration",
+        id=id,
+        team_name=team,
+        channel_name=channel,
+    )
+
+
+def _webhook_integration(id="int_webhook_1", name="prod-webhook", url="https://example.com/hook"):
+    return SimpleNamespace(
+        typename__="GenericWebhookIntegration",
+        id=id,
+        name=name,
+        url_endpoint=url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_automations
+# ---------------------------------------------------------------------------
+
+
+class TestListAutomations:
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_no_entity_arg_calls_api_without_entity(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation()])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations())
+
+        assert result["count"] == 1
+        assert result["entity"] is None
+        assert result["truncated"] is False
+        # entity must NOT be in the kwargs when caller passed None
+        kwargs = api.automations.call_args.kwargs
+        assert "entity" not in kwargs
+        assert "name" not in kwargs
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_entity_and_name_passed_through(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(name="exact-match")])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(entity="my-team", name="exact-match"))
+
+        assert result["entity"] == "my-team"
+        assert result["count"] == 1
+        assert result["automations"][0]["name"] == "exact-match"
+        kwargs = api.automations.call_args.kwargs
+        assert kwargs["entity"] == "my-team"
+        assert kwargs["name"] == "exact-match"
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_max_items_truncation(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(id=f"a{i}", name=f"n{i}") for i in range(10)])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(max_items=3))
+        assert result["count"] == 3
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_max_items_ceiling(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(id=f"a{i}") for i in range(250)])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        # ceiling is 200
+        result = json.loads(list_automations(max_items=999))
+        assert result["count"] == 200
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_empty_result(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(entity="empty-team"))
+        assert result == {
+            "automations": [],
+            "count": 0,
+            "entity": "empty-team",
+            "truncated": False,
+        }
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_serializes_project_scope(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(scope=_project_scope(entity="t1", project="p1"))])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        scope = json.loads(list_automations())["automations"][0]["scope"]
+        assert scope["type"] == "PROJECT"
+        assert scope["project"] == "p1"
+        assert scope["entity"] == "t1"
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_serializes_collection_scope(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter(
+            [_automation(scope=_collection_scope(entity="t1", project="p1", collection="my-models"))]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        scope = json.loads(list_automations())["automations"][0]["scope"]
+        assert scope["type"] == "ARTIFACT_COLLECTION"
+        assert scope["name"] == "my-models"
+        assert scope["project"] == "p1"
+        assert scope["entity"] == "t1"
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_each_event_type_serializes(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter(
+            [
+                _automation(id="a1", event=_threshold_event()),
+                _automation(id="a2", event=_change_event()),
+                _automation(id="a3", event=_zscore_event()),
+                _automation(id="a4", event=_run_state_event()),
+                _automation(id="a5", event=_create_artifact_event()),
+            ]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        events = [a["event"] for a in json.loads(list_automations())["automations"]]
+        assert [e["type"] for e in events] == [
+            "RUN_METRIC",
+            "RUN_METRIC_CHANGE",
+            "RUN_METRIC_ZSCORE",
+            "RUN_STATE",
+            "CREATE_ARTIFACT",
+        ]
+        # threshold/change/zscore/state should have a non-empty summary string
+        for e in events[:4]:
+            assert isinstance(e["summary"], str) and e["summary"]
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_serializes_notification_action(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter(
+            [_automation(action=_notification_action(integration_id="int_x", title="T", message="M", severity="WARN"))]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        assert action == {
+            "type": "NOTIFICATION",
+            "integration_id": "int_x",
+            "title": "T",
+            "message": "M",
+            "severity": "WARN",
+        }
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_serializes_webhook_action(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(action=_webhook_action(integration_id="int_w"))])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        assert action == {"type": "GENERIC_WEBHOOK", "integration_id": "int_w"}
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_serializes_no_op_action(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(action=_no_op_action())])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        assert action == {"type": "NO_OP"}
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_iso_timestamps(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation()])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        auto = json.loads(list_automations())["automations"][0]
+        assert auto["created_at"] == "2026-01-01T12:00:00"
+        assert auto["updated_at"] == "2026-05-01T12:00:00"
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_api_error_returns_error_dict(self, mock_mgr):
+        api = MagicMock()
+        api.automations.side_effect = RuntimeError("boom")
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations())
+        assert result["error"] == "api_error"
+        assert "boom" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# list_integrations
+# ---------------------------------------------------------------------------
+
+
+class TestListIntegrations:
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_no_type_returns_both(self, mock_mgr):
+        api = MagicMock()
+        api.integrations.return_value = iter([_slack_integration(), _webhook_integration()])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(entity="my-team"))
+        assert result["count"] == 2
+        types = {item["type"] for item in result["integrations"]}
+        assert types == {"slack", "webhook"}
+        # Slack and webhook endpoints were NOT both called
+        api.slack_integrations.assert_not_called()
+        api.webhook_integrations.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_filter_slack(self, mock_mgr):
+        api = MagicMock()
+        api.slack_integrations.return_value = iter([_slack_integration(id="s1", team="acme", channel="alerts")])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(entity="my-team", integration_type="slack"))
+        assert result["count"] == 1
+        assert result["integrations"][0] == {
+            "id": "s1",
+            "type": "slack",
+            "team_name": "acme",
+            "channel_name": "alerts",
+        }
+        api.integrations.assert_not_called()
+        api.webhook_integrations.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_filter_webhook(self, mock_mgr):
+        api = MagicMock()
+        api.webhook_integrations.return_value = iter(
+            [_webhook_integration(id="w1", name="prod", url="https://x.test/hook")]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(integration_type="webhook"))
+        assert result["count"] == 1
+        assert result["integrations"][0] == {
+            "id": "w1",
+            "type": "webhook",
+            "name": "prod",
+            "url_endpoint": "https://x.test/hook",
+        }
+        api.integrations.assert_not_called()
+        api.slack_integrations.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_invalid_type_returns_error(self, mock_mgr):
+        api = MagicMock()
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(integration_type="email"))
+        assert result["error"] == "invalid_input"
+        # No API calls should have happened
+        api.integrations.assert_not_called()
+        api.slack_integrations.assert_not_called()
+        api.webhook_integrations.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_empty(self, mock_mgr):
+        api = MagicMock()
+        api.integrations.return_value = iter([])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["count"] == 0
+        assert result["integrations"] == []
+        assert result["truncated"] is False
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_max_items_truncation(self, mock_mgr):
+        api = MagicMock()
+        api.integrations.return_value = iter([_slack_integration(id=f"s{i}") for i in range(20)])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(max_items=5))
+        assert result["count"] == 5
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_max_items_ceiling(self, mock_mgr):
+        api = MagicMock()
+        api.integrations.return_value = iter([_webhook_integration(id=f"w{i}") for i in range(250)])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(max_items=999))
+        assert result["count"] == 200
+        assert result["truncated"] is True
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_api_error_returns_error_dict(self, mock_mgr):
+        api = MagicMock()
+        api.integrations.side_effect = RuntimeError("kapow")
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["error"] == "api_error"
+        assert "kapow" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_unknown_typename_falls_back(self, mock_mgr):
+        # Future integration kinds we don't recognize should still serialize.
+        api = MagicMock()
+        api.integrations.return_value = iter([SimpleNamespace(typename__="DiscordIntegration", id="d1")])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["count"] == 1
+        assert result["integrations"][0]["id"] == "d1"
+        assert result["integrations"][0]["type"] == "DiscordIntegration"
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions are present and non-trivial (smoke test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "const_name",
+    ["LIST_AUTOMATIONS_TOOL_DESCRIPTION", "LIST_INTEGRATIONS_TOOL_DESCRIPTION"],
+)
+def test_tool_descriptions_present(const_name):
+    from wandb_mcp_server.mcp_tools import automations as mod
+
+    val = getattr(mod, const_name)
+    assert isinstance(val, str)
+    assert "<when_to_use>" in val
+    assert "<critical_info>" in val

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -18,6 +18,12 @@ import pytest
 
 # ---------------------------------------------------------------------------
 # Helpers to build fake wandb-SDK-shaped objects
+#
+# We mirror the public pydantic shapes from wandb/wandb/automations/:
+#   - Scope:        scope_type (enum), id, name
+#   - Event:        event_type (enum), filter (typed per event)
+#   - Action:       action_type (enum), integration (with .id), + variant fields
+#   - Integration:  typename__ (literal), id, + variant fields
 # ---------------------------------------------------------------------------
 
 
@@ -26,60 +32,76 @@ def _enum(value):
     return SimpleNamespace(value=value)
 
 
-def _project_scope(entity="my-team", project="my-project"):
-    return SimpleNamespace(
-        scope_type=_enum("PROJECT"),
-        name=project,
-        project=SimpleNamespace(name=project, entity_name=entity),
+def _project_scope(id="scope_proj_1", name="my-project"):
+    return SimpleNamespace(scope_type=_enum("PROJECT"), id=id, name=name)
+
+
+def _collection_scope(id="scope_coll_1", name="my-models"):
+    return SimpleNamespace(scope_type=_enum("ARTIFACT_COLLECTION"), id=id, name=name)
+
+
+# Inner metric filters: each defines exactly one of threshold_filter /
+# change_filter / zscore_filter, matching wandb's _Wrapped* pydantic shapes.
+
+
+def _threshold_metric_filter(name="acc", agg="MAX", window=5, cmp="$gt", threshold=0.9):
+    inner = SimpleNamespace(
+        name=name,
+        agg=_enum(agg) if agg else None,
+        window=window,
+        cmp=cmp,
+        threshold=threshold,
     )
+    return SimpleNamespace(threshold_filter=inner)
 
 
-def _collection_scope(entity="my-team", project="my-project", collection="my-models"):
-    # ArtifactSequenceScope / ArtifactPortfolioScope shape: name on the scope
-    # itself, project/entity on a nested project ref.
-    return SimpleNamespace(
-        scope_type=_enum("ARTIFACT_COLLECTION"),
-        name=collection,
-        project=SimpleNamespace(name=project, entity_name=entity),
+def _change_metric_filter(
+    name="loss",
+    agg="AVERAGE",
+    window=3,
+    prior_window=3,
+    change_type="RELATIVE",
+    change_dir="DECREASE",
+    threshold=0.1,
+):
+    inner = SimpleNamespace(
+        name=name,
+        agg=_enum(agg) if agg else None,
+        window=window,
+        prior_window=prior_window,
+        change_type=_enum(change_type),
+        change_dir=_enum(change_dir),
+        threshold=threshold,
     )
+    return SimpleNamespace(change_filter=inner)
 
 
-def _threshold_event():
-    # Mirrors the wrapping in events.py: RunMetricFilter.metric.threshold_filter
-    inner = MagicMock()
-    inner.__repr__ = lambda self: "'MAX(acc) > 0.9'"  # mimics MetricThresholdFilter.__repr__
-    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=inner, change_filter=None, zscore_filter=None))
-    return SimpleNamespace(event_type=_enum("RUN_METRIC"), filter=filt)
+def _zscore_metric_filter(name="loss", window=30, change_dir="ANY", threshold=3.0):
+    inner = SimpleNamespace(
+        name=name,
+        window=window,
+        change_dir=_enum(change_dir),
+        threshold=threshold,
+    )
+    return SimpleNamespace(zscore_filter=inner)
 
 
-def _change_event():
-    inner = MagicMock()
-    inner.__repr__ = lambda self: "'AVG(loss) decreases 10.00%'"
-    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=None, change_filter=inner, zscore_filter=None))
-    return SimpleNamespace(event_type=_enum("RUN_METRIC_CHANGE"), filter=filt)
+def _run_metric_event(event_type="RUN_METRIC", metric=None):
+    filt = SimpleNamespace(metric=metric or _threshold_metric_filter())
+    return SimpleNamespace(event_type=_enum(event_type), filter=filt)
 
 
-def _zscore_event():
-    inner = MagicMock()
-    inner.__repr__ = lambda self: "'abs(zscore(\"loss\")) > 3.0'"
-    filt = SimpleNamespace(metric=SimpleNamespace(threshold_filter=None, change_filter=None, zscore_filter=inner))
-    return SimpleNamespace(event_type=_enum("RUN_METRIC_ZSCORE"), filter=filt)
-
-
-def _run_state_event():
-    state = MagicMock()
-    state.__repr__ = lambda self: "'state in [finished, failed]'"
-    filt = SimpleNamespace(metric=None, state=state)
+def _run_state_event(states=("finished", "failed")):
+    state = SimpleNamespace(states=[_enum(s) for s in states])
+    filt = SimpleNamespace(state=state)
+    # `filter` for RUN_STATE only carries .state, not .metric -- match that.
     return SimpleNamespace(event_type=_enum("RUN_STATE"), filter=filt)
 
 
-def _create_artifact_event():
-    # Mutation events use _WrappedSavedEventFilter -> no .metric / .state.
-    filt = MagicMock()
-    filt.metric = None
-    filt.state = None
-    filt.__repr__ = lambda self: "And()"
-    return SimpleNamespace(event_type=_enum("CREATE_ARTIFACT"), filter=filt)
+def _mutation_event(event_type="CREATE_ARTIFACT"):
+    # Mutation-event filters are MongoLikeFilter (And() etc.) -- no .metric or .state.
+    filt = SimpleNamespace()
+    return SimpleNamespace(event_type=_enum(event_type), filter=filt)
 
 
 def _notification_action(integration_id="int_slack_1", title="t", message="m", severity="INFO"):
@@ -88,14 +110,15 @@ def _notification_action(integration_id="int_slack_1", title="t", message="m", s
         integration=SimpleNamespace(id=integration_id),
         title=title,
         message=message,
-        severity=_enum(severity),
+        severity=_enum(severity) if severity else None,
     )
 
 
-def _webhook_action(integration_id="int_webhook_1"):
+def _webhook_action(integration_id="int_webhook_1", request_payload=None):
     return SimpleNamespace(
         action_type=_enum("GENERIC_WEBHOOK"),
         integration=SimpleNamespace(id=integration_id),
+        request_payload=request_payload,
     )
 
 
@@ -112,6 +135,7 @@ def _automation(
     scope=None,
     event=None,
     action=None,
+    updated_at=datetime(2026, 5, 1, 12, 0, 0),
 ):
     return SimpleNamespace(
         id=id,
@@ -119,9 +143,9 @@ def _automation(
         enabled=enabled,
         description=description,
         created_at=datetime(2026, 1, 1, 12, 0, 0),
-        updated_at=datetime(2026, 5, 1, 12, 0, 0),
+        updated_at=updated_at,
         scope=scope or _project_scope(),
-        event=event or _threshold_event(),
+        event=event or _run_metric_event(),
         action=action or _notification_action(),
     )
 
@@ -163,7 +187,6 @@ class TestListAutomations:
         assert result["count"] == 1
         assert result["entity"] is None
         assert result["truncated"] is False
-        # entity must NOT be in the kwargs when caller passed None
         kwargs = api.automations.call_args.kwargs
         assert "entity" not in kwargs
         assert "name" not in kwargs
@@ -188,7 +211,7 @@ class TestListAutomations:
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_max_items_truncation(self, mock_mgr):
         api = MagicMock()
-        api.automations.return_value = iter([_automation(id=f"a{i}", name=f"n{i}") for i in range(10)])
+        api.automations.return_value = iter([_automation(id=f"a{i}") for i in range(10)])
         mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
@@ -205,7 +228,6 @@ class TestListAutomations:
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
-        # ceiling is 200
         result = json.loads(list_automations(max_items=999))
         assert result["count"] == 200
         assert result["truncated"] is True
@@ -229,59 +251,144 @@ class TestListAutomations:
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_serializes_project_scope(self, mock_mgr):
         api = MagicMock()
-        api.automations.return_value = iter([_automation(scope=_project_scope(entity="t1", project="p1"))])
+        api.automations.return_value = iter([_automation(scope=_project_scope(id="scope_p1", name="proj-1"))])
         mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         scope = json.loads(list_automations())["automations"][0]["scope"]
-        assert scope["type"] == "PROJECT"
-        assert scope["project"] == "p1"
-        assert scope["entity"] == "t1"
+        assert scope == {"type": "PROJECT", "id": "scope_p1", "name": "proj-1"}
 
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_serializes_collection_scope(self, mock_mgr):
         api = MagicMock()
-        api.automations.return_value = iter(
-            [_automation(scope=_collection_scope(entity="t1", project="p1", collection="my-models"))]
-        )
+        api.automations.return_value = iter([_automation(scope=_collection_scope(id="scope_c1", name="my-models"))])
         mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         scope = json.loads(list_automations())["automations"][0]["scope"]
-        assert scope["type"] == "ARTIFACT_COLLECTION"
-        assert scope["name"] == "my-models"
-        assert scope["project"] == "p1"
-        assert scope["entity"] == "t1"
+        assert scope == {"type": "ARTIFACT_COLLECTION", "id": "scope_c1", "name": "my-models"}
 
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_each_event_type_serializes(self, mock_mgr):
+    def test_threshold_event_serialized_structured(self, mock_mgr):
         api = MagicMock()
         api.automations.return_value = iter(
             [
-                _automation(id="a1", event=_threshold_event()),
-                _automation(id="a2", event=_change_event()),
-                _automation(id="a3", event=_zscore_event()),
-                _automation(id="a4", event=_run_state_event()),
-                _automation(id="a5", event=_create_artifact_event()),
+                _automation(
+                    event=_run_metric_event(
+                        event_type="RUN_METRIC",
+                        metric=_threshold_metric_filter(
+                            name="accuracy", agg="MAX", window=5, cmp="$gt", threshold=0.95
+                        ),
+                    )
+                )
             ]
         )
         mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
-        events = [a["event"] for a in json.loads(list_automations())["automations"]]
-        assert [e["type"] for e in events] == [
-            "RUN_METRIC",
-            "RUN_METRIC_CHANGE",
-            "RUN_METRIC_ZSCORE",
-            "RUN_STATE",
-            "CREATE_ARTIFACT",
-        ]
-        # threshold/change/zscore/state should have a non-empty summary string
-        for e in events[:4]:
-            assert isinstance(e["summary"], str) and e["summary"]
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "RUN_METRIC"
+        assert event["filter"] == {
+            "kind": "threshold",
+            "metric": "accuracy",
+            "agg": "MAX",
+            "window": 5,
+            "cmp": "$gt",
+            "threshold": 0.95,
+        }
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_change_event_serialized_structured(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter(
+            [
+                _automation(
+                    event=_run_metric_event(
+                        event_type="RUN_METRIC_CHANGE",
+                        metric=_change_metric_filter(
+                            name="loss",
+                            agg="AVERAGE",
+                            window=3,
+                            prior_window=3,
+                            change_type="RELATIVE",
+                            change_dir="DECREASE",
+                            threshold=0.1,
+                        ),
+                    )
+                )
+            ]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "RUN_METRIC_CHANGE"
+        assert event["filter"] == {
+            "kind": "change",
+            "metric": "loss",
+            "agg": "AVERAGE",
+            "current_window": 3,
+            "prior_window": 3,
+            "change_type": "RELATIVE",
+            "change_dir": "DECREASE",
+            "threshold": 0.1,
+        }
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_zscore_event_serialized_structured(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter(
+            [
+                _automation(
+                    event=_run_metric_event(
+                        event_type="RUN_METRIC_ZSCORE",
+                        metric=_zscore_metric_filter(name="loss", window=30, change_dir="ANY", threshold=3.0),
+                    )
+                )
+            ]
+        )
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "RUN_METRIC_ZSCORE"
+        assert event["filter"] == {
+            "kind": "zscore",
+            "metric": "loss",
+            "window": 30,
+            "change_dir": "ANY",
+            "threshold": 3.0,
+        }
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_run_state_event_serialized(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(event=_run_state_event(states=("finished", "failed")))])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "RUN_STATE"
+        assert event["filter"] == {"states": ["finished", "failed"]}
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_mutation_event_serialized(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(event=_mutation_event("CREATE_ARTIFACT"))])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "CREATE_ARTIFACT"
+        # Mutation event filter is open-ended; we just expose a summary.
+        assert "summary" in event["filter"]
 
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_serializes_notification_action(self, mock_mgr):
@@ -305,13 +412,19 @@ class TestListAutomations:
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_serializes_webhook_action(self, mock_mgr):
         api = MagicMock()
-        api.automations.return_value = iter([_automation(action=_webhook_action(integration_id="int_w"))])
+        api.automations.return_value = iter(
+            [_automation(action=_webhook_action(integration_id="int_w", request_payload={"k": "v"}))]
+        )
         mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         action = json.loads(list_automations())["automations"][0]["action"]
-        assert action == {"type": "GENERIC_WEBHOOK", "integration_id": "int_w"}
+        assert action == {
+            "type": "GENERIC_WEBHOOK",
+            "integration_id": "int_w",
+            "request_payload": {"k": "v"},
+        }
 
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_serializes_no_op_action(self, mock_mgr):
@@ -335,6 +448,17 @@ class TestListAutomations:
         auto = json.loads(list_automations())["automations"][0]
         assert auto["created_at"] == "2026-01-01T12:00:00"
         assert auto["updated_at"] == "2026-05-01T12:00:00"
+
+    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
+    def test_null_updated_at(self, mock_mgr):
+        api = MagicMock()
+        api.automations.return_value = iter([_automation(updated_at=None)])
+        mock_mgr.get_api.return_value = api
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        auto = json.loads(list_automations())["automations"][0]
+        assert auto["updated_at"] is None
 
     @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
     def test_api_error_returns_error_dict(self, mock_mgr):
@@ -367,7 +491,6 @@ class TestListIntegrations:
         assert result["count"] == 2
         types = {item["type"] for item in result["integrations"]}
         assert types == {"slack", "webhook"}
-        # Slack and webhook endpoints were NOT both called
         api.slack_integrations.assert_not_called()
         api.webhook_integrations.assert_not_called()
 
@@ -420,7 +543,6 @@ class TestListIntegrations:
 
         result = json.loads(list_integrations(integration_type="email"))
         assert result["error"] == "invalid_input"
-        # No API calls should have happened
         api.integrations.assert_not_called()
         api.slack_integrations.assert_not_called()
         api.webhook_integrations.assert_not_called()

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,171 +1,297 @@
 """Mock-based unit tests for the list_automations and list_integrations tools.
 
-These tests stand in for the wandb SDK -- they exercise the flattening logic
-in mcp_tools/automations.py against fake Automation / Integration objects
-shaped like the pydantic models in wandb/wandb/automations/. No live wandb
-API calls.
+These tests exercise the flattening logic in ``mcp_tools/automations.py``
+against ``MagicMock(spec=...)`` stand-ins for the wandb SDK's pydantic
+models -- this gives us correct ``isinstance``/``match-case`` behavior
+without paying the cost of constructing real Automation/Integration
+objects through pydantic validation. No live wandb API calls.
 """
 
 from __future__ import annotations
 
 import json
 from datetime import datetime
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from typing import Callable
+from unittest.mock import MagicMock
 
-import pytest
+from pytest import fixture, mark
+from wandb.automations import (
+    ActionType,
+    Automation,
+    EventType,
+    SlackIntegration,
+    WebhookIntegration,
+)
+
+PATCH_TARGET = "wandb_mcp_server.mcp_tools.automations.WandBApiManager"
 
 
 # ---------------------------------------------------------------------------
-# Helpers to build fake wandb-SDK-shaped objects
+# Fixtures: factories for fake wandb-SDK-shaped objects
 #
-# We mirror the public pydantic shapes from wandb/wandb/automations/:
-#   - Scope:        scope_type (enum), id, name
-#   - Event:        event_type (enum), filter (typed per event)
-#   - Action:       action_type (enum), integration (with .id), + variant fields
-#   - Integration:  typename__ (literal), id, + variant fields
+# We use MagicMock(spec=<real wandb class>) so that isinstance() and the
+# match-case class patterns in the production code work correctly. Each
+# fixture returns a *factory* so individual tests can override only the
+# fields they care about.
 # ---------------------------------------------------------------------------
 
 
-def _enum(value):
-    """Build a fake enum-like object whose .value matches the SDK's LenientStrEnum."""
-    return SimpleNamespace(value=value)
+@fixture
+def mock_api(mocker) -> MagicMock:
+    """Patch WandBApiManager and yield the mocked ``api`` instance.
+
+    The production code under test calls ``WandBApiManager.get_api()``;
+    we replace the whole manager with a MagicMock and return the api
+    object so tests can configure ``api.automations.return_value`` etc.
+    """
+    mgr = mocker.patch(PATCH_TARGET)
+    api = MagicMock()
+    mgr.get_api.return_value = api
+    return api
 
 
-def _project_scope(id="scope_proj_1", name="my-project"):
-    return SimpleNamespace(scope_type=_enum("PROJECT"), id=id, name=name)
+@fixture
+def make_project_scope() -> Callable[..., MagicMock]:
+    def _make(*, id: str = "scope_proj_1", name: str = "my-project") -> MagicMock:
+        s = MagicMock()
+        s.scope_type = MagicMock(value="PROJECT")
+        s.id = id
+        s.name = name
+        return s
+
+    return _make
 
 
-def _collection_scope(id="scope_coll_1", name="my-models"):
-    return SimpleNamespace(scope_type=_enum("ARTIFACT_COLLECTION"), id=id, name=name)
+@fixture
+def make_collection_scope() -> Callable[..., MagicMock]:
+    def _make(*, id: str = "scope_coll_1", name: str = "my-models") -> MagicMock:
+        s = MagicMock()
+        s.scope_type = MagicMock(value="ARTIFACT_COLLECTION")
+        s.id = id
+        s.name = name
+        return s
+
+    return _make
 
 
-# Inner metric filters: each defines exactly one of threshold_filter /
-# change_filter / zscore_filter, matching wandb's _Wrapped* pydantic shapes.
+# NOTE: ``MagicMock(name=x, ...)`` treats ``name`` as the mock's repr name,
+# NOT as setting the ``.name`` attribute. For any wandb field literally called
+# "name" we always assign it via attribute after construction.
 
 
-def _threshold_metric_filter(name="acc", agg="MAX", window=5, cmp="$gt", threshold=0.9):
-    inner = SimpleNamespace(
-        name=name,
-        agg=_enum(agg) if agg else None,
-        window=window,
-        cmp=cmp,
-        threshold=threshold,
-    )
-    return SimpleNamespace(threshold_filter=inner)
+@fixture
+def make_threshold_event() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        metric_name: str = "acc",
+        agg: str | None = "MAX",
+        window: int = 5,
+        cmp: str = "$gt",
+        threshold: float = 0.9,
+    ) -> MagicMock:
+        inner = MagicMock(window=window, cmp=cmp, threshold=threshold)
+        inner.name = metric_name
+        inner.agg = MagicMock(value=agg) if agg else None
+        wrapper = MagicMock(event_type=EventType.RUN_METRIC_THRESHOLD, threshold_filter=inner)
+        return MagicMock(event_type=EventType.RUN_METRIC_THRESHOLD, filter=MagicMock(metric=wrapper))
+
+    return _make
 
 
-def _change_metric_filter(
-    name="loss",
-    agg="AVERAGE",
-    window=3,
-    prior_window=3,
-    change_type="RELATIVE",
-    change_dir="DECREASE",
-    threshold=0.1,
-):
-    inner = SimpleNamespace(
-        name=name,
-        agg=_enum(agg) if agg else None,
-        window=window,
-        prior_window=prior_window,
-        change_type=_enum(change_type),
-        change_dir=_enum(change_dir),
-        threshold=threshold,
-    )
-    return SimpleNamespace(change_filter=inner)
+@fixture
+def make_change_event() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        metric_name: str = "loss",
+        agg: str | None = "AVERAGE",
+        window: int = 3,
+        prior_window: int = 3,
+        change_type: str = "RELATIVE",
+        change_dir: str = "DECREASE",
+        threshold: float = 0.1,
+    ) -> MagicMock:
+        inner = MagicMock(
+            window=window,
+            prior_window=prior_window,
+            change_type=MagicMock(value=change_type),
+            change_dir=MagicMock(value=change_dir),
+            threshold=threshold,
+        )
+        inner.name = metric_name
+        inner.agg = MagicMock(value=agg) if agg else None
+        wrapper = MagicMock(event_type=EventType.RUN_METRIC_CHANGE, change_filter=inner)
+        return MagicMock(event_type=EventType.RUN_METRIC_CHANGE, filter=MagicMock(metric=wrapper))
+
+    return _make
 
 
-def _zscore_metric_filter(name="loss", window=30, change_dir="ANY", threshold=3.0):
-    inner = SimpleNamespace(
-        name=name,
-        window=window,
-        change_dir=_enum(change_dir),
-        threshold=threshold,
-    )
-    return SimpleNamespace(zscore_filter=inner)
+@fixture
+def make_zscore_event() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        metric_name: str = "loss",
+        window: int = 30,
+        change_dir: str = "ANY",
+        threshold: float = 3.0,
+    ) -> MagicMock:
+        inner = MagicMock(
+            window=window,
+            change_dir=MagicMock(value=change_dir),
+            threshold=threshold,
+        )
+        inner.name = metric_name
+        wrapper = MagicMock(event_type=EventType.RUN_METRIC_ZSCORE, zscore_filter=inner)
+        return MagicMock(event_type=EventType.RUN_METRIC_ZSCORE, filter=MagicMock(metric=wrapper))
+
+    return _make
 
 
-def _run_metric_event(event_type="RUN_METRIC", metric=None):
-    filt = SimpleNamespace(metric=metric or _threshold_metric_filter())
-    return SimpleNamespace(event_type=_enum(event_type), filter=filt)
+@fixture
+def make_run_state_event() -> Callable[..., MagicMock]:
+    def _make(*, states: tuple[str, ...] = ("finished", "failed")) -> MagicMock:
+        state = MagicMock(states=[MagicMock(value=s) for s in states])
+        return MagicMock(event_type=EventType.RUN_STATE, filter=MagicMock(state=state))
+
+    return _make
 
 
-def _run_state_event(states=("finished", "failed")):
-    state = SimpleNamespace(states=[_enum(s) for s in states])
-    filt = SimpleNamespace(state=state)
-    # `filter` for RUN_STATE only carries .state, not .metric -- match that.
-    return SimpleNamespace(event_type=_enum("RUN_STATE"), filter=filt)
+@fixture
+def make_mutation_event() -> Callable[..., MagicMock]:
+    """An event for CREATE_ARTIFACT / ADD_ARTIFACT_ALIAS / LINK_ARTIFACT.
+
+    Mutation-event filters are open-ended MongoLikeFilter objects; the
+    production code falls back to ``repr()`` for these, so we only need
+    a sentinel filter object whose ``repr`` is recognizable.
+    """
+
+    def _make(*, event_type: EventType = EventType.CREATE_ARTIFACT) -> MagicMock:
+        return MagicMock(event_type=event_type, filter=MagicMock())
+
+    return _make
 
 
-def _mutation_event(event_type="CREATE_ARTIFACT"):
-    # Mutation-event filters are MongoLikeFilter (And() etc.) -- no .metric or .state.
-    filt = SimpleNamespace()
-    return SimpleNamespace(event_type=_enum(event_type), filter=filt)
+@fixture
+def make_notification_action() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        integration_id: str = "int_slack_1",
+        title: str = "t",
+        message: str = "m",
+        severity: str | None = "INFO",
+    ) -> MagicMock:
+        a = MagicMock(
+            action_type=ActionType.NOTIFICATION,
+            integration=MagicMock(id=integration_id),
+            title=title,
+            message=message,
+            severity=MagicMock(value=severity) if severity else None,
+        )
+        return a
+
+    return _make
 
 
-def _notification_action(integration_id="int_slack_1", title="t", message="m", severity="INFO"):
-    return SimpleNamespace(
-        action_type=_enum("NOTIFICATION"),
-        integration=SimpleNamespace(id=integration_id),
-        title=title,
-        message=message,
-        severity=_enum(severity) if severity else None,
-    )
+@fixture
+def make_webhook_action() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        integration_id: str = "int_webhook_1",
+        request_payload: dict | None = None,
+    ) -> MagicMock:
+        return MagicMock(
+            action_type=ActionType.GENERIC_WEBHOOK,
+            integration=MagicMock(id=integration_id),
+            request_payload=request_payload,
+        )
+
+    return _make
 
 
-def _webhook_action(integration_id="int_webhook_1", request_payload=None):
-    return SimpleNamespace(
-        action_type=_enum("GENERIC_WEBHOOK"),
-        integration=SimpleNamespace(id=integration_id),
-        request_payload=request_payload,
-    )
+@fixture
+def make_no_op_action() -> Callable[..., MagicMock]:
+    def _make() -> MagicMock:
+        return MagicMock(action_type=ActionType.NO_OP)
+
+    return _make
 
 
-def _no_op_action():
-    return SimpleNamespace(action_type=_enum("NO_OP"), integration=None)
+@fixture
+def make_automation(make_project_scope, make_threshold_event, make_notification_action) -> Callable[..., MagicMock]:
+    """Build a MagicMock with the same surface as ``wandb.automations.Automation``.
+
+    Using ``spec=Automation`` would make ``isinstance(m, Automation)`` true,
+    but the production code doesn't isinstance-check Automations -- it
+    only attribute-accesses them -- so a plain MagicMock keeps fixture
+    setup simpler. Override any field via kwargs.
+    """
+
+    def _make(
+        *,
+        id: str = "auto_1",
+        name: str = "my-automation",
+        enabled: bool = True,
+        description: str | None = "desc",
+        created_at: datetime = datetime(2026, 1, 1, 12, 0, 0),
+        updated_at: datetime | None = datetime(2026, 5, 1, 12, 0, 0),
+        scope: MagicMock | None = None,
+        event: MagicMock | None = None,
+        action: MagicMock | None = None,
+    ) -> MagicMock:
+        m = MagicMock(
+            id=id,
+            enabled=enabled,
+            description=description,
+            created_at=created_at,
+            updated_at=updated_at,
+            scope=scope or make_project_scope(),
+            event=event or make_threshold_event(),
+            action=action or make_notification_action(),
+        )
+        m.name = name  # see note above: ``name`` is reserved in MagicMock()
+        return m
+
+    return _make
 
 
-def _automation(
-    *,
-    id="auto_1",
-    name="my-automation",
-    enabled=True,
-    description="desc",
-    scope=None,
-    event=None,
-    action=None,
-    updated_at=datetime(2026, 5, 1, 12, 0, 0),
-):
-    return SimpleNamespace(
-        id=id,
-        name=name,
-        enabled=enabled,
-        description=description,
-        created_at=datetime(2026, 1, 1, 12, 0, 0),
-        updated_at=updated_at,
-        scope=scope or _project_scope(),
-        event=event or _run_metric_event(),
-        action=action or _notification_action(),
-    )
+@fixture
+def make_slack_integration() -> Callable[..., MagicMock]:
+    """Build a MagicMock that passes ``isinstance(m, SlackIntegration)``.
+
+    Using ``spec=SlackIntegration`` is the canonical way to get a mock
+    that the production code's ``match SlackIntegration():`` pattern
+    will recognize.
+    """
+
+    def _make(
+        *,
+        id: str = "int_slack_1",
+        team_name: str = "acme",
+        channel_name: str = "alerts",
+    ) -> MagicMock:
+        m = MagicMock(spec=SlackIntegration)
+        m.id = id
+        m.team_name = team_name
+        m.channel_name = channel_name
+        return m
+
+    return _make
 
 
-def _slack_integration(id="int_slack_1", team="acme", channel="alerts"):
-    return SimpleNamespace(
-        typename__="SlackIntegration",
-        id=id,
-        team_name=team,
-        channel_name=channel,
-    )
+@fixture
+def make_webhook_integration() -> Callable[..., MagicMock]:
+    def _make(
+        *,
+        id: str = "int_webhook_1",
+        name: str = "prod-webhook",
+        url_endpoint: str = "https://example.com/hook",
+    ) -> MagicMock:
+        m = MagicMock(spec=WebhookIntegration)
+        m.id = id
+        m.name = name  # safe here -- assigned via attribute, not kwarg
+        m.url_endpoint = url_endpoint
+        return m
 
-
-def _webhook_integration(id="int_webhook_1", name="prod-webhook", url="https://example.com/hook"):
-    return SimpleNamespace(
-        typename__="GenericWebhookIntegration",
-        id=id,
-        name=name,
-        url_endpoint=url,
-    )
+    return _make
 
 
 # ---------------------------------------------------------------------------
@@ -174,11 +300,8 @@ def _webhook_integration(id="int_webhook_1", name="prod-webhook", url="https://e
 
 
 class TestListAutomations:
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_no_entity_arg_calls_api_without_entity(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation()])
-        mock_mgr.get_api.return_value = api
+    def test_no_entity_arg_calls_api_without_entity(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation()])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -187,15 +310,12 @@ class TestListAutomations:
         assert result["count"] == 1
         assert result["entity"] is None
         assert result["truncated"] is False
-        kwargs = api.automations.call_args.kwargs
+        kwargs = mock_api.automations.call_args.kwargs
         assert "entity" not in kwargs
         assert "name" not in kwargs
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_entity_and_name_passed_through(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(name="exact-match")])
-        mock_mgr.get_api.return_value = api
+    def test_entity_and_name_passed_through(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(name="exact-match")])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -204,15 +324,12 @@ class TestListAutomations:
         assert result["entity"] == "my-team"
         assert result["count"] == 1
         assert result["automations"][0]["name"] == "exact-match"
-        kwargs = api.automations.call_args.kwargs
+        kwargs = mock_api.automations.call_args.kwargs
         assert kwargs["entity"] == "my-team"
         assert kwargs["name"] == "exact-match"
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_max_items_truncation(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(id=f"a{i}") for i in range(10)])
-        mock_mgr.get_api.return_value = api
+    def test_max_items_truncation(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(id=f"a{i}") for i in range(10)])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -220,11 +337,8 @@ class TestListAutomations:
         assert result["count"] == 3
         assert result["truncated"] is True
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_max_items_ceiling(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(id=f"a{i}") for i in range(250)])
-        mock_mgr.get_api.return_value = api
+    def test_max_items_ceiling(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(id=f"a{i}") for i in range(250)])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -232,11 +346,8 @@ class TestListAutomations:
         assert result["count"] == 200
         assert result["truncated"] is True
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_empty_result(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([])
-        mock_mgr.get_api.return_value = api
+    def test_empty_result(self, mock_api):
+        mock_api.automations.return_value = iter([])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -248,128 +359,107 @@ class TestListAutomations:
             "truncated": False,
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_serializes_project_scope(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(scope=_project_scope(id="scope_p1", name="proj-1"))])
-        mock_mgr.get_api.return_value = api
+    def test_project_scope_serialized(self, mock_api, make_automation, make_project_scope):
+        mock_api.automations.return_value = iter(
+            [make_automation(scope=make_project_scope(id="scope_p1", name="proj-1"))]
+        )
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         scope = json.loads(list_automations())["automations"][0]["scope"]
         assert scope == {"type": "PROJECT", "id": "scope_p1", "name": "proj-1"}
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_serializes_collection_scope(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(scope=_collection_scope(id="scope_c1", name="my-models"))])
-        mock_mgr.get_api.return_value = api
+    def test_collection_scope_serialized(self, mock_api, make_automation, make_collection_scope):
+        mock_api.automations.return_value = iter(
+            [make_automation(scope=make_collection_scope(id="scope_c1", name="my-models"))]
+        )
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         scope = json.loads(list_automations())["automations"][0]["scope"]
         assert scope == {"type": "ARTIFACT_COLLECTION", "id": "scope_c1", "name": "my-models"}
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_threshold_event_serialized_structured(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter(
+    def test_threshold_event_structured(self, mock_api, make_automation, make_threshold_event):
+        mock_api.automations.return_value = iter(
             [
-                _automation(
-                    event=_run_metric_event(
-                        event_type="RUN_METRIC",
-                        metric=_threshold_metric_filter(
-                            name="accuracy", agg="MAX", window=5, cmp="$gt", threshold=0.95
-                        ),
-                    )
+                make_automation(
+                    event=make_threshold_event(metric_name="accuracy", agg="MAX", window=5, cmp="$gt", threshold=0.95)
                 )
             ]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         event = json.loads(list_automations())["automations"][0]["event"]
-        assert event["type"] == "RUN_METRIC"
-        assert event["filter"] == {
-            "kind": "threshold",
-            "metric": "accuracy",
-            "agg": "MAX",
-            "window": 5,
-            "cmp": "$gt",
-            "threshold": 0.95,
+        assert event == {
+            "type": "RUN_METRIC",
+            "filter": {
+                "kind": "threshold",
+                "metric": "accuracy",
+                "agg": "MAX",
+                "window": 5,
+                "cmp": "$gt",
+                "threshold": 0.95,
+            },
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_change_event_serialized_structured(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter(
+    def test_change_event_structured(self, mock_api, make_automation, make_change_event):
+        mock_api.automations.return_value = iter(
             [
-                _automation(
-                    event=_run_metric_event(
-                        event_type="RUN_METRIC_CHANGE",
-                        metric=_change_metric_filter(
-                            name="loss",
-                            agg="AVERAGE",
-                            window=3,
-                            prior_window=3,
-                            change_type="RELATIVE",
-                            change_dir="DECREASE",
-                            threshold=0.1,
-                        ),
+                make_automation(
+                    event=make_change_event(
+                        metric_name="loss",
+                        agg="AVERAGE",
+                        window=3,
+                        prior_window=3,
+                        change_type="RELATIVE",
+                        change_dir="DECREASE",
+                        threshold=0.1,
                     )
                 )
             ]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         event = json.loads(list_automations())["automations"][0]["event"]
-        assert event["type"] == "RUN_METRIC_CHANGE"
-        assert event["filter"] == {
-            "kind": "change",
-            "metric": "loss",
-            "agg": "AVERAGE",
-            "current_window": 3,
-            "prior_window": 3,
-            "change_type": "RELATIVE",
-            "change_dir": "DECREASE",
-            "threshold": 0.1,
+        assert event == {
+            "type": "RUN_METRIC_CHANGE",
+            "filter": {
+                "kind": "change",
+                "metric": "loss",
+                "agg": "AVERAGE",
+                "current_window": 3,
+                "prior_window": 3,
+                "change_type": "RELATIVE",
+                "change_dir": "DECREASE",
+                "threshold": 0.1,
+            },
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_zscore_event_serialized_structured(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter(
-            [
-                _automation(
-                    event=_run_metric_event(
-                        event_type="RUN_METRIC_ZSCORE",
-                        metric=_zscore_metric_filter(name="loss", window=30, change_dir="ANY", threshold=3.0),
-                    )
-                )
-            ]
+    def test_zscore_event_structured(self, mock_api, make_automation, make_zscore_event):
+        mock_api.automations.return_value = iter(
+            [make_automation(event=make_zscore_event(metric_name="loss", window=30, change_dir="ANY", threshold=3.0))]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         event = json.loads(list_automations())["automations"][0]["event"]
-        assert event["type"] == "RUN_METRIC_ZSCORE"
-        assert event["filter"] == {
-            "kind": "zscore",
-            "metric": "loss",
-            "window": 30,
-            "change_dir": "ANY",
-            "threshold": 3.0,
+        assert event == {
+            "type": "RUN_METRIC_ZSCORE",
+            "filter": {
+                "kind": "zscore",
+                "metric": "loss",
+                "window": 30,
+                "change_dir": "ANY",
+                "threshold": 3.0,
+            },
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_run_state_event_serialized(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(event=_run_state_event(states=("finished", "failed")))])
-        mock_mgr.get_api.return_value = api
+    def test_run_state_event_serialized(self, mock_api, make_automation, make_run_state_event):
+        mock_api.automations.return_value = iter(
+            [make_automation(event=make_run_state_event(states=("finished", "failed")))]
+        )
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -377,26 +467,28 @@ class TestListAutomations:
         assert event["type"] == "RUN_STATE"
         assert event["filter"] == {"states": ["finished", "failed"]}
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_mutation_event_serialized(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(event=_mutation_event("CREATE_ARTIFACT"))])
-        mock_mgr.get_api.return_value = api
+    @mark.parametrize(
+        "event_type",
+        [EventType.CREATE_ARTIFACT, EventType.ADD_ARTIFACT_ALIAS, EventType.LINK_ARTIFACT],
+    )
+    def test_mutation_event_serialized(self, mock_api, make_automation, make_mutation_event, event_type):
+        mock_api.automations.return_value = iter([make_automation(event=make_mutation_event(event_type=event_type))])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         event = json.loads(list_automations())["automations"][0]["event"]
-        assert event["type"] == "CREATE_ARTIFACT"
-        # Mutation event filter is open-ended; we just expose a summary.
-        assert "summary" in event["filter"]
+        assert event["type"] == event_type.value
+        # Mutation-event filter has no structured shape -- only a summary string.
+        assert set(event["filter"].keys()) == {"summary"}
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_serializes_notification_action(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter(
-            [_automation(action=_notification_action(integration_id="int_x", title="T", message="M", severity="WARN"))]
+    def test_notification_action_serialized(self, mock_api, make_automation, make_notification_action):
+        mock_api.automations.return_value = iter(
+            [
+                make_automation(
+                    action=make_notification_action(integration_id="int_x", title="T", message="M", severity="WARN")
+                )
+            ]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -409,13 +501,10 @@ class TestListAutomations:
             "severity": "WARN",
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_serializes_webhook_action(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter(
-            [_automation(action=_webhook_action(integration_id="int_w", request_payload={"k": "v"}))]
+    def test_webhook_action_serialized(self, mock_api, make_automation, make_webhook_action):
+        mock_api.automations.return_value = iter(
+            [make_automation(action=make_webhook_action(integration_id="int_w", request_payload={"k": "v"}))]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -426,22 +515,16 @@ class TestListAutomations:
             "request_payload": {"k": "v"},
         }
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_serializes_no_op_action(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(action=_no_op_action())])
-        mock_mgr.get_api.return_value = api
+    def test_no_op_action_serialized(self, mock_api, make_automation, make_no_op_action):
+        mock_api.automations.return_value = iter([make_automation(action=make_no_op_action())])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         action = json.loads(list_automations())["automations"][0]["action"]
         assert action == {"type": "NO_OP"}
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_iso_timestamps(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation()])
-        mock_mgr.get_api.return_value = api
+    def test_iso_timestamps(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation()])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -449,22 +532,16 @@ class TestListAutomations:
         assert auto["created_at"] == "2026-01-01T12:00:00"
         assert auto["updated_at"] == "2026-05-01T12:00:00"
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_null_updated_at(self, mock_mgr):
-        api = MagicMock()
-        api.automations.return_value = iter([_automation(updated_at=None)])
-        mock_mgr.get_api.return_value = api
+    def test_null_updated_at(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(updated_at=None)])
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         auto = json.loads(list_automations())["automations"][0]
         assert auto["updated_at"] is None
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_api_error_returns_error_dict(self, mock_mgr):
-        api = MagicMock()
-        api.automations.side_effect = RuntimeError("boom")
-        mock_mgr.get_api.return_value = api
+    def test_api_error_returns_error_dict(self, mock_api):
+        mock_api.automations.side_effect = RuntimeError("boom")
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
@@ -479,30 +556,25 @@ class TestListAutomations:
 
 
 class TestListIntegrations:
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_no_type_returns_both(self, mock_mgr):
-        api = MagicMock()
-        api.integrations.return_value = iter([_slack_integration(), _webhook_integration()])
-        mock_mgr.get_api.return_value = api
+    def test_no_type_returns_both(self, mock_api, make_slack_integration, make_webhook_integration):
+        mock_api.integrations.return_value = iter([make_slack_integration(), make_webhook_integration()])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
         result = json.loads(list_integrations(entity="my-team"))
         assert result["count"] == 2
-        types = {item["type"] for item in result["integrations"]}
-        assert types == {"slack", "webhook"}
-        api.slack_integrations.assert_not_called()
-        api.webhook_integrations.assert_not_called()
+        assert {item["type"] for item in result["integrations"]} == {"slack", "webhook"}
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_filter_slack(self, mock_mgr):
-        api = MagicMock()
-        api.slack_integrations.return_value = iter([_slack_integration(id="s1", team="acme", channel="alerts")])
-        mock_mgr.get_api.return_value = api
+    def test_filter_slack(self, mock_api, make_slack_integration):
+        mock_api.slack_integrations.return_value = iter(
+            [make_slack_integration(id="s1", team_name="acme", channel_name="alerts")]
+        )
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
-        result = json.loads(list_integrations(entity="my-team", integration_type="slack"))
+        result = json.loads(list_integrations(entity="my-team", kind="slack"))
         assert result["count"] == 1
         assert result["integrations"][0] == {
             "id": "s1",
@@ -510,20 +582,17 @@ class TestListIntegrations:
             "team_name": "acme",
             "channel_name": "alerts",
         }
-        api.integrations.assert_not_called()
-        api.webhook_integrations.assert_not_called()
+        mock_api.integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_filter_webhook(self, mock_mgr):
-        api = MagicMock()
-        api.webhook_integrations.return_value = iter(
-            [_webhook_integration(id="w1", name="prod", url="https://x.test/hook")]
+    def test_filter_webhook(self, mock_api, make_webhook_integration):
+        mock_api.webhook_integrations.return_value = iter(
+            [make_webhook_integration(id="w1", name="prod", url_endpoint="https://x.test/hook")]
         )
-        mock_mgr.get_api.return_value = api
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
-        result = json.loads(list_integrations(integration_type="webhook"))
+        result = json.loads(list_integrations(kind="webhook"))
         assert result["count"] == 1
         assert result["integrations"][0] == {
             "id": "w1",
@@ -531,27 +600,20 @@ class TestListIntegrations:
             "name": "prod",
             "url_endpoint": "https://x.test/hook",
         }
-        api.integrations.assert_not_called()
-        api.slack_integrations.assert_not_called()
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_invalid_type_returns_error(self, mock_mgr):
-        api = MagicMock()
-        mock_mgr.get_api.return_value = api
-
+    def test_invalid_type_returns_error(self, mock_api):
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
-        result = json.loads(list_integrations(integration_type="email"))
+        result = json.loads(list_integrations(kind="email"))
         assert result["error"] == "invalid_input"
-        api.integrations.assert_not_called()
-        api.slack_integrations.assert_not_called()
-        api.webhook_integrations.assert_not_called()
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_empty(self, mock_mgr):
-        api = MagicMock()
-        api.integrations.return_value = iter([])
-        mock_mgr.get_api.return_value = api
+    def test_empty(self, mock_api):
+        mock_api.integrations.return_value = iter([])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
@@ -560,11 +622,8 @@ class TestListIntegrations:
         assert result["integrations"] == []
         assert result["truncated"] is False
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_max_items_truncation(self, mock_mgr):
-        api = MagicMock()
-        api.integrations.return_value = iter([_slack_integration(id=f"s{i}") for i in range(20)])
-        mock_mgr.get_api.return_value = api
+    def test_max_items_truncation(self, mock_api, make_slack_integration):
+        mock_api.integrations.return_value = iter([make_slack_integration(id=f"s{i}") for i in range(20)])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
@@ -572,11 +631,8 @@ class TestListIntegrations:
         assert result["count"] == 5
         assert result["truncated"] is True
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_max_items_ceiling(self, mock_mgr):
-        api = MagicMock()
-        api.integrations.return_value = iter([_webhook_integration(id=f"w{i}") for i in range(250)])
-        mock_mgr.get_api.return_value = api
+    def test_max_items_ceiling(self, mock_api, make_webhook_integration):
+        mock_api.integrations.return_value = iter([make_webhook_integration(id=f"w{i}") for i in range(250)])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
@@ -584,11 +640,8 @@ class TestListIntegrations:
         assert result["count"] == 200
         assert result["truncated"] is True
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_api_error_returns_error_dict(self, mock_mgr):
-        api = MagicMock()
-        api.integrations.side_effect = RuntimeError("kapow")
-        mock_mgr.get_api.return_value = api
+    def test_api_error_returns_error_dict(self, mock_api):
+        mock_api.integrations.side_effect = RuntimeError("kapow")
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
@@ -596,19 +649,21 @@ class TestListIntegrations:
         assert result["error"] == "api_error"
         assert "kapow" in result["message"]
 
-    @patch("wandb_mcp_server.mcp_tools.automations.WandBApiManager")
-    def test_unknown_typename_falls_back(self, mock_mgr):
-        # Future integration kinds we don't recognize should still serialize.
-        api = MagicMock()
-        api.integrations.return_value = iter([SimpleNamespace(typename__="DiscordIntegration", id="d1")])
-        mock_mgr.get_api.return_value = api
+    def test_unknown_typename_falls_back(self, mock_api):
+        """Forward-compat: an Integration kind that's neither Slack nor Webhook
+        should still serialize (this is the wildcard match arm)."""
+        other = MagicMock()
+        other.id = "d1"
+        other.typename__ = "DiscordIntegration"
+        # IMPORTANT: do NOT spec=SlackIntegration/WebhookIntegration so the
+        # match-case wildcard fires.
+        mock_api.integrations.return_value = iter([other])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
         result = json.loads(list_integrations())
         assert result["count"] == 1
-        assert result["integrations"][0]["id"] == "d1"
-        assert result["integrations"][0]["type"] == "DiscordIntegration"
+        assert result["integrations"][0] == {"id": "d1", "type": "DiscordIntegration"}
 
 
 # ---------------------------------------------------------------------------
@@ -616,10 +671,7 @@ class TestListIntegrations:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "const_name",
-    ["LIST_AUTOMATIONS_TOOL_DESCRIPTION", "LIST_INTEGRATIONS_TOOL_DESCRIPTION"],
-)
+@mark.parametrize("const_name", ["LIST_AUTOMATIONS_TOOL_DESCRIPTION", "LIST_INTEGRATIONS_TOOL_DESCRIPTION"])
 def test_tool_descriptions_present(const_name):
     from wandb_mcp_server.mcp_tools import automations as mod
 
@@ -627,3 +679,14 @@ def test_tool_descriptions_present(const_name):
     assert isinstance(val, str)
     assert "<when_to_use>" in val
     assert "<critical_info>" in val
+
+
+# ---------------------------------------------------------------------------
+# Sanity check: ``Automation`` import works so spec= would work in future tests
+# ---------------------------------------------------------------------------
+
+
+def test_wandb_automation_class_importable():
+    """If wandb ever moves/renames Automation, this test will fail loudly
+    so the mock fixtures above can be updated in lockstep."""
+    assert isinstance(Automation, type)

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,22 +1,23 @@
-"""Mock-based unit tests for the list_automations and list_integrations tools.
+"""Unit tests for the list_automations and list_integrations tools.
 
-These tests exercise the flattening logic in ``mcp_tools/automations.py``
-against ``MagicMock(spec=...)`` stand-ins for the wandb SDK's pydantic
-models -- this gives us correct ``isinstance``/``match-case`` behavior
-without paying the cost of constructing real Automation/Integration
-objects through pydantic validation. No live wandb API calls.
+These tests use *real* wandb pydantic instances (via ``Automation.model_validate``
+and ``SlackIntegration.model_validate`` / ``WebhookIntegration.model_validate``)
+rather than mocks, so they exercise the production serializer (``_jsonify_*``)
+against the actual model contracts the wandb SDK guarantees -- if wandb
+renames a field or changes a discriminator, these tests catch it. The only
+``MagicMock`` left in the file is the one ``test_unknown_typename_falls_back``
+needs to simulate a future integration kind that isn't ``SlackIntegration``
+or ``WebhookIntegration`` -- there's no way to do that with a real type.
 """
 
 from __future__ import annotations
 
 import json
-from datetime import datetime
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import MagicMock
 
 from pytest import fixture, mark
 from wandb.automations import (
-    ActionType,
     Automation,
     EventType,
     SlackIntegration,
@@ -27,22 +28,20 @@ PATCH_TARGET = "wandb_mcp_server.mcp_tools.automations.WandBApiManager"
 
 
 # ---------------------------------------------------------------------------
-# Fixtures: factories for fake wandb-SDK-shaped objects
-#
-# We use MagicMock(spec=<real wandb class>) so that isinstance() and the
-# match-case class patterns in the production code work correctly. Each
-# fixture returns a *factory* so individual tests can override only the
-# fields they care about.
+# Fixtures: factories that build real wandb pydantic instances via
+# ``model_validate``, the canonical "construct from API response" path.
+# Tests get factories rather than fixed instances so individual cases can
+# override only the fields they care about.
 # ---------------------------------------------------------------------------
 
 
 @fixture
 def mock_api(mocker) -> MagicMock:
-    """Patch WandBApiManager and yield the mocked ``api`` instance.
+    """Patch ``WandBApiManager`` and yield the mocked ``api`` instance.
 
-    The production code under test calls ``WandBApiManager.get_api()``;
-    we replace the whole manager with a MagicMock and return the api
-    object so tests can configure ``api.automations.return_value`` etc.
+    Production calls ``WandBApiManager.get_api()``; we replace the manager
+    with a MagicMock and return the api so tests can configure
+    ``api.automations.return_value`` etc.
     """
     mgr = mocker.patch(PATCH_TARGET)
     api = MagicMock()
@@ -50,37 +49,52 @@ def mock_api(mocker) -> MagicMock:
     return api
 
 
+# ---------------------------------------------------------------------------
+# Scope payload factories (GraphQL-shaped dicts; assembled by make_automation
+# and validated through Automation.model_validate).
+# ---------------------------------------------------------------------------
+
+
 @fixture
-def make_project_scope() -> Callable[..., MagicMock]:
-    def _make(*, id: str = "scope_proj_1", name: str = "my-project") -> MagicMock:
-        s = MagicMock()
-        s.scope_type = MagicMock(value="PROJECT")
-        s.id = id
-        s.name = name
-        return s
+def make_project_scope() -> Callable[..., dict[str, Any]]:
+    def _make(*, id: str = "scope_proj_1", name: str = "my-project") -> dict[str, Any]:
+        return {"__typename": "Project", "id": id, "name": name}
 
     return _make
 
 
 @fixture
-def make_collection_scope() -> Callable[..., MagicMock]:
-    def _make(*, id: str = "scope_coll_1", name: str = "my-models") -> MagicMock:
-        s = MagicMock()
-        s.scope_type = MagicMock(value="ARTIFACT_COLLECTION")
-        s.id = id
-        s.name = name
-        return s
+def make_collection_scope() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        id: str = "scope_coll_1",
+        name: str = "my-models",
+        kind: str = "ArtifactSequence",
+    ) -> dict[str, Any]:
+        # wandb has two artifact-collection variants -- ArtifactSequence
+        # (versioned artifact) and ArtifactPortfolio (registry collection).
+        # Both serialize to ARTIFACT_COLLECTION scope_type so either works.
+        return {"__typename": kind, "id": id, "name": name}
 
     return _make
 
 
-# NOTE: ``MagicMock(name=x, ...)`` treats ``name`` as the mock's repr name,
-# NOT as setting the ``.name`` attribute. For any wandb field literally called
-# "name" we always assign it via attribute after construction.
+# ---------------------------------------------------------------------------
+# Event payload factories.
+# ---------------------------------------------------------------------------
+
+
+def _filter_event_payload(event_type: str, filter_obj: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "__typename": "FilterEventTriggeringCondition",
+        "eventType": event_type,
+        # The wire format stores the filter as a JSON-encoded string.
+        "filter": json.dumps(filter_obj),
+    }
 
 
 @fixture
-def make_threshold_event() -> Callable[..., MagicMock]:
+def make_threshold_event() -> Callable[..., dict[str, Any]]:
     def _make(
         *,
         metric_name: str = "acc",
@@ -88,18 +102,28 @@ def make_threshold_event() -> Callable[..., MagicMock]:
         window: int = 5,
         cmp: str = "$gt",
         threshold: float = 0.9,
-    ) -> MagicMock:
-        inner = MagicMock(window=window, cmp=cmp, threshold=threshold)
-        inner.name = metric_name
-        inner.agg = MagicMock(value=agg) if agg else None
-        wrapper = MagicMock(event_type=EventType.RUN_METRIC_THRESHOLD, threshold_filter=inner)
-        return MagicMock(event_type=EventType.RUN_METRIC_THRESHOLD, filter=MagicMock(metric=wrapper))
+    ) -> dict[str, Any]:
+        threshold_filter: dict[str, Any] = {
+            "name": metric_name,
+            "window_size": window,
+            "cmp_op": cmp,
+            "threshold": threshold,
+        }
+        if agg is not None:
+            threshold_filter["agg_op"] = agg
+        return _filter_event_payload(
+            "RUN_METRIC",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {"threshold_filter": threshold_filter},
+            },
+        )
 
     return _make
 
 
 @fixture
-def make_change_event() -> Callable[..., MagicMock]:
+def make_change_event() -> Callable[..., dict[str, Any]]:
     def _make(
         *,
         metric_name: str = "loss",
@@ -109,120 +133,150 @@ def make_change_event() -> Callable[..., MagicMock]:
         change_type: str = "RELATIVE",
         change_dir: str = "DECREASE",
         threshold: float = 0.1,
-    ) -> MagicMock:
-        inner = MagicMock(
-            window=window,
-            prior_window=prior_window,
-            change_type=MagicMock(value=change_type),
-            change_dir=MagicMock(value=change_dir),
-            threshold=threshold,
+    ) -> dict[str, Any]:
+        change_filter: dict[str, Any] = {
+            "name": metric_name,
+            "current_window_size": window,
+            "prior_window_size": prior_window,
+            "change_type": change_type,
+            "change_dir": change_dir,
+            "change_amount": threshold,
+        }
+        if agg is not None:
+            change_filter["agg_op"] = agg
+        return _filter_event_payload(
+            "RUN_METRIC_CHANGE",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {"change_filter": change_filter},
+            },
         )
-        inner.name = metric_name
-        inner.agg = MagicMock(value=agg) if agg else None
-        wrapper = MagicMock(event_type=EventType.RUN_METRIC_CHANGE, change_filter=inner)
-        return MagicMock(event_type=EventType.RUN_METRIC_CHANGE, filter=MagicMock(metric=wrapper))
 
     return _make
 
 
 @fixture
-def make_zscore_event() -> Callable[..., MagicMock]:
+def make_zscore_event() -> Callable[..., dict[str, Any]]:
     def _make(
         *,
         metric_name: str = "loss",
         window: int = 30,
         change_dir: str = "ANY",
         threshold: float = 3.0,
-    ) -> MagicMock:
-        inner = MagicMock(
-            window=window,
-            change_dir=MagicMock(value=change_dir),
-            threshold=threshold,
+    ) -> dict[str, Any]:
+        return _filter_event_payload(
+            "RUN_METRIC_ZSCORE",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {
+                    "zscore_filter": {
+                        "name": metric_name,
+                        "window_size": window,
+                        "change_dir": change_dir,
+                        "threshold": threshold,
+                    },
+                },
+            },
         )
-        inner.name = metric_name
-        wrapper = MagicMock(event_type=EventType.RUN_METRIC_ZSCORE, zscore_filter=inner)
-        return MagicMock(event_type=EventType.RUN_METRIC_ZSCORE, filter=MagicMock(metric=wrapper))
 
     return _make
 
 
 @fixture
-def make_run_state_event() -> Callable[..., MagicMock]:
-    def _make(*, states: tuple[str, ...] = ("finished", "failed")) -> MagicMock:
-        state = MagicMock(states=[MagicMock(value=s) for s in states])
-        return MagicMock(event_type=EventType.RUN_STATE, filter=MagicMock(state=state))
+def make_run_state_event() -> Callable[..., dict[str, Any]]:
+    def _make(*, states: tuple[str, ...] = ("FINISHED", "FAILED")) -> dict[str, Any]:
+        # wandb's StateFilter validator dedupes + sorts these on the way in,
+        # so the order tests assert on is the canonical sorted order.
+        return _filter_event_payload(
+            "RUN_STATE",
+            {
+                "run_filter": {"$and": []},
+                "run_state_filter": {"states": list(states)},
+            },
+        )
 
     return _make
 
 
 @fixture
-def make_mutation_event() -> Callable[..., MagicMock]:
+def make_mutation_event() -> Callable[..., dict[str, Any]]:
     """An event for CREATE_ARTIFACT / ADD_ARTIFACT_ALIAS / LINK_ARTIFACT.
 
     Mutation-event filters are open-ended MongoLikeFilter objects; the
     production code falls back to ``repr()`` for these, so we only need
-    a sentinel filter object whose ``repr`` is recognizable.
+    a sentinel filter payload.
     """
 
-    def _make(*, event_type: EventType = EventType.CREATE_ARTIFACT) -> MagicMock:
-        return MagicMock(event_type=event_type, filter=MagicMock())
+    def _make(*, event_type: EventType = EventType.CREATE_ARTIFACT) -> dict[str, Any]:
+        return _filter_event_payload(event_type.value, {"filter": {}})
 
     return _make
 
 
+# ---------------------------------------------------------------------------
+# Action payload factories.
+# ---------------------------------------------------------------------------
+
+
 @fixture
-def make_notification_action() -> Callable[..., MagicMock]:
+def make_notification_action() -> Callable[..., dict[str, Any]]:
     def _make(
         *,
         integration_id: str = "int_slack_1",
         title: str = "t",
         message: str = "m",
         severity: str | None = "INFO",
-    ) -> MagicMock:
-        a = MagicMock(
-            action_type=ActionType.NOTIFICATION,
-            integration=MagicMock(id=integration_id),
-            title=title,
-            message=message,
-            severity=MagicMock(value=severity) if severity else None,
-        )
-        return a
+    ) -> dict[str, Any]:
+        return {
+            "__typename": "NotificationTriggeredAction",
+            "integration": {"__typename": "SlackIntegration", "id": integration_id},
+            "title": title,
+            "message": message,
+            "severity": severity,
+        }
 
     return _make
 
 
 @fixture
-def make_webhook_action() -> Callable[..., MagicMock]:
+def make_webhook_action() -> Callable[..., dict[str, Any]]:
     def _make(
         *,
         integration_id: str = "int_webhook_1",
-        request_payload: dict | None = None,
-    ) -> MagicMock:
-        return MagicMock(
-            action_type=ActionType.GENERIC_WEBHOOK,
-            integration=MagicMock(id=integration_id),
-            request_payload=request_payload,
-        )
+        request_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "__typename": "GenericWebhookTriggeredAction",
+            "integration": {"__typename": "GenericWebhookIntegration", "id": integration_id},
+            # wire format is JSON-encoded; wandb parses it back to a dict in-memory
+            # but model_dump round-trips it to a string. Tests assert the string form.
+            "requestPayload": json.dumps(request_payload) if request_payload is not None else None,
+        }
 
     return _make
 
 
 @fixture
-def make_no_op_action() -> Callable[..., MagicMock]:
-    def _make() -> MagicMock:
-        return MagicMock(action_type=ActionType.NO_OP)
+def make_no_op_action() -> Callable[..., dict[str, Any]]:
+    def _make() -> dict[str, Any]:
+        return {"__typename": "NoOpTriggeredAction", "noOp": True}
 
     return _make
 
 
-@fixture
-def make_automation(make_project_scope, make_threshold_event, make_notification_action) -> Callable[..., MagicMock]:
-    """Build a MagicMock with the same surface as ``wandb.automations.Automation``.
+# ---------------------------------------------------------------------------
+# Top-level Automation factory.
+# ---------------------------------------------------------------------------
 
-    Using ``spec=Automation`` would make ``isinstance(m, Automation)`` true,
-    but the production code doesn't isinstance-check Automations -- it
-    only attribute-accesses them -- so a plain MagicMock keeps fixture
-    setup simpler. Override any field via kwargs.
+
+@fixture
+def make_automation(make_project_scope, make_threshold_event, make_notification_action) -> Callable[..., Automation]:
+    """Build a real ``wandb.automations.Automation`` via ``model_validate``.
+
+    Override any of ``scope`` / ``event`` / ``action`` with a payload dict
+    from the matching factory (e.g. ``make_threshold_event(...)``). Defaults
+    produce a Project-scoped RUN_METRIC threshold automation with a Slack
+    notification action.
     """
 
     def _make(
@@ -231,65 +285,70 @@ def make_automation(make_project_scope, make_threshold_event, make_notification_
         name: str = "my-automation",
         enabled: bool = True,
         description: str | None = "desc",
-        created_at: datetime = datetime(2026, 1, 1, 12, 0, 0),
-        updated_at: datetime | None = datetime(2026, 5, 1, 12, 0, 0),
-        scope: MagicMock | None = None,
-        event: MagicMock | None = None,
-        action: MagicMock | None = None,
-    ) -> MagicMock:
-        m = MagicMock(
-            id=id,
-            enabled=enabled,
-            description=description,
-            created_at=created_at,
-            updated_at=updated_at,
-            scope=scope or make_project_scope(),
-            event=event or make_threshold_event(),
-            action=action or make_notification_action(),
-        )
-        m.name = name  # see note above: ``name`` is reserved in MagicMock()
-        return m
+        created_at: str = "2026-01-01T12:00:00",
+        updated_at: str | None = "2026-05-01T12:00:00",
+        scope: dict[str, Any] | None = None,
+        event: dict[str, Any] | None = None,
+        action: dict[str, Any] | None = None,
+    ) -> Automation:
+        payload = {
+            "__typename": "Trigger",
+            "id": id,
+            "name": name,
+            "enabled": enabled,
+            "description": description,
+            "createdAt": created_at,
+            "updatedAt": updated_at,
+            "scope": scope if scope is not None else make_project_scope(),
+            "event": event if event is not None else make_threshold_event(),
+            "action": action if action is not None else make_notification_action(),
+        }
+        return Automation.model_validate(payload)
 
     return _make
 
 
+# ---------------------------------------------------------------------------
+# Integration factories.
+# ---------------------------------------------------------------------------
+
+
 @fixture
-def make_slack_integration() -> Callable[..., MagicMock]:
-    """Build a MagicMock that passes ``isinstance(m, SlackIntegration)``.
-
-    Using ``spec=SlackIntegration`` is the canonical way to get a mock
-    that the production code's ``match SlackIntegration():`` pattern
-    will recognize.
-    """
-
+def make_slack_integration() -> Callable[..., SlackIntegration]:
     def _make(
         *,
         id: str = "int_slack_1",
         team_name: str = "acme",
         channel_name: str = "alerts",
-    ) -> MagicMock:
-        m = MagicMock(spec=SlackIntegration)
-        m.id = id
-        m.team_name = team_name
-        m.channel_name = channel_name
-        return m
+    ) -> SlackIntegration:
+        return SlackIntegration.model_validate(
+            {
+                "__typename": "SlackIntegration",
+                "id": id,
+                "teamName": team_name,
+                "channelName": channel_name,
+            }
+        )
 
     return _make
 
 
 @fixture
-def make_webhook_integration() -> Callable[..., MagicMock]:
+def make_webhook_integration() -> Callable[..., WebhookIntegration]:
     def _make(
         *,
         id: str = "int_webhook_1",
         name: str = "prod-webhook",
         url_endpoint: str = "https://example.com/hook",
-    ) -> MagicMock:
-        m = MagicMock(spec=WebhookIntegration)
-        m.id = id
-        m.name = name  # safe here -- assigned via attribute, not kwarg
-        m.url_endpoint = url_endpoint
-        return m
+    ) -> WebhookIntegration:
+        return WebhookIntegration.model_validate(
+            {
+                "__typename": "GenericWebhookIntegration",
+                "id": id,
+                "name": name,
+                "urlEndpoint": url_endpoint,
+            }
+        )
 
     return _make
 
@@ -311,8 +370,8 @@ class TestListAutomations:
         assert result["entity"] is None
         assert result["truncated"] is False
         kwargs = mock_api.automations.call_args.kwargs
-        assert "entity" not in kwargs
-        assert "name" not in kwargs
+        assert kwargs.get("entity") is None
+        assert kwargs.get("name") is None
 
     def test_entity_and_name_passed_through(self, mock_api, make_automation):
         mock_api.automations.return_value = iter([make_automation(name="exact-match")])
@@ -395,7 +454,7 @@ class TestListAutomations:
             "type": "RUN_METRIC",
             "filter": {
                 "kind": "threshold",
-                "metric": "accuracy",
+                "name": "accuracy",
                 "agg": "MAX",
                 "window": 5,
                 "cmp": "$gt",
@@ -427,9 +486,9 @@ class TestListAutomations:
             "type": "RUN_METRIC_CHANGE",
             "filter": {
                 "kind": "change",
-                "metric": "loss",
+                "name": "loss",
                 "agg": "AVERAGE",
-                "current_window": 3,
+                "window": 3,
                 "prior_window": 3,
                 "change_type": "RELATIVE",
                 "change_dir": "DECREASE",
@@ -449,7 +508,7 @@ class TestListAutomations:
             "type": "RUN_METRIC_ZSCORE",
             "filter": {
                 "kind": "zscore",
-                "metric": "loss",
+                "name": "loss",
                 "window": 30,
                 "change_dir": "ANY",
                 "threshold": 3.0,
@@ -458,14 +517,15 @@ class TestListAutomations:
 
     def test_run_state_event_serialized(self, mock_api, make_automation, make_run_state_event):
         mock_api.automations.return_value = iter(
-            [make_automation(event=make_run_state_event(states=("finished", "failed")))]
+            [make_automation(event=make_run_state_event(states=("FINISHED", "FAILED")))]
         )
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         event = json.loads(list_automations())["automations"][0]["event"]
         assert event["type"] == "RUN_STATE"
-        assert event["filter"] == {"states": ["finished", "failed"]}
+        # StateFilter dedupes + sorts; ``FAILED`` sorts before ``FINISHED``.
+        assert event["filter"] == {"states": ["FAILED", "FINISHED"]}
 
     @mark.parametrize(
         "event_type",
@@ -509,10 +569,12 @@ class TestListAutomations:
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         action = json.loads(list_automations())["automations"][0]["action"]
+        # wandb's ``request_payload`` round-trips through model_dump as the
+        # JSON-encoded wire form, not the in-memory dict.
         assert action == {
             "type": "GENERIC_WEBHOOK",
             "integration_id": "int_w",
-            "request_payload": {"k": "v"},
+            "request_payload": '{"k":"v"}',
         }
 
     def test_no_op_action_serialized(self, mock_api, make_automation, make_no_op_action):
@@ -651,12 +713,18 @@ class TestListIntegrations:
 
     def test_unknown_typename_falls_back(self, mock_api):
         """Forward-compat: an Integration kind that's neither Slack nor Webhook
-        should still serialize (this is the wildcard match arm)."""
+        should still serialize through the wildcard match arm.
+
+        This is the one case where a real wandb instance won't do -- the
+        whole point is "we don't know about this type yet" -- so we drop
+        down to a MagicMock for this test specifically. The production
+        wildcard arm calls ``.model_dump(include={"id"}, ...)``, so we wire
+        that up to return the expected dict.
+        """
         other = MagicMock()
         other.id = "d1"
         other.typename__ = "DiscordIntegration"
-        # IMPORTANT: do NOT spec=SlackIntegration/WebhookIntegration so the
-        # match-case wildcard fires.
+        other.model_dump.return_value = {"id": "d1"}
         mock_api.integrations.return_value = iter([other])
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
@@ -679,14 +747,3 @@ def test_tool_descriptions_present(const_name):
     assert isinstance(val, str)
     assert "<when_to_use>" in val
     assert "<critical_info>" in val
-
-
-# ---------------------------------------------------------------------------
-# Sanity check: ``Automation`` import works so spec= would work in future tests
-# ---------------------------------------------------------------------------
-
-
-def test_wandb_automation_class_importable():
-    """If wandb ever moves/renames Automation, this test will fail loudly
-    so the mock fixtures above can be updated in lockstep."""
-    assert isinstance(Automation, type)

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,13 +1,13 @@
 """Unit tests for the list_automations and list_integrations tools.
 
-These tests use *real* wandb pydantic instances (via ``Automation.model_validate``
+These tests use real wandb pydantic instances (via ``Automation.model_validate``
 and ``SlackIntegration.model_validate`` / ``WebhookIntegration.model_validate``)
-rather than mocks, so they exercise the production serializer (``_jsonify_*``)
-against the actual model contracts the wandb SDK guarantees -- if wandb
-renames a field or changes a discriminator, these tests catch it. The only
-``MagicMock`` left in the file is the one ``test_unknown_typename_falls_back``
-needs to simulate a future integration kind that isn't ``SlackIntegration``
-or ``WebhookIntegration`` -- there's no way to do that with a real type.
+rather than mocks. The production serializer (``_jsonify_*``) runs against the
+actual model contracts the wandb SDK guarantees, so if wandb renames a field
+or changes a discriminator, these tests catch it. The one ``MagicMock`` left
+in the file is in ``test_unknown_typename_falls_back``. It simulates an
+integration kind that is not ``SlackIntegration`` or ``WebhookIntegration``,
+which no real type satisfies by construction.
 """
 
 from __future__ import annotations
@@ -37,9 +37,9 @@ PATCH_TARGET = "wandb_mcp_server.mcp_tools.automations.WandBApiManager"
 
 @fixture
 def mock_api(mocker) -> MagicMock:
-    """Patch ``WandBApiManager`` and yield the mocked ``api`` instance.
+    """Patch ``WandBApiManager`` and return the mocked ``api`` instance.
 
-    Production calls ``WandBApiManager.get_api()``; we replace the manager
+    Production calls ``WandBApiManager.get_api()``. We replace the manager
     with a MagicMock and return the api so tests can configure
     ``api.automations.return_value`` etc.
     """
@@ -50,8 +50,8 @@ def mock_api(mocker) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
-# Scope payload factories (GraphQL-shaped dicts; assembled by make_automation
-# and validated through Automation.model_validate).
+# Scope payload factories. These return GraphQL-shaped dicts that
+# make_automation assembles and validates through Automation.model_validate.
 # ---------------------------------------------------------------------------
 
 
@@ -71,7 +71,7 @@ def make_collection_scope() -> Callable[..., dict[str, Any]]:
         name: str = "my-models",
         kind: str = "ArtifactSequence",
     ) -> dict[str, Any]:
-        # wandb has two artifact-collection variants -- ArtifactSequence
+        # wandb has two artifact-collection variants: ArtifactSequence
         # (versioned artifact) and ArtifactPortfolio (registry collection).
         # Both serialize to ARTIFACT_COLLECTION scope_type so either works.
         return {"__typename": kind, "id": id, "name": name}
@@ -202,7 +202,7 @@ def make_run_state_event() -> Callable[..., dict[str, Any]]:
 def make_mutation_event() -> Callable[..., dict[str, Any]]:
     """An event for CREATE_ARTIFACT / ADD_ARTIFACT_ALIAS / LINK_ARTIFACT.
 
-    Mutation-event filters are open-ended MongoLikeFilter objects; the
+    Mutation-event filters are open-ended MongoLikeFilter objects. The
     production code falls back to ``repr()`` for these, so we only need
     a sentinel filter payload.
     """
@@ -248,8 +248,9 @@ def make_webhook_action() -> Callable[..., dict[str, Any]]:
         return {
             "__typename": "GenericWebhookTriggeredAction",
             "integration": {"__typename": "GenericWebhookIntegration", "id": integration_id},
-            # wire format is JSON-encoded; wandb parses it back to a dict in-memory
-            # but model_dump round-trips it to a string. Tests assert the string form.
+            # wire format is JSON-encoded. wandb parses it back to a dict
+            # in-memory but model_dump round-trips it to a string. Tests
+            # assert the string form.
             "requestPayload": json.dumps(request_payload) if request_payload is not None else None,
         }
 
@@ -524,7 +525,7 @@ class TestListAutomations:
 
         event = json.loads(list_automations())["automations"][0]["event"]
         assert event["type"] == "RUN_STATE"
-        # StateFilter dedupes + sorts; ``FAILED`` sorts before ``FINISHED``.
+        # StateFilter dedupes and sorts. ``FAILED`` sorts before ``FINISHED``.
         assert event["filter"] == {"states": ["FAILED", "FINISHED"]}
 
     @mark.parametrize(
@@ -538,7 +539,7 @@ class TestListAutomations:
 
         event = json.loads(list_automations())["automations"][0]["event"]
         assert event["type"] == event_type.value
-        # Mutation-event filter has no structured shape -- only a summary string.
+        # Mutation-event filter has no structured shape, only a summary string.
         assert set(event["filter"].keys()) == {"summary"}
 
     def test_notification_action_serialized(self, mock_api, make_automation, make_notification_action):
@@ -715,11 +716,11 @@ class TestListIntegrations:
         """Forward-compat: an Integration kind that's neither Slack nor Webhook
         should still serialize through the wildcard match arm.
 
-        This is the one case where a real wandb instance won't do -- the
-        whole point is "we don't know about this type yet" -- so we drop
+        This is the one case where a real wandb instance won't do. The
+        whole point is "we don't know about this type yet", so we drop
         down to a MagicMock for this test specifically. The production
-        wildcard arm calls ``.model_dump(include={"id"}, ...)``, so we wire
-        that up to return the expected dict.
+        wildcard arm calls ``.model_dump(include={"id"}, ...)``, so we
+        wire that up to return the expected dict.
         """
         other = MagicMock()
         other.id = "d1"

--- a/uv.lock
+++ b/uv.lock
@@ -1522,6 +1522,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2169,6 +2181,7 @@ test = [
     { name = "litellm" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "pytest-xdist" },
 ]
 
@@ -2188,6 +2201,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.26.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.14.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },


### PR DESCRIPTION
## Summary

Adds two read-only MCP tools that wrap the public `wandb.Api` Automations surface. The Automations API was introduced in wandb 0.19.11 and was fully built out by 0.23.1, well within the current `wandb>=0.25.1` pin in `pyproject.toml`.

- **`list_wandb_automations_tool`** lists Automations. These are the rules that fire Slack notifications or generic webhooks when artifacts, run states, or run metrics change. Returns `id`, `name`, `enabled`, `description`, `scope` (PROJECT or ARTIFACT_COLLECTION), `event` with a structured `filter` per event type, `action` with type-specific fields (NOTIFICATION, GENERIC_WEBHOOK, NO_OP), and timestamps.
- **`list_wandb_integrations_tool`** lists Slack and webhook integrations on an entity, with an optional `kind` filter (`"slack"`, `"webhook"`, or null). Integration ids are required inputs for any Automation action, so this is the discovery counterpart to the create flow that will land in PR #2 of this stack.

Both tools follow existing repo conventions. `WandBApiManager.get_api()` for per-request API keys, `track_tool_execution` for analytics, `max_items` capped at 200 with a `truncated` flag, and `json.dumps(...)` for the return shape. Tool descriptions use the existing `<when_to_use>` and `<critical_info>` block style.

The serializers (`_jsonify_*`) lean on the wandb pydantic models directly: `model_dump(mode="json", by_alias=False, round_trip=True)` for the scalar field bundles, `match` on the public discriminated-union classes (`SlackIntegration`, `WebhookIntegration`, `Saved*Action`, `EventType`) for the variant fan-out.

## Changes

- `src/wandb_mcp_server/mcp_tools/automations.py`. New module with both tools, their tool descriptions, and per-variant `_jsonify_*` helpers.
- `src/wandb_mcp_server/server.py`. Register `list_wandb_automations_tool` and `list_wandb_integrations_tool` alongside `query_wandb_entity_projects`. Bump the tool count in the `register_tools` docstring from 20 to 22. Lift `PositiveInt` out of `TYPE_CHECKING` since it is referenced in a runtime parameter annotation.
- `README.md`. Bump the visible tool count from 14 to 16 and add two rows to the Available Tools table.
- `tests/test_automations.py`. 31 unit tests built on real `wandb.automations.Automation`, `SlackIntegration`, and `WebhookIntegration` instances via `model_validate`. Exercises scope and event and action serialization for every variant (threshold, change, zscore, run-state, mutation events, notification, webhook, no-op), `max_items` truncation and ceiling, name filter, invalid `kind`, API error paths, and ISO timestamp serialization. One `MagicMock` holdout in `test_unknown_typename_falls_back` to exercise the wildcard arm.
- `pyproject.toml`. Add `pytest-mock>=3.14.0` to the test extras.

## Stack context

This is stage 1 of 3 in a graphite-style stack:

| Stage | Scope | Status |
|---|---|---|
| 1 | Read-only: `list_wandb_automations_tool` and `list_wandb_integrations_tool` | **this PR** |
| 2 | Create: single `create_wandb_automation_tool` with discriminated `event_type` and `event_config` | next PR |
| 3 | Update and delete with safeguards | follow-up |

Stage 3 will need to land a destructive-mutation convention alongside the tools. The repo does not have one today. The only existing mutating tools, `create_wandb_report_tool` and `log_analysis_to_wandb`, are both additive.

## Companion PR

The matching integration tests live in [wandb/wandb-mcp-server-test#83](https://github.com/wandb/wandb-mcp-server-test/pull/83). They pin `wandb-mcp-server @main`, so that PR's CI will go green only after this one merges.

## Jira

https://coreweave.atlassian.net/browse/WB-34751
