### PR TITLE
feat: add read-only Automations tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Query and analyze your Weights & Biases data using natural language through the 
 </details>
 
 <details>
-<summary><strong>Available Tools</strong> (14 tools)</summary>
+<summary><strong>Available Tools</strong> (16 tools)</summary>
 
 | Tool | Description | Example Query |
 |------|-------------|---------------|
@@ -51,6 +51,8 @@ Query and analyze your Weights & Biases data using natural language through the 
 | **list_artifact_versions_tool** | List versions of an artifact collection | *"Show versions of my model artifact"* |
 | **get_artifact_details_tool** | Get full details of an artifact version | *"What's in model-v2 artifact?"* |
 | **compare_artifact_versions_tool** | Diff two artifact versions | *"Compare model v1 vs v2"* |
+| **list_wandb_automations_tool** | List W&B Automations | *"What automations alert on run metrics or status for my team's runs?"* |
+| **list_wandb_integrations_tool** | List registered integrations for W&B automations (e.g. Slack, webhook) | *"Which Slack channels can my automations target?"* |
 
 **Schema-first workflow:** Call `infer_trace_schema_tool` first to discover fields, then `query_weave_traces_tool` with precise columns and `detail_level`:
 - `"schema"` -- structural fields only (fast browsing)
@@ -66,13 +68,13 @@ Query and analyze your Weights & Biases data using natural language through the 
 <details>
 <summary><strong>Usage Tips</strong> (best practices)</summary>
 
-**→ Provide your W&B project and entity name**  
+**→ Provide your W&B project and entity name**
 LLMs are not mind readers, ensure you specify the W&B Entity and W&B Project to the LLM.
 
-**→ Avoid asking overly broad questions**  
+**→ Avoid asking overly broad questions**
 Questions such as "what is my best evaluation?" are probably overly broad and you'll get to an answer faster by refining your question to be more specific such as: "what eval had the highest f1 score?"
 
-**→ Ensure all data was retrieved**  
+**→ Ensure all data was retrieved**
 When asking broad, general questions such as "what are my best performing runs/evaluations?" it's always a good idea to ask the LLM to check that it retrieved all the available runs. The MCP tools are designed to fetch the correct amount of data, but sometimes there can be a tendency from the LLMs to only retrieve the latest runs or the last N runs.
 
 </details>
@@ -94,7 +96,7 @@ We recommend using our **hosted server** at `https://mcp.withwandb.com` - no ins
   * Click on the button above to automatically add the config to Cursor
   * Then add your WANDB_API_KEY in the respective field `Bearer YOUR_API_KEY` and connect
 
