### PR TITLE
fix: support current W&B workspace SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --extra test --python ${{ matrix.python-version }}
 
+      - name: Smoke test package import
+        run: uv run --no-sync python -c "import wandb_mcp_server; print('ok')"
+
       - name: Lint with ruff
         run: |
           uv run --no-sync ruff check src/ tests/
@@ -33,6 +36,17 @@ jobs:
 
       - name: Run unit tests
         run: uv run --no-sync pytest tests/ -x -v --tb=short -q
+        env:
+          WANDB_SILENT: "True"
+          WEAVE_SILENT: "True"
+
+      - name: Build and smoke test wheel install
+        run: |
+          uv build
+          SMOKE_ENV="$RUNNER_TEMP/wandb-mcp-install-smoke"
+          uv venv "$SMOKE_ENV" --python ${{ matrix.python-version }}
+          uv pip install --python "$SMOKE_ENV/bin/python" dist/*.whl
+          "$SMOKE_ENV/bin/python" -c "import wandb_mcp_server; print('ok')"
         env:
           WANDB_SILENT: "True"
           WEAVE_SILENT: "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.3.5"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",
-    "wandb>=0.25.1",
+    "wandb[workspaces]>=0.27.1",
     "httpx>=0.28.1",
     "mcp[cli]>=1.0.0",
     "simple-parsing>=0.1.7",
     "python-dotenv>=1.0.0",
     "tiktoken>=0.9.0",
-    "wandb-workspaces>=0.3.9",
+    "wandb-workspaces>=0.4.2",
     "requests>=2.31.0",
 ]
 

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -10,9 +10,9 @@ from graphql import parse
 from graphql.language import ast as gql_ast
 from graphql.language import printer as gql_printer
 from graphql.language import visitor as gql_visitor
-from wandb_gql import gql  # This must be imported after wandb
-from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_graphql import execute_graphql
 
 logger = get_rich_logger(__name__)
 
@@ -745,14 +745,14 @@ def query_paginated_wandb_gql(
                     return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
 
             try:
-                parsed_initial_query = gql(query.strip())
+                parse(query.strip())
             except Exception as e:
-                logger.error(f"Failed to parse initial query with wandb_gql: {e}")
+                logger.error(f"Failed to parse initial query with graphql-core: {e}")
                 ctx.mark_error(f"invalid_input: {e}")
                 return {"errors": [{"message": f"Failed to parse initial query: {e}"}]}
 
             try:
-                result1 = api.client.execute(parsed_initial_query, variable_values=page1_vars_func)
+                result1 = execute_graphql(api, query.strip(), page1_vars_func)
                 result_dict = copy.deepcopy(result1)
                 if "errors" in result_dict:
                     logger.error(f"GraphQL errors in initial response: {result_dict['errors']}")
@@ -859,9 +859,8 @@ def query_paginated_wandb_gql(
                 page_vars[after_variable_name] = current_cursor
 
                 try:
-                    parsed_generated = gql(generated_paginated_query_string)
                     logging.info(f"Executing generated query for page {page_num} with vars: {page_vars}")
-                    result_page = api.client.execute(parsed_generated, variable_values=page_vars)
+                    result_page = execute_graphql(api, generated_paginated_query_string, page_vars)
 
                     if "errors" in result_page:
                         logger.error(

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -1,0 +1,21 @@
+"""GraphQL helpers compatible across W&B SDK GraphQL transports."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Mapping
+
+
+def execute_graphql(
+    api: Any,
+    query: str,
+    variables: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a GraphQL document with the current or legacy W&B SDK transport."""
+    variables_dict = dict(variables or {})
+    service_api = getattr(api, "__dict__", {}).get("_service_api")
+    if service_api is not None and hasattr(service_api, "execute_graphql"):
+        return service_api.execute_graphql(query, variables=variables_dict)
+
+    gql = importlib.import_module("wandb_gql").gql
+    return api.client.execute(gql(query), variable_values=variables_dict)

--- a/tests/test_create_report_panels.py
+++ b/tests/test_create_report_panels.py
@@ -515,6 +515,9 @@ class TestRealWorkspacesReportObjects:
         fake_api = MagicMock()
         fake_api.client.app_url = "https://wandb.ai"
         fake_api.client.execute.return_value = {"project": {"internalId": "project-internal-id"}}
+        fake_api._service_api = MagicMock()
+        fake_api._service_api.app_url = "https://wandb.ai"
+        fake_api._service_api.execute_graphql.return_value = {"project": {"internalId": "project-internal-id"}}
         captured_reports = []
 
         def fake_save(report, *args, **kwargs):
@@ -565,11 +568,26 @@ class TestRealWorkspacesReportObjects:
         panel_grid = panel_grids[0]
         runset = panel_grid.metadata.run_sets[0]
         assert runset.search.query == ""
-        filters = runset.filters.filters[0].filters
-        assert len(filters) == 1
-        assert filters[0].key.name == "name"
-        assert filters[0].op == "IN"
-        assert filters[0].value == ["run_a", "run_b"]
+        if isinstance(runset.filters, dict):
+
+            def iter_filter_nodes(node):
+                if isinstance(node, dict):
+                    yield node
+                    for child in node.get("filters", []):
+                        yield from iter_filter_nodes(child)
+
+            assert any(
+                node.get("key") == {"section": "run", "name": "name"}
+                and node.get("op") == "IN"
+                and node.get("value") == ["run_a", "run_b"]
+                for node in iter_filter_nodes(runset.filters)
+            )
+        else:
+            filters = runset.filters.filters[0].filters
+            assert len(filters) == 1
+            assert filters[0].key.name == "name"
+            assert filters[0].op == "IN"
+            assert filters[0].value == ["run_a", "run_b"]
 
         panels = panel_grid.metadata.panel_bank_section_config.panels
         assert len(panels) == 2

--- a/tests/test_hosted_gql_guardrails.py
+++ b/tests/test_hosted_gql_guardrails.py
@@ -6,6 +6,7 @@ from graphql.language.printer import print_ast
 
 import wandb_mcp_server.api_client as api_client
 import wandb_mcp_server.config as cfg
+import wandb_mcp_server.wandb_graphql as graphql_transport
 from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
 
 
@@ -40,9 +41,50 @@ class FakeApi:
         self.viewer = SimpleNamespace(username="tester")
 
 
+class FakeServiceApi:
+    def __init__(self, response=None):
+        self.response = response or {
+            "project": {
+                "runs": {
+                    "edges": [],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+        self.executions = []
+
+    def execute_graphql(self, query, variables=None):
+        self.executions.append((query, dict(variables or {})))
+        return self.response
+
+
+class FakeServiceBackedApi:
+    def __init__(self, service_api):
+        self._service_api = service_api
+        self.viewer = SimpleNamespace(username="tester")
+
+
 def _install_fake_api(monkeypatch, client):
     monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
-    monkeypatch.setattr(gql_tool, "gql", parse)
+    monkeypatch.setattr(
+        graphql_transport.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(gql=parse),
+    )
+
+    @contextmanager
+    def fake_track_tool_execution(*args, **kwargs):
+        yield DummyToolContext()
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_track_tool_execution)
+
+
+def _install_fake_service_api(monkeypatch, service_api):
+    monkeypatch.setattr(
+        api_client,
+        "get_wandb_api",
+        lambda: FakeServiceBackedApi(service_api),
+    )
 
     @contextmanager
     def fake_track_tool_execution(*args, **kwargs):
@@ -81,6 +123,24 @@ def test_hosted_literal_first_is_rewritten_before_execute(monkeypatch):
     assert "first: 50" in executed_query
     assert "100000" not in executed_query
     assert variables["limit"] == 50
+    assert "errors" not in result
+
+
+def test_query_executes_with_service_api_without_client(monkeypatch):
+    monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", False)
+    service_api = FakeServiceApi()
+    _install_fake_service_api(monkeypatch, service_api)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        _run_query(),
+        variables={"entity": "e", "project": "p"},
+        max_items=100,
+        items_per_page=100,
+    )
+
+    executed_query, variables = service_api.executions[0]
+    assert "first: 100000" in executed_query
+    assert variables["limit"] == 100
     assert "errors" not in result
 
 

--- a/tests/test_hosted_gql_production_errors.py
+++ b/tests/test_hosted_gql_production_errors.py
@@ -6,6 +6,7 @@ from graphql.language.printer import print_ast
 
 import wandb_mcp_server.api_client as api_client
 import wandb_mcp_server.config as cfg
+import wandb_mcp_server.wandb_graphql as graphql_transport
 from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
 
 
@@ -42,7 +43,11 @@ class FakeApi:
 
 def _install_fake_api(monkeypatch, client):
     monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
-    monkeypatch.setattr(gql_tool, "gql", parse)
+    monkeypatch.setattr(
+        graphql_transport.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(gql=parse),
+    )
 
     @contextmanager
     def fake_track_tool_execution(*args, **kwargs):

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,73 @@
+"""Smoke tests for import paths that must work after a fresh install."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+_IMPORT_SCRIPT = textwrap.dedent(
+    """
+    import importlib
+    import sys
+
+    target = sys.argv[1]
+    for name in list(sys.modules):
+        if name == "wandb_gql" or name.startswith("wandb_gql."):
+            del sys.modules[name]
+        if name == "wandb_graphql" or name.startswith("wandb_graphql."):
+            del sys.modules[name]
+
+    sys.path = [
+        path for path in sys.path
+        if "/wandb/vendor" not in path
+        and "gql-0.2.0" not in path
+        and "graphql-core-1.1" not in path
+    ]
+
+    importlib.import_module(target)
+
+    leaked_paths = [
+        path for path in sys.path
+        if "/wandb/vendor" in path
+        or "gql-0.2.0" in path
+        or "graphql-core-1.1" in path
+    ]
+    if leaked_paths:
+        message = "W&B vendor paths leaked into sys.path: "
+        raise AssertionError(message + repr(leaked_paths))
+
+    print("ok")
+    """
+)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "wandb_mcp_server.mcp_tools.create_report",
+        "wandb_mcp_server.mcp_tools.query_wandb_gql",
+        "wandb_mcp_server",
+    ],
+)
+def test_fresh_install_imports_without_preloaded_vendor_path(
+    module_name: str,
+) -> None:
+    env = os.environ.copy()
+    env["WANDB_SILENT"] = "True"
+    env["WEAVE_SILENT"] = "True"
+
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_SCRIPT, module_name],
+        check=False,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/test_wandb_graphql.py
+++ b/tests/test_wandb_graphql.py
@@ -1,0 +1,62 @@
+"""Tests for W&B SDK GraphQL transport compatibility."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+import types
+
+from wandb_mcp_server.wandb_graphql import execute_graphql
+
+
+def test_query_tool_has_no_top_level_wandb_gql_import():
+    module_path = Path(__file__).parents[1] / "src" / "wandb_mcp_server" / "mcp_tools" / "query_wandb_gql.py"
+    tree = ast.parse(module_path.read_text())
+
+    assert not any(isinstance(node, ast.ImportFrom) and node.module == "wandb_gql" for node in tree.body)
+
+
+def test_execute_graphql_prefers_service_api_without_client():
+    class ServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            self.calls.append((query, variables))
+            return {"ok": True}
+
+    class Api:
+        def __init__(self):
+            self._service_api = ServiceApi()
+            self.viewer = object()
+
+    api = Api()
+    result = execute_graphql(api, "query Test { viewer { id } }", {"x": 1})
+
+    assert result == {"ok": True}
+    assert api._service_api.calls == [("query Test { viewer { id } }", {"x": 1})]
+
+
+def test_execute_graphql_lazily_falls_back_to_wandb_gql(monkeypatch):
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, query, *, variable_values):
+            self.calls.append((query, variable_values))
+            return {"ok": True}
+
+    class Api:
+        def __init__(self):
+            self.client = Client()
+            self.viewer = object()
+
+    fake_wandb_gql = types.SimpleNamespace(gql=lambda query: f"parsed:{query}")
+    monkeypatch.setitem(sys.modules, "wandb_gql", fake_wandb_gql)
+
+    api = Api()
+    result = execute_graphql(api, "query Test { viewer { id } }", {"x": 1})
+
+    assert result == {"ok": True}
+    assert api.client.calls == [("parsed:query Test { viewer { id } }", {"x": 1})]

--- a/uv.lock
+++ b/uv.lock
@@ -2115,7 +2115,7 @@ wheels = [
 
 [[package]]
 name = "wandb"
-version = "0.25.1"
+version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2129,17 +2129,22 @@ dependencies = [
     { name = "sentry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/bb/eb579bf9abac70934a014a9d4e45346aab307994f3021d201bebe5fa25ec/wandb-0.25.1.tar.gz", hash = "sha256:b2a95cd777ecbe7499599a43158834983448a0048329bc7210ef46ca18d21994", size = 43983308, upload-time = "2026-03-10T23:51:44.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/35a6e297ca22e0e2cbe77cbd21d33462874b8f508b41f0fae2f4c292ffea/wandb-0.27.1.tar.gz", hash = "sha256:214b3430c1e76e5eb55192c1bb4184a084f969e0c75cb15a709324c069efe10e", size = 40298729, upload-time = "2026-06-04T04:28:23.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/d8/873553b6818499d1b1de314067d528b892897baf0dc81fedc0e845abc2dd/wandb-0.25.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:9bb0679a3e2dcd96db9d9b6d3e17d046241d8d122974b24facb85cc93309a8c9", size = 23615900, upload-time = "2026-03-10T23:51:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ea/b131f319aaa5d0bf7572b6bfcff3dd89e1cf92b17eee443bbab71d12d74c/wandb-0.25.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:0fb13ed18914027523e7b4fc20380c520e0d10da0ee452f924a13f84509fbe12", size = 25576144, upload-time = "2026-03-10T23:51:11.527Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5f/81508581f0bb77b0495665c1c78e77606a48e66e855ca71ba7c8ae29efa4/wandb-0.25.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:cc4521eb5223429ddab5e8eee9b42fdf4caabdf0bc4e0e809042720e5fbef0ed", size = 23070425, upload-time = "2026-03-10T23:51:15.71Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c7/445155ef010e2e35d190797d7c36ff441e062a5b566a6da4778e22233395/wandb-0.25.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:e73b4c55b947edae349232d5845204d30fac88e18eb4ad1d4b96bf7cf898405a", size = 25628142, upload-time = "2026-03-10T23:51:19.326Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/63/f5c55ee00cf481ef1ccd3c385a0585ad52e7840d08419d4f82ddbeeea959/wandb-0.25.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:22b84065aa398e1624d2e5ad79e08bc4d2af41a6db61697b03b3aaba332977c6", size = 23123172, upload-time = "2026-03-10T23:51:23.418Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d9/19eb7974c0e9253bcbaee655222c0f0e1a52e63e9479ee711b4208f8ac31/wandb-0.25.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:005c4c6b5126ef8f4b4110e5372d950918b00637d6dc4b615ad17445f9739478", size = 25714479, upload-time = "2026-03-10T23:51:27.421Z" },
-    { url = "https://files.pythonhosted.org/packages/11/19/466c1d03323a4a0ed7d4036a59b18d6b6f67cb5032e444205927e226b18d/wandb-0.25.1-py3-none-win32.whl", hash = "sha256:8f2d04f16b88d65bfba9d79fb945f6c64e2686215469a841936e0972be8ec6a5", size = 24967338, upload-time = "2026-03-10T23:51:31.833Z" },
-    { url = "https://files.pythonhosted.org/packages/89/22/680d34c1587f3a979c701b66d71aa7c42b4ef2fdf0774f67034e618e834e/wandb-0.25.1-py3-none-win_amd64.whl", hash = "sha256:62db5166de14456156d7a85953a58733a631228e6d4248a753605f75f75fb845", size = 24967343, upload-time = "2026-03-10T23:51:36.026Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/e8/76836b75d401ff5912aaf513176e64557ceaec4c4946bfd38a698ff84d48/wandb-0.25.1-py3-none-win_arm64.whl", hash = "sha256:cc7c34b70cf4b7be4d395541e82e325fd9d2be978d62c9ec01f1a7141523b6bb", size = 22080774, upload-time = "2026-03-10T23:51:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e2/3fa03632b11cbaa8b078a2c50fd985b6009a3ffcc566c3898d430c987cd1/wandb-0.27.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:abd80f9f74a4c28890c2a38d356fb0bceadfce497311ff13431ff387f4f23698", size = 23985424, upload-time = "2026-06-04T04:28:01.685Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4a/4dfa139ccce0f686eef44e3b8a3efc535333e4275e8fddcb68ff03b4f60d/wandb-0.27.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:2fb189f186f2a41df9c559918a3308da22069dca5bc6f021bfface197a9aa1ff", size = 25164981, upload-time = "2026-06-04T04:28:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/872bd057b83a6c5da5c4e8c482c41df9338898a3c34d26172eb306388b8c/wandb-0.27.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1c62f0daae156b1f56b2ac78e3dab25a19c8e4ef73b83547c0c877c77d433e9a", size = 24551609, upload-time = "2026-06-04T04:28:06.786Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cd/0cd5ef8723581cef8d6ecb9de29623a3da89c969b04f32809c1f22985ba2/wandb-0.27.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:77ccc56582d07671a867b78ced686096ca53c021d79fed38e5aaf4cebbd0450b", size = 26378746, upload-time = "2026-06-04T04:28:09.015Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/9fbaac13e1ffcecb3265dd08b8a76a15c21361ccbc0c65ab745847268240/wandb-0.27.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:af91e99c0dc02de03997169d218698e1175fca1cd06d5af5ef68a855c0cf6968", size = 24724687, upload-time = "2026-06-04T04:28:11.651Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2b/f9c5bffd1f858c2c0a6dd41a8b5dea3d9337d4282dd247e603e1bea98d80/wandb-0.27.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a79f899de9861543bf20f273cdfe513c85d6841e88568aa1de05ce4a0a5a547b", size = 26690886, upload-time = "2026-06-04T04:28:14.364Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/14/91283eb2a17063091858f9f2b822437b16d75e53d742e295db1b479dcca4/wandb-0.27.1-py3-none-win32.whl", hash = "sha256:38dd902b56188789d3b17c03f8f77fef97a0b1c5aecee94c5bd70836e667b2cf", size = 24149484, upload-time = "2026-06-04T04:28:16.712Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a9/7d25ba1386fe6b4dea65342aba7c82a9ac3294cb591b449622b31d75e0c5/wandb-0.27.1-py3-none-win_amd64.whl", hash = "sha256:2d7e4bb60a28756a0a6c78884dbad60bcd07e7cf840cdd8e3a3873bdf2af62af", size = 24149492, upload-time = "2026-06-04T04:28:18.85Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/ed3e3410d0a86b9542c4cd3839f47bd72493063240759e7120f38637a9c0/wandb-0.27.1-py3-none-win_arm64.whl", hash = "sha256:356eda1fbce41101286935f5291e7db5ddfd062b23ddbbdd1d45ed03763ba2c4", size = 22059130, upload-time = "2026-06-04T04:28:20.985Z" },
+]
+
+[package.optional-dependencies]
+workspaces = [
+    { name = "wandb-workspaces" },
 ]
 
 [[package]]
@@ -2153,7 +2158,7 @@ dependencies = [
     { name = "requests" },
     { name = "simple-parsing" },
     { name = "tiktoken" },
-    { name = "wandb" },
+    { name = "wandb", extra = ["workspaces"] },
     { name = "wandb-workspaces" },
     { name = "weave" },
 ]
@@ -2194,8 +2199,8 @@ requires-dist = [
     { name = "simple-parsing", specifier = ">=0.1.7" },
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
-    { name = "wandb", specifier = ">=0.25.1" },
-    { name = "wandb-workspaces", specifier = ">=0.3.9" },
+    { name = "wandb", extras = ["workspaces"], specifier = ">=0.27.1" },
+    { name = "wandb-workspaces", specifier = ">=0.4.2" },
     { name = "weave", specifier = ">=0.52.35" },
 ]
 provides-extras = ["test", "http"]
@@ -2208,15 +2213,15 @@ dev = [
 
 [[package]]
 name = "wandb-workspaces"
-version = "0.3.9"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/d3/3a5ebc8b969ec8d2391bb43e4a3d76ceaee2bfc11c9e9dc96b61577a9092/wandb_workspaces-0.3.9.tar.gz", hash = "sha256:d186faa7b0c4e6c33aecfea833e81ca0256d117b26f7e428f002c14cbf30601c", size = 210169, upload-time = "2026-03-31T15:23:20.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c2/4f4b202d09917fff2271cb6464150932fe2474e27f949bd69704a8470a01/wandb_workspaces-0.4.2.tar.gz", hash = "sha256:bade2052aef40a286f833c962b7016c608bab62f61c9397f07ae3963da5997ff", size = 231126, upload-time = "2026-06-05T18:50:53.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/46/112522e555b1fef7129e85065348d20dcb8761171b07614b5d3e95f86759/wandb_workspaces-0.3.9-py3-none-any.whl", hash = "sha256:79fbb9e899e5457f18446fd6a8c066a05709562ad9fe31b3d215ca4749a65f25", size = 100710, upload-time = "2026-03-31T15:23:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ef/2a75bb3403f6c300355772b601324c4c8bfd83ff3eb12ca465be5d1f8190/wandb_workspaces-0.4.2-py3-none-any.whl", hash = "sha256:60739ebba89e254fd3e469591df014161c81e52970b93760bc42d56cf24d91fb", size = 107339, upload-time = "2026-06-05T18:50:52.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Requires the fixed W&B workspace SDK stack: `wandb[workspaces]>=0.27.1` and `wandb-workspaces>=0.4.2`.
- Removes MCP's top-level dependency on private `wandb_gql` in `query_wandb_gql.py`.
- Adds `execute_graphql(...)`, which prefers the current W&B SDK `_service_api.execute_graphql` path and lazily falls back to `wandb_gql` only for legacy SDK clients.
- Adds CI built-wheel smoke checks so fresh install resolver/package regressions fail before release.

## Why
`wandb==0.27.1` removed vendored `wandb_gql`. `wandb-workspaces==0.4.2` contains the upstream compatibility fix, and this PR removes MCP's own direct `wandb_gql` usage so MCP can support the current W&B SDK stack directly.

## Links
- Jira: https://coreweave.atlassian.net/browse/WB-35227
- Build-break tracker: https://coreweave.atlassian.net/browse/WB-35219
- Workspaces fix: https://github.com/wandb/wandb-workspaces/pull/174
- SDK change: https://github.com/wandb/wandb/pull/11818

## Test plan
- `uv lock`
- `uv sync --frozen --extra test`
- `uv run pytest tests/test_wandb_graphql.py tests/test_import_smoke.py tests/test_hosted_gql_guardrails.py tests/test_hosted_gql_production_errors.py tests/test_tool_descriptions.py -v`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv build`
- Fresh wheel smoke: clean Python 3.12 venv, install `dist/*.whl`, verify resolved `wandb==0.27.1` and `wandb-workspaces==0.4.2`, then import `wandb_mcp_server`, `create_report`, and `query_wandb_gql`.