-For manual or local installation, see [Option 2](#general-installation-guide) below. 
+For manual or local installation, see [Option 2](#general-installation-guide) below.
 </details>
 
 ### OpenAI Response API
@@ -214,7 +216,7 @@ If adding the W&B connector from the Le Chat connector directory returns an `int
 <details>
 <summary>Configuration setup</summary>
 
-Add to your Claude config file. Claude desktop currently doesn't support remote MCPs to be added so we're adding the local MCP. Be careful to add the full path to `uv` for the command because Claude Desktop potentially doesn't find your `uv` installation otherwise. 
+Add to your Claude config file. Claude desktop currently doesn't support remote MCPs to be added so we're adding the local MCP. Be careful to add the full path to `uv` for the command because Claude Desktop potentially doesn't find your `uv` installation otherwise.
 
 ```bash
 # macOS
@@ -245,7 +247,7 @@ notepad %APPDATA%\Claude\claude_desktop_config.json
 Restart Claude Desktop to activate.
 </details>
 
-We're working on adding OAuth support so that we can integrate with ChatGPT. 
+We're working on adding OAuth support so that we can integrate with ChatGPT.
 
 ---
 
@@ -313,7 +315,7 @@ Add to your MCP client config (for detailed client-specific configs see below):
 }
 ```
 
-### Cursor 
+### Cursor
 1. Open Cursor Settings (`⌘,` or `Ctrl,`)
 2. Navigate to **Features** → **Model Context Protocol**
 3. Click **"Install from Registry"** or **"Add MCP Server"**
@@ -321,8 +323,8 @@ Add to your MCP client config (for detailed client-specific configs see below):
    - **Name**: `wandb`
    - **URL**: `https://mcp.withwandb.com/mcp`
    - **API Key**: Your W&B API key
-  
-Manual hosted config in `mcp.json`: 
+
+Manual hosted config in `mcp.json`:
 ```
 "wandb": {
   "transport": "http",
@@ -365,8 +367,8 @@ Add `--scope user` for global config.
 claude mcp add wandb -e WANDB_API_KEY=your-api-key -e WANDB_BASE_URL=your-base-url -- uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server
 ```
 
-### Claude Desktop 
-Same as above. 
+### Claude Desktop
+Same as above.
 ```bash
 # macOS
 open ~/Library/Application\ Support/Claude/claude_desktop_config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ add_to_client = "wandb_mcp_server.add_to_client:add_to_client_cli"
 [project.optional-dependencies]
 test = [
     "pytest>=8.3.1",
+    "pytest-mock>=3.14.0",
     "litellm>=1.67.2,<=1.82.6",
     "anthropic>=0.50.0",
     "pytest-xdist>=3.6.1",

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -1,0 +1,338 @@
+"""List W&B Automations and the integrations they can target.
+
+Provides two read-only tools for discovering Automations and the
+Slack/webhook integrations that Automation actions reference, via the
+public ``wandb.Api`` interface introduced in wandb 0.19.11.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Collection, Iterator
+from itertools import islice
+from textwrap import dedent
+from typing import TYPE_CHECKING, Any, Final, Literal, get_args
+
+from pydantic import PositiveInt
+from wandb.automations import EventType, SlackIntegration, WebhookIntegration
+
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+
+if TYPE_CHECKING:
+    from wandb.automations import ArtifactCollectionScope, Automation, Integration, ProjectScope
+    from wandb.automations.actions import SavedAction
+    from wandb.automations.events import SavedEvent
+
+logger = get_rich_logger(__name__)
+
+MAX_ITEMS_DEFAULT: Final[int] = 50
+MAX_ITEMS_CEIL: Final[int] = 200
+
+# Public literal type so MCP clients see the allowed values for the ``kind`` parameter.
+IntegrationKind = Literal["slack", "webhook"]
+_VALID_INTEGRATION_KINDS: Final[Collection[IntegrationKind]] = frozenset(get_args(IntegrationKind))
+
+_DUMP_KWARGS: Final[dict[str, Any]] = dict(mode="json", by_alias=False, round_trip=True)
+
+
+# ---------------------------------------------------------------------------
+# Tool 1 -- list_automations
+# ---------------------------------------------------------------------------
+
+LIST_AUTOMATIONS_TOOL_DESCRIPTION = dedent(
+    """\
+    List W&B Automations the current API key can access.
+
+    Automations are user-configured rules that fire actions (Slack notification or
+    generic webhook) when events happen in W&B: a new artifact is created, an
+    alias is added, a model artifact is linked to a registry collection, a run
+    metric crosses a threshold or changes significantly, or a run changes state.
+
+    <when_to_use>
+    Call this tool when the user asks about:
+    - "What automations / alerts / triggers / webhooks do we have?"
+    - "Is there an automation that fires when X happens?"
+    - "Audit automations on my project / team"
+    - "Which automations send to Slack channel #foo?"
+
+    If the user wants to know the available Slack channels or webhook URLs that
+    existing or new automations can target, call list_wandb_integrations_tool
+    instead (or in addition).
+    </when_to_use>
+
+    <critical_info>
+    - entity=None lists every automation the authenticated viewer can see across
+    all of their teams. Pass entity="<team-or-user>" to scope to one entity.
+    - The optional name filter is an exact match (not regex or substring).
+    - Results are capped by max_items (default 50, ceiling 200). When more exist,
+    the response sets truncated=true.
+    - Each returned automation has these fields: id, name, enabled, description,
+    created_at, updated_at, scope, event, action.
+    - scope is {type, id, name} where type is PROJECT or ARTIFACT_COLLECTION.
+    - event is {type, filter} where filter shape depends on the event type.
+    - action is {type, ...} with extra fields per action type (NOTIFICATION for
+    Slack, GENERIC_WEBHOOK for webhooks, NO_OP for placeholders).
+    - The scope only includes id and name. The parent project and entity are
+    not on the scope. If you need them, use the `entity` you passed to this
+    tool and look up the project separately.
+    - This tool is read-only. It cannot create, modify, or delete automations.
+    </critical_info>
+
+    Parameters
+    ----------
+    entity : str, optional
+        W&B entity (team or user) to filter by. If omitted, returns every
+        automation the authenticated viewer has access to.
+    name : str, optional
+        Exact-match filter on the automation's name.
+    max_items : int, optional
+        Maximum automations to return. Default 50, ceiling 200.
+
+    Returns
+    -------
+    JSON with:
+    - automations: list of automation objects (see fields above)
+    - count: number of automations returned
+    - entity: the entity filter applied (or null)
+    - truncated: whether more automations exist beyond max_items
+    """
+)
+
+
+def _clamp(value: int, floor: int, ceil: int, /) -> int:
+    return max(floor, min(value, ceil))
+
+
+def _jsonify_scope(scope: ProjectScope | ArtifactCollectionScope) -> dict[str, Any]:
+    """Flatten an AutomationScope to ``{type, id, name}``.
+
+    The wandb GraphQL fragments only carry ``id`` and ``name`` on scopes
+    (see ``wandb/automations/_generated/fragments.py``: ProjectScopeFields,
+    ArtifactSequenceScopeFields, ArtifactPortfolioScopeFields). The public
+    ``scope_type`` enum (PROJECT | ARTIFACT_COLLECTION) lets agents branch
+    on it without parsing GraphQL typename strings.
+    """
+    return {"type": scope.scope_type.value, "id": scope.id, "name": scope.name}
+
+
+def _jsonify_metric_filter(metric_filter: Any) -> dict[str, Any]:
+    """Flatten the inner metric filter from a RunMetricFilter wrapper.
+
+    A ``RunMetricFilter.metric`` is one of three pydantic wrapper variants.
+    Each carries its own ``event_type`` discriminator and exposes exactly
+    one of the threshold, change, or zscore sub-filter attributes. We
+    discriminate via the upstream-defined enum value rather than poking at
+    attribute presence.
+    """
+    match metric_filter:
+        case object(event_type=EventType.RUN_METRIC_THRESHOLD, threshold_filter=threshold_filter):
+            return {"kind": "threshold"} | threshold_filter.model_dump(**_DUMP_KWARGS)
+        case object(event_type=EventType.RUN_METRIC_CHANGE, change_filter=change_filter):
+            return {"kind": "change"} | change_filter.model_dump(**_DUMP_KWARGS)
+        case object(event_type=EventType.RUN_METRIC_ZSCORE, zscore_filter=zscore_filter):
+            return {"kind": "zscore"} | zscore_filter.model_dump(**_DUMP_KWARGS)
+        case _:
+            return {"kind": "unknown"}
+
+
+def _jsonify_event(event: SavedEvent) -> dict[str, Any]:
+    """Flatten a SavedEvent to ``{type, filter}``.
+
+    The filter shape is structured for run-metric and run-state events.
+    Mutation events (CREATE_ARTIFACT etc.) carry an open-ended MongoLikeFilter
+    that we surface as a brief string ``summary`` since the SDK doesn't
+    expose a stable structured shape for it.
+    """
+    from wandb.automations.events import RunMetricFilter, RunStateFilter, SavedEvent
+
+    match event:
+        case SavedEvent(event_type=type_, filter=RunMetricFilter(metric=metric_filter)):
+            return {"type": type_.value, "filter": _jsonify_metric_filter(metric_filter)}
+        case SavedEvent(event_type=type_, filter=RunStateFilter(state=state_filter)):
+            return {"type": type_.value, "filter": state_filter.model_dump(**_DUMP_KWARGS)}
+        case _:
+            return {"type": event.event_type.value, "filter": {"summary": repr(event.filter)}}
+
+
+def _jsonify_action(action: SavedAction) -> dict[str, Any]:
+    """Flatten a SavedAction to a JSON-safe dict.
+
+    Match-cases on the public ``Saved*Action`` pydantic types
+    (SavedNotificationAction, SavedWebhookAction, SavedNoOpAction). Each
+    arm emits only the fields its variant guarantees, so we never reach
+    for an attribute the variant does not define.
+    """
+    from wandb.automations.actions import SavedNoOpAction, SavedNotificationAction, SavedWebhookAction
+
+    match action:
+        case SavedNotificationAction(action_type=type_, integration=integration):
+            jsonable = action.model_dump(include={"title", "message", "severity"}, **_DUMP_KWARGS)
+            return {"type": type_.value, "integration_id": integration.id} | jsonable
+        case SavedWebhookAction(action_type=type_, integration=integration):
+            jsonable = action.model_dump(include={"request_payload"}, **_DUMP_KWARGS)
+            return {"type": type_.value, "integration_id": integration.id} | jsonable
+        case SavedNoOpAction(action_type=type_):
+            return {"type": type_.value}
+        case _:
+            # QUEUE_JOB / PUSH_NOTIFICATION are currently excluded from the public create API, but they may appear on saved automations. Only expose the type.
+            return {"type": action.action_type.value}
+
+
+def _jsonify_automation(automation: Automation) -> dict[str, Any]:
+    """Flatten an Automation pydantic object to a JSON-safe dict."""
+    jsonable = automation.model_dump(exclude={"scope", "event", "action"}, **_DUMP_KWARGS)
+    jsonable_scope = _jsonify_scope(automation.scope)
+    jsonable_event = _jsonify_event(automation.event)
+    jsonable_action = _jsonify_action(automation.action)
+    return jsonable | {"scope": jsonable_scope, "event": jsonable_event, "action": jsonable_action}
+
+
+def list_automations(
+    entity: str | None = None,
+    name: str | None = None,
+    max_items: PositiveInt = MAX_ITEMS_DEFAULT,
+) -> str:
+    """List W&B Automations accessible with the current API key."""
+    params = locals()  # Must be first so it only picks up the function args
+
+    api = WandBApiManager.get_api()
+    with track_tool_execution("list_automations", api.viewer, params) as ctx:
+        max_items = _clamp(max_items, 1, MAX_ITEMS_CEIL)
+
+        try:
+            iterator = api.automations(entity=entity, name=name, per_page=_clamp(max_items, 1, 100))
+            automations = list(map(_jsonify_automation, islice(iterator, max_items)))
+            truncated = next(iterator, None) is not None
+
+            result = {
+                "automations": automations,
+                "count": len(automations),
+                "entity": entity,
+                "truncated": truncated,
+            }
+            return json.dumps(result)
+
+        except Exception as e:
+            logger.error(f"Error in list_automations: {e}", exc_info=True)
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+# ---------------------------------------------------------------------------
+# Tool 2 -- list_integrations
+# ---------------------------------------------------------------------------
+
+LIST_INTEGRATIONS_TOOL_DESCRIPTION = dedent("""\
+    List W&B integrations (Slack channels and webhooks) for an entity.
+
+    Integrations are the destinations that W&B Automations send notifications to.
+    A SlackIntegration represents a connected Slack channel. A WebhookIntegration
+    represents a configured outbound webhook URL. An Automation action references
+    exactly one integration by id.
+
+    <when_to_use>
+    Call this tool when the user asks about:
+    - "What Slack channels / webhooks can I send alerts to?"
+    - "Which integrations are set up for my team?"
+    - "List the webhooks configured on entity X"
+
+    You should also call this BEFORE creating an automation (a future tool) when
+    you need an integration_id to pass into the action.
+    </when_to_use>
+
+    <critical_info>
+    - Integrations are configured at the entity (team) level via the W&B UI.
+    This tool only lists existing integrations. It does not create them.
+    - entity=None defaults to the authenticated viewer's default entity.
+    - kind is "slack" (Slack only), "webhook" (webhook only), or null (both).
+    - Each returned record always has {id, type}. Slack adds {team_name,
+    channel_name}. Webhook adds {name, url_endpoint}.
+    </critical_info>
+
+    Parameters
+    ----------
+    entity : str, optional
+        W&B entity (team or user). Omit to use the viewer's default entity.
+    kind : "slack" | "webhook" | None
+        Omit to return both kinds.
+    max_items : int, optional
+        Maximum integrations to return. Default 50, ceiling 200.
+
+    Returns
+    -------
+    JSON with:
+    - integrations: list of integration objects
+    - count: number of integrations returned
+    - entity: the entity filter applied (or null)
+    - kind: the type filter applied (or null)
+    - truncated: whether more integrations exist beyond max_items
+    """)
+
+
+def _jsonify_integration(integration: Integration) -> dict[str, Any]:
+    """Flatten a Slack or Webhook integration to a JSON-safe dict.
+
+    Discriminated via ``isinstance`` against the public wandb pydantic
+    classes. pydantic v2 returns concrete subclass instances for
+    discriminated unions, so this is the canonical way to branch.
+    The wildcard arm keeps the tool forward-compatible with future
+    integration kinds the server may add.
+    """
+    match integration:
+        case SlackIntegration():
+            jsonable = integration.model_dump(include={"id", "team_name", "channel_name"}, **_DUMP_KWARGS)
+            return {"type": "slack"} | jsonable
+        case WebhookIntegration():
+            jsonable = integration.model_dump(include={"id", "name", "url_endpoint"}, **_DUMP_KWARGS)
+            return {"type": "webhook"} | jsonable
+        case _:
+            jsonable = integration.model_dump(include={"id"}, **_DUMP_KWARGS)
+            return {"type": integration.typename__} | jsonable
+
+
+def list_integrations(
+    entity: str | None = None,
+    kind: IntegrationKind | str | None = None,
+    max_items: int = MAX_ITEMS_DEFAULT,
+) -> str:
+    """List Slack and/or webhook integrations for an entity."""
+    params = locals()  # Must be first so it only picks up the function args
+
+    api = WandBApiManager.get_api()
+    with track_tool_execution("list_integrations", api.viewer, params) as ctx:
+        max_items = _clamp(max_items, 1, MAX_ITEMS_CEIL)
+
+        if kind is not None and kind not in _VALID_INTEGRATION_KINDS:
+            ctx.mark_error(f"invalid kind: {kind!r}")
+
+            msg = f"kind must be one of {sorted(_VALID_INTEGRATION_KINDS)} or null, got {kind!r}"
+            return json.dumps({"error": "invalid_input", "message": msg})
+
+        try:
+            iterator: Iterator[Integration]
+            match kind:
+                case "slack":
+                    iterator = api.slack_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
+                case "webhook":
+                    iterator = api.webhook_integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
+                case _:  # None (already validated above)
+                    iterator = api.integrations(entity=entity, per_page=_clamp(max_items, 1, 100))
+
+            integrations = list(map(_jsonify_integration, islice(iterator, max_items)))
+            truncated = next(iterator, None) is not None
+
+            result = {
+                "integrations": integrations,
+                "count": len(integrations),
+                "entity": entity,
+                "kind": kind,
+                "truncated": truncated,
+            }
+            return json.dumps(result)
+
+        except Exception as e:
+            logger.error(f"Error in list_integrations: {e}", exc_info=True)
+            ctx.mark_error(f"{type(e).__name__}: {e}")
+            return json.dumps({"error": "api_error", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional, Union
 import wandb
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
 from wandb_mcp_server.config import WANDB_BASE_URL
 
 # Import Weave for tracing MCP tool calls
@@ -35,6 +36,20 @@ except ImportError:
     weave = None
     WEAVE_AVAILABLE = False
 
+from wandb_mcp_server.mcp_tools.automations import (
+    LIST_AUTOMATIONS_TOOL_DESCRIPTION,
+    LIST_INTEGRATIONS_TOOL_DESCRIPTION,
+    list_automations,
+    list_integrations,
+)
+from wandb_mcp_server.mcp_tools.count_traces import (
+    COUNT_WEAVE_TRACES_TOOL_DESCRIPTION,
+    count_traces,
+)
+from wandb_mcp_server.mcp_tools.create_report import (
+    CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
+    create_report,
+)
 from wandb_mcp_server.mcp_tools.list_entities import (
     LIST_ENTITIES_TOOL_DESCRIPTION,
     list_entities,
@@ -43,32 +58,23 @@ from wandb_mcp_server.mcp_tools.list_wandb_entities_projects import (
     LIST_ENTITY_PROJECTS_TOOL_DESCRIPTION,
     list_entity_projects,
 )
-from wandb_mcp_server.mcp_tools.create_report import (
-    CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
-    create_report,
+from wandb_mcp_server.mcp_tools.query_artifacts import (
+    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
+    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
+    compare_artifact_versions,
+    get_artifact_details,
+    list_artifact_versions,
 )
-from wandb_mcp_server.mcp_tools.count_traces import (
-    COUNT_WEAVE_TRACES_TOOL_DESCRIPTION,
-    count_traces,
+from wandb_mcp_server.mcp_tools.query_registry import (
+    LIST_REGISTRIES_TOOL_DESCRIPTION,
+    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
+    list_registries,
+    list_registry_collections,
 )
 from wandb_mcp_server.mcp_tools.query_wandb_gql import (
     QUERY_WANDB_GQL_TOOL_DESCRIPTION,
     query_paginated_wandb_gql,
-)
-
-from wandb_mcp_server.mcp_tools.query_registry import (
-    LIST_REGISTRIES_TOOL_DESCRIPTION,
-    list_registries,
-    LIST_REGISTRY_COLLECTIONS_TOOL_DESCRIPTION,
-    list_registry_collections,
-)
-from wandb_mcp_server.mcp_tools.query_artifacts import (
-    LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
-    list_artifact_versions,
-    GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION,
-    get_artifact_details,
-    COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
-    compare_artifact_versions,
 )
 
 # wandbot removed -- zero usage across 400+ benchmark runs, superseded by search_wandb_docs_tool
@@ -76,7 +82,9 @@ from wandb_mcp_server.mcp_tools.query_weave import (
     QUERY_WEAVE_TRACES_TOOL_DESCRIPTION,
     query_paginated_weave_traces,
 )
-from wandb_mcp_server.utils import get_rich_logger, get_server_args, ServerMCPArgs
+from wandb_mcp_server.utils import ServerMCPArgs, get_rich_logger, get_server_args
+
+from pydantic import PositiveInt
 
 # Export key functions for HF Spaces app
 __all__ = [
@@ -373,7 +381,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
     """
     Register all W&B MCP tools on the given FastMCP instance.
 
-    Available tools (20):
+    Available tools (22):
     - query_weave_traces_tool: Query LLM traces with filtering and pagination
     - count_weave_traces_tool: Efficiently count traces without returning data
     - resolve_trace_roots_tool: Batch-resolve root spans for child trace_ids
@@ -394,6 +402,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
     - summarize_evaluation_tool: Aggregate Weave evaluation results
     - diagnose_run_tool: Automatic training health check
     - probe_project_tool: Run-side schema and structure discovery
+    - list_wandb_automations_tool: List W&B Automations (rules that trigger
+      notifications/webhooks on artifact, run-state, or run-metric events)
+    - list_wandb_integrations_tool: List Slack and webhook integrations
+      available as targets for Automation actions
 
     Args:
         mcp_instance: The FastMCP instance to register tools on
@@ -728,6 +740,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         scalars: Optional[Dict[str, float]] = None,
     ) -> str:
         from concurrent.futures import ThreadPoolExecutor
+
         from wandb_mcp_server.api_client import WandBApiManager
 
         try:
@@ -763,6 +776,24 @@ def register_tools(mcp_instance: FastMCP) -> None:
     ) -> str:
         """List projects for a W&B entity."""
         return list_entity_projects(entity=entity, max_projects=max_projects)
+
+    @mcp_instance.tool(description=LIST_AUTOMATIONS_TOOL_DESCRIPTION)
+    def list_wandb_automations_tool(
+        entity: Optional[str] = None,
+        name: Optional[str] = None,
+        max_items: int = 50,
+    ) -> str:
+        """List W&B Automations accessible with the current API key."""
+        return list_automations(entity=entity, name=name, max_items=max_items)
+
+    @mcp_instance.tool(description=LIST_INTEGRATIONS_TOOL_DESCRIPTION)
+    def list_wandb_integrations_tool(
+        entity: str | None = None,
+        kind: str | None = None,
+        max_items: PositiveInt = 50,
+    ) -> str:
+        """List Slack and webhook integrations for a W&B entity."""
+        return list_integrations(entity=entity, kind=kind, max_items=max_items)
 
     from wandb_mcp_server.mcp_tools.infer_schema import (
         INFER_TRACE_SCHEMA_TOOL_DESCRIPTION,

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,0 +1,763 @@
+"""Unit tests for the list_automations and list_integrations tools.
+
+These tests use real wandb pydantic instances (via ``Automation.model_validate``
+and ``SlackIntegration.model_validate`` / ``WebhookIntegration.model_validate``)
+rather than mocks. The production serializer (``_jsonify_*``) runs against the
+actual model contracts the wandb SDK guarantees, so if wandb renames a field
+or changes a discriminator, these tests catch it. The one ``MagicMock`` left
+in the file is in ``test_unknown_typename_falls_back``. It simulates an
+integration kind that is not ``SlackIntegration`` or ``WebhookIntegration``,
+which no real type satisfies by construction.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+from pytest import fixture, mark
+from wandb.automations import (
+    Automation,
+    EventType,
+    SlackIntegration,
+    WebhookIntegration,
+)
+
+PATCH_TARGET = "wandb_mcp_server.mcp_tools.automations.WandBApiManager"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: factories that build real wandb pydantic instances via
+# ``model_validate``, the canonical "construct from API response" path.
+# Tests get factories rather than fixed instances so individual cases can
+# override only the fields they care about.
+# ---------------------------------------------------------------------------
+
+
+@fixture
+def mock_api(mocker) -> MagicMock:
+    """Patch ``WandBApiManager`` and return the mocked ``api`` instance.
+
+    Production calls ``WandBApiManager.get_api()``. We replace the manager
+    with a MagicMock and return the api so tests can configure
+    ``api.automations.return_value`` etc.
+    """
+    mgr = mocker.patch(PATCH_TARGET)
+    api = MagicMock()
+    mgr.get_api.return_value = api
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Scope payload factories. These return GraphQL-shaped dicts that
+# make_automation assembles and validates through Automation.model_validate.
+# ---------------------------------------------------------------------------
+
+
+@fixture
+def make_project_scope() -> Callable[..., dict[str, Any]]:
+    def _make(*, id: str = "scope_proj_1", name: str = "my-project") -> dict[str, Any]:
+        return {"__typename": "Project", "id": id, "name": name}
+
+    return _make
+
+
+@fixture
+def make_collection_scope() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        id: str = "scope_coll_1",
+        name: str = "my-models",
+        kind: str = "ArtifactSequence",
+    ) -> dict[str, Any]:
+        # wandb has two artifact-collection variants: ArtifactSequence
+        # (versioned artifact) and ArtifactPortfolio (registry collection).
+        # Both serialize to ARTIFACT_COLLECTION scope_type so either works.
+        return {"__typename": kind, "id": id, "name": name}
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Event payload factories.
+# ---------------------------------------------------------------------------
+
+
+def _filter_event_payload(event_type: str, filter_obj: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "__typename": "FilterEventTriggeringCondition",
+        "eventType": event_type,
+        # The wire format stores the filter as a JSON-encoded string.
+        "filter": json.dumps(filter_obj),
+    }
+
+
+@fixture
+def make_threshold_event() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        metric_name: str = "acc",
+        agg: str | None = "MAX",
+        window: int = 5,
+        cmp: str = "$gt",
+        threshold: float = 0.9,
+    ) -> dict[str, Any]:
+        threshold_filter: dict[str, Any] = {
+            "name": metric_name,
+            "window_size": window,
+            "cmp_op": cmp,
+            "threshold": threshold,
+        }
+        if agg is not None:
+            threshold_filter["agg_op"] = agg
+        return _filter_event_payload(
+            "RUN_METRIC",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {"threshold_filter": threshold_filter},
+            },
+        )
+
+    return _make
+
+
+@fixture
+def make_change_event() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        metric_name: str = "loss",
+        agg: str | None = "AVERAGE",
+        window: int = 3,
+        prior_window: int = 3,
+        change_type: str = "RELATIVE",
+        change_dir: str = "DECREASE",
+        threshold: float = 0.1,
+    ) -> dict[str, Any]:
+        change_filter: dict[str, Any] = {
+            "name": metric_name,
+            "current_window_size": window,
+            "prior_window_size": prior_window,
+            "change_type": change_type,
+            "change_dir": change_dir,
+            "change_amount": threshold,
+        }
+        if agg is not None:
+            change_filter["agg_op"] = agg
+        return _filter_event_payload(
+            "RUN_METRIC_CHANGE",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {"change_filter": change_filter},
+            },
+        )
+
+    return _make
+
+
+@fixture
+def make_zscore_event() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        metric_name: str = "loss",
+        window: int = 30,
+        change_dir: str = "ANY",
+        threshold: float = 3.0,
+    ) -> dict[str, Any]:
+        return _filter_event_payload(
+            "RUN_METRIC_ZSCORE",
+            {
+                "run_filter": {"$and": []},
+                "run_metric_filter": {
+                    "zscore_filter": {
+                        "name": metric_name,
+                        "window_size": window,
+                        "change_dir": change_dir,
+                        "threshold": threshold,
+                    },
+                },
+            },
+        )
+
+    return _make
+
+
+@fixture
+def make_run_state_event() -> Callable[..., dict[str, Any]]:
+    def _make(*, states: tuple[str, ...] = ("FINISHED", "FAILED")) -> dict[str, Any]:
+        # wandb's StateFilter validator dedupes + sorts these on the way in,
+        # so the order tests assert on is the canonical sorted order.
+        return _filter_event_payload(
+            "RUN_STATE",
+            {
+                "run_filter": {"$and": []},
+                "run_state_filter": {"states": list(states)},
+            },
+        )
+
+    return _make
+
+
+@fixture
+def make_mutation_event() -> Callable[..., dict[str, Any]]:
+    """An event for CREATE_ARTIFACT / ADD_ARTIFACT_ALIAS / LINK_ARTIFACT.
+
+    Mutation-event filters are open-ended MongoLikeFilter objects. The
+    production code falls back to ``repr()`` for these, so we only need
+    a sentinel filter payload.
+    """
+
+    def _make(*, event_type: EventType = EventType.CREATE_ARTIFACT) -> dict[str, Any]:
+        return _filter_event_payload(event_type.value, {"filter": {}})
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Action payload factories.
+# ---------------------------------------------------------------------------
+
+
+@fixture
+def make_notification_action() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        integration_id: str = "int_slack_1",
+        title: str = "t",
+        message: str = "m",
+        severity: str | None = "INFO",
+    ) -> dict[str, Any]:
+        return {
+            "__typename": "NotificationTriggeredAction",
+            "integration": {"__typename": "SlackIntegration", "id": integration_id},
+            "title": title,
+            "message": message,
+            "severity": severity,
+        }
+
+    return _make
+
+
+@fixture
+def make_webhook_action() -> Callable[..., dict[str, Any]]:
+    def _make(
+        *,
+        integration_id: str = "int_webhook_1",
+        request_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "__typename": "GenericWebhookTriggeredAction",
+            "integration": {"__typename": "GenericWebhookIntegration", "id": integration_id},
+            # wire format is JSON-encoded. wandb parses it back to a dict
+            # in-memory but model_dump round-trips it to a string. Tests
+            # assert the string form.
+            "requestPayload": json.dumps(request_payload) if request_payload is not None else None,
+        }
+
+    return _make
+
+
+@fixture
+def make_no_op_action() -> Callable[..., dict[str, Any]]:
+    def _make() -> dict[str, Any]:
+        return {"__typename": "NoOpTriggeredAction", "noOp": True}
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Top-level Automation factory.
+# ---------------------------------------------------------------------------
+
+
+@fixture
+def make_automation(make_project_scope, make_threshold_event, make_notification_action) -> Callable[..., Automation]:
+    """Build a real ``wandb.automations.Automation`` via ``model_validate``.
+
+    Override any of ``scope`` / ``event`` / ``action`` with a payload dict
+    from the matching factory (e.g. ``make_threshold_event(...)``). Defaults
+    produce a Project-scoped RUN_METRIC threshold automation with a Slack
+    notification action.
+    """
+
+    def _make(
+        *,
+        id: str = "auto_1",
+        name: str = "my-automation",
+        enabled: bool = True,
+        description: str | None = "desc",
+        created_at: str = "2026-01-01T12:00:00",
+        updated_at: str | None = "2026-05-01T12:00:00",
+        scope: dict[str, Any] | None = None,
+        event: dict[str, Any] | None = None,
+        action: dict[str, Any] | None = None,
+    ) -> Automation:
+        payload = {
+            "__typename": "Trigger",
+            "id": id,
+            "name": name,
+            "enabled": enabled,
+            "description": description,
+            "createdAt": created_at,
+            "updatedAt": updated_at,
+            "scope": scope if scope is not None else make_project_scope(),
+            "event": event if event is not None else make_threshold_event(),
+            "action": action if action is not None else make_notification_action(),
+        }
+        return Automation.model_validate(payload)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Integration factories.
+# ---------------------------------------------------------------------------
+
+
+@fixture
+def make_slack_integration() -> Callable[..., SlackIntegration]:
+    def _make(
+        *,
+        id: str = "int_slack_1",
+        team_name: str = "acme",
+        channel_name: str = "alerts",
+    ) -> SlackIntegration:
+        return SlackIntegration.model_validate(
+            {
+                "__typename": "SlackIntegration",
+                "id": id,
+                "teamName": team_name,
+                "channelName": channel_name,
+            }
+        )
+
+    return _make
+
+
+@fixture
+def make_webhook_integration() -> Callable[..., WebhookIntegration]:
+    def _make(
+        *,
+        id: str = "int_webhook_1",
+        name: str = "prod-webhook",
+        url_endpoint: str = "https://example.com/hook",
+    ) -> WebhookIntegration:
+        return WebhookIntegration.model_validate(
+            {
+                "__typename": "GenericWebhookIntegration",
+                "id": id,
+                "name": name,
+                "urlEndpoint": url_endpoint,
+            }
+        )
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# list_automations
+# ---------------------------------------------------------------------------
+
+
+class TestListAutomations:
+    def test_no_entity_arg_calls_api_without_entity(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation()])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations())
+
+        assert result["count"] == 1
+        assert result["entity"] is None
+        assert result["truncated"] is False
+        kwargs = mock_api.automations.call_args.kwargs
+        assert kwargs.get("entity") is None
+        assert kwargs.get("name") is None
+
+    def test_entity_and_name_passed_through(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(name="exact-match")])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(entity="my-team", name="exact-match"))
+
+        assert result["entity"] == "my-team"
+        assert result["count"] == 1
+        assert result["automations"][0]["name"] == "exact-match"
+        kwargs = mock_api.automations.call_args.kwargs
+        assert kwargs["entity"] == "my-team"
+        assert kwargs["name"] == "exact-match"
+
+    def test_max_items_truncation(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(id=f"a{i}") for i in range(10)])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(max_items=3))
+        assert result["count"] == 3
+        assert result["truncated"] is True
+
+    def test_max_items_ceiling(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(id=f"a{i}") for i in range(250)])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(max_items=999))
+        assert result["count"] == 200
+        assert result["truncated"] is True
+
+    def test_empty_result(self, mock_api):
+        mock_api.automations.return_value = iter([])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations(entity="empty-team"))
+        assert result == {
+            "automations": [],
+            "count": 0,
+            "entity": "empty-team",
+            "truncated": False,
+        }
+
+    def test_project_scope_serialized(self, mock_api, make_automation, make_project_scope):
+        mock_api.automations.return_value = iter(
+            [make_automation(scope=make_project_scope(id="scope_p1", name="proj-1"))]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        scope = json.loads(list_automations())["automations"][0]["scope"]
+        assert scope == {"type": "PROJECT", "id": "scope_p1", "name": "proj-1"}
+
+    def test_collection_scope_serialized(self, mock_api, make_automation, make_collection_scope):
+        mock_api.automations.return_value = iter(
+            [make_automation(scope=make_collection_scope(id="scope_c1", name="my-models"))]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        scope = json.loads(list_automations())["automations"][0]["scope"]
+        assert scope == {"type": "ARTIFACT_COLLECTION", "id": "scope_c1", "name": "my-models"}
+
+    def test_threshold_event_structured(self, mock_api, make_automation, make_threshold_event):
+        mock_api.automations.return_value = iter(
+            [
+                make_automation(
+                    event=make_threshold_event(metric_name="accuracy", agg="MAX", window=5, cmp="$gt", threshold=0.95)
+                )
+            ]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event == {
+            "type": "RUN_METRIC",
+            "filter": {
+                "kind": "threshold",
+                "name": "accuracy",
+                "agg": "MAX",
+                "window": 5,
+                "cmp": "$gt",
+                "threshold": 0.95,
+            },
+        }
+
+    def test_change_event_structured(self, mock_api, make_automation, make_change_event):
+        mock_api.automations.return_value = iter(
+            [
+                make_automation(
+                    event=make_change_event(
+                        metric_name="loss",
+                        agg="AVERAGE",
+                        window=3,
+                        prior_window=3,
+                        change_type="RELATIVE",
+                        change_dir="DECREASE",
+                        threshold=0.1,
+                    )
+                )
+            ]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event == {
+            "type": "RUN_METRIC_CHANGE",
+            "filter": {
+                "kind": "change",
+                "name": "loss",
+                "agg": "AVERAGE",
+                "window": 3,
+                "prior_window": 3,
+                "change_type": "RELATIVE",
+                "change_dir": "DECREASE",
+                "threshold": 0.1,
+            },
+        }
+
+    def test_zscore_event_structured(self, mock_api, make_automation, make_zscore_event):
+        mock_api.automations.return_value = iter(
+            [make_automation(event=make_zscore_event(metric_name="loss", window=30, change_dir="ANY", threshold=3.0))]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event == {
+            "type": "RUN_METRIC_ZSCORE",
+            "filter": {
+                "kind": "zscore",
+                "name": "loss",
+                "window": 30,
+                "change_dir": "ANY",
+                "threshold": 3.0,
+            },
+        }
+
+    def test_run_state_event_serialized(self, mock_api, make_automation, make_run_state_event):
+        mock_api.automations.return_value = iter(
+            [make_automation(event=make_run_state_event(states=("FINISHED", "FAILED")))]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == "RUN_STATE"
+        # StateFilter dedupes and sorts. ``FAILED`` sorts before ``FINISHED``.
+        assert event["filter"] == {"states": ["FAILED", "FINISHED"]}
+
+    @mark.parametrize(
+        "event_type",
+        [EventType.CREATE_ARTIFACT, EventType.ADD_ARTIFACT_ALIAS, EventType.LINK_ARTIFACT],
+    )
+    def test_mutation_event_serialized(self, mock_api, make_automation, make_mutation_event, event_type):
+        mock_api.automations.return_value = iter([make_automation(event=make_mutation_event(event_type=event_type))])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        event = json.loads(list_automations())["automations"][0]["event"]
+        assert event["type"] == event_type.value
+        # Mutation-event filter has no structured shape, only a summary string.
+        assert set(event["filter"].keys()) == {"summary"}
+
+    def test_notification_action_serialized(self, mock_api, make_automation, make_notification_action):
+        mock_api.automations.return_value = iter(
+            [
+                make_automation(
+                    action=make_notification_action(integration_id="int_x", title="T", message="M", severity="WARN")
+                )
+            ]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        assert action == {
+            "type": "NOTIFICATION",
+            "integration_id": "int_x",
+            "title": "T",
+            "message": "M",
+            "severity": "WARN",
+        }
+
+    def test_webhook_action_serialized(self, mock_api, make_automation, make_webhook_action):
+        mock_api.automations.return_value = iter(
+            [make_automation(action=make_webhook_action(integration_id="int_w", request_payload={"k": "v"}))]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        # wandb's ``request_payload`` round-trips through model_dump as the
+        # JSON-encoded wire form, not the in-memory dict.
+        assert action == {
+            "type": "GENERIC_WEBHOOK",
+            "integration_id": "int_w",
+            "request_payload": '{"k":"v"}',
+        }
+
+    def test_no_op_action_serialized(self, mock_api, make_automation, make_no_op_action):
+        mock_api.automations.return_value = iter([make_automation(action=make_no_op_action())])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        action = json.loads(list_automations())["automations"][0]["action"]
+        assert action == {"type": "NO_OP"}
+
+    def test_iso_timestamps(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation()])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        auto = json.loads(list_automations())["automations"][0]
+        assert auto["created_at"] == "2026-01-01T12:00:00"
+        assert auto["updated_at"] == "2026-05-01T12:00:00"
+
+    def test_null_updated_at(self, mock_api, make_automation):
+        mock_api.automations.return_value = iter([make_automation(updated_at=None)])
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        auto = json.loads(list_automations())["automations"][0]
+        assert auto["updated_at"] is None
+
+    def test_api_error_returns_error_dict(self, mock_api):
+        mock_api.automations.side_effect = RuntimeError("boom")
+
+        from wandb_mcp_server.mcp_tools.automations import list_automations
+
+        result = json.loads(list_automations())
+        assert result["error"] == "api_error"
+        assert "boom" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# list_integrations
+# ---------------------------------------------------------------------------
+
+
+class TestListIntegrations:
+    def test_no_type_returns_both(self, mock_api, make_slack_integration, make_webhook_integration):
+        mock_api.integrations.return_value = iter([make_slack_integration(), make_webhook_integration()])
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(entity="my-team"))
+        assert result["count"] == 2
+        assert {item["type"] for item in result["integrations"]} == {"slack", "webhook"}
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
+
+    def test_filter_slack(self, mock_api, make_slack_integration):
+        mock_api.slack_integrations.return_value = iter(
+            [make_slack_integration(id="s1", team_name="acme", channel_name="alerts")]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(entity="my-team", kind="slack"))
+        assert result["count"] == 1
+        assert result["integrations"][0] == {
+            "id": "s1",
+            "type": "slack",
+            "team_name": "acme",
+            "channel_name": "alerts",
+        }
+        mock_api.integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
+
+    def test_filter_webhook(self, mock_api, make_webhook_integration):
+        mock_api.webhook_integrations.return_value = iter(
+            [make_webhook_integration(id="w1", name="prod", url_endpoint="https://x.test/hook")]
+        )
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(kind="webhook"))
+        assert result["count"] == 1
+        assert result["integrations"][0] == {
+            "id": "w1",
+            "type": "webhook",
+            "name": "prod",
+            "url_endpoint": "https://x.test/hook",
+        }
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
+
+    def test_invalid_type_returns_error(self, mock_api):
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(kind="email"))
+        assert result["error"] == "invalid_input"
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
+
+    def test_empty_string_kind_is_invalid(self, mock_api):
+        """Regression: empty string is falsy in Python so a naive truthy check
+        would silently treat ``kind=""`` as ``None`` and return both kinds.
+        It must be rejected like any other non-allowed value.
+        """
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(kind=""))
+        assert result["error"] == "invalid_input"
+        mock_api.integrations.assert_not_called()
+        mock_api.slack_integrations.assert_not_called()
+        mock_api.webhook_integrations.assert_not_called()
+
+    def test_empty(self, mock_api):
+        mock_api.integrations.return_value = iter([])
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["count"] == 0
+        assert result["integrations"] == []
+        assert result["truncated"] is False
+
+    def test_max_items_truncation(self, mock_api, make_slack_integration):
+        mock_api.integrations.return_value = iter([make_slack_integration(id=f"s{i}") for i in range(20)])
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(max_items=5))
+        assert result["count"] == 5
+        assert result["truncated"] is True
+
+    def test_max_items_ceiling(self, mock_api, make_webhook_integration):
+        mock_api.integrations.return_value = iter([make_webhook_integration(id=f"w{i}") for i in range(250)])
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations(max_items=999))
+        assert result["count"] == 200
+        assert result["truncated"] is True
+
+    def test_api_error_returns_error_dict(self, mock_api):
+        mock_api.integrations.side_effect = RuntimeError("kapow")
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["error"] == "api_error"
+        assert "kapow" in result["message"]
+
+    def test_unknown_typename_falls_back(self, mock_api):
+        """Forward-compat: an Integration kind that's neither Slack nor Webhook
+        should still serialize through the wildcard match arm.
+
+        This is the one case where a real wandb instance won't do. The
+        whole point is "we don't know about this type yet", so we drop
+        down to a MagicMock for this test specifically. The production
+        wildcard arm calls ``.model_dump(include={"id"}, ...)``, so we
+        wire that up to return the expected dict.
+        """
+        other = MagicMock()
+        other.id = "d1"
+        other.typename__ = "DiscordIntegration"
+        other.model_dump.return_value = {"id": "d1"}
+        mock_api.integrations.return_value = iter([other])
+
+        from wandb_mcp_server.mcp_tools.automations import list_integrations
+
+        result = json.loads(list_integrations())
+        assert result["count"] == 1
+        assert result["integrations"][0] == {"id": "d1", "type": "DiscordIntegration"}
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions are present and non-trivial (smoke test)
+# ---------------------------------------------------------------------------
+
+
+@mark.parametrize("const_name", ["LIST_AUTOMATIONS_TOOL_DESCRIPTION", "LIST_INTEGRATIONS_TOOL_DESCRIPTION"])
+def test_tool_descriptions_present(const_name):
+    from wandb_mcp_server.mcp_tools import automations as mod
+
+    val = getattr(mod, const_name)
+    assert isinstance(val, str)
+    assert "<when_to_use>" in val
+    assert "<critical_info>" in val

--- a/uv.lock
+++ b/uv.lock
@@ -1522,6 +1522,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2174,6 +2186,7 @@ test = [
     { name = "litellm" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "pytest-xdist" },
 ]
 
@@ -2193,6 +2206,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.26.0" },
+    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.14.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },


### PR DESCRIPTION
## Summary
Adds two read-only MCP tools that wrap the public `wandb.Api` Automations surface on top of the `staging/0.3.6` dependency stack.

- `list_wandb_automations_tool` lists Automations and serializes scope, event, action, timestamps, enabled state, and metadata.
- `list_wandb_integrations_tool` lists Slack and webhook integrations with an optional `kind` filter.

This is a staging-based replacement for #90 because the original PR branch is not maintainer-modifiable.

## Changes
- Adds `src/wandb_mcp_server/mcp_tools/automations.py`.
- Registers the tools in `src/wandb_mcp_server/server.py`.
- Updates README tool list.
- Adds `tests/test_automations.py` using real W&B automations/integration pydantic models.
- Adds `pytest-mock>=3.14.0` to test extras and regenerates `uv.lock` with `uv lock`.

## Base
Targets `staging/0.3.6`, which includes the current W&B SDK/workspaces compatibility stack:

- `wandb[workspaces]>=0.27.1`
- `wandb-workspaces>=0.4.2`

## Test plan
- `uv sync --frozen --extra test`
- `uv run pytest tests/test_automations.py tests/test_tool_descriptions.py tests/test_import_smoke.py -v`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv build`
- Fresh wheel smoke importing:
  - `wandb_mcp_server`
  - `wandb_mcp_server.mcp_tools.automations`
  - `wandb_mcp_server.mcp_tools.query_wandb_gql`
  - `wandb_mcp_server.mcp_tools.create_report`

Validation result: `86 passed, 3 warnings`; ruff and wheel smoke passed.

## Related
- Original PR: #90
- Jira: https://coreweave.atlassian.net/browse/WB-34751

Made with [Cursor](https://cursor.com)