### PR TITLE
feat(reports): support full report layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Query and analyze your Weights & Biases data using natural language through the 
 - `"summary"` -- truncated inputs/outputs (default)
 - `"full"` -- everything untruncated (drill into specific traces)
 
-**Chart panels:** `create_wandb_report_tool` accepts a `panels` parameter for LinePlots, BarPlots, and run comparisons alongside markdown.
+**Chart panels:** `create_wandb_report_tool` accepts a `panels` parameter for LinePlots, BarPlots, run comparisons, custom Vega charts, and ordered report layouts. Use `panel_grid` when multiple charts should share one runset, and use `heading` plus `markdown` blocks to interleave narrative sections with charts.
 
 **Docs search:** `search_wandb_docs_tool` proxies [docs.wandb.ai](https://docs.wandb.ai) so you get data tools + documentation search from a single MCP connection. Disable with `WANDB_MCP_PROXY_DOCS=false` if you connect the docs MCP separately.
 

--- a/docs/REPORT_LAYOUT_STAGING_0_3_6.md
+++ b/docs/REPORT_LAYOUT_STAGING_0_3_6.md
@@ -1,0 +1,637 @@
+# Report Layout Support for `staging/0.3.6`
+
+## Summary
+
+`create_wandb_report_tool` already has the right primitive for custom Vega
+charts through `custom_chart` and `custom_chart_table`, but it cannot yet build
+production-style reports that combine narrative sections with groups of charts
+sharing a single runset.
+
+This document describes the implementation needed for the `staging/0.3.6`
+release so MCP can create full W&B Reports without asking the agent to generate
+Python scripts.
+
+The work should extend the existing `panels` input schema in a backward
+compatible way. Existing flat `line`, `bar`, `scatter`, `run_comparison`,
+`custom_chart`, and `custom_chart_table` panel specs should keep working.
+
+## Current Behavior
+
+The current implementation in `src/wandb_mcp_server/mcp_tools/create_report.py`
+has these limitations:
+
+1. `custom_chart` and `custom_chart_table` create one `PanelGrid` per chart.
+2. `create_report()` appends all panel blocks under one trailing `wr.H2("Charts")`.
+3. `run_ids` are converted into `wr.Runset(query=" ".join(run_ids))`, which is a
+   search query, not a deterministic run filter.
+4. There is no way to express this structure through MCP:
+
+```python
+[
+    wr.H2("Average precision"),
+    wr.MarkdownBlock("Overview text."),
+    wr.PanelGrid(
+        runsets=[shared_runset],
+        panels=[car_ap, truck_ap, motorcycle_ap],
+    ),
+    wr.H2("Error analysis"),
+    wr.MarkdownBlock("More text."),
+    wr.PanelGrid(
+        runsets=[shared_runset],
+        panels=[error_chart_1, error_chart_2],
+    ),
+]
+```
+
+Customer impact:
+
+- Agents can create individual custom charts.
+- Agents cannot assemble full multi-section model-card/report layouts.
+- Agents often fall back to writing Python scripts, which defeats the purpose of
+  using the MCP report tool.
+
+## Goals
+
+- Support multiple charts in one `PanelGrid`.
+- Support interleaved narrative and chart sections.
+- Support deterministic run selection for explicit run IDs.
+- Preserve existing flat-panel behavior.
+- Keep the MCP input shape JSON-serializable and easy for an LLM to emit.
+- Add tests that inspect real `wandb_workspaces.reports.v2` objects, not just
+  mocks.
+
+## Non-Goals
+
+- Do not add create/update/delete automation behavior in this work.
+- Do not introduce a separate scripting tool.
+- Do not attempt to support every possible W&B Report block in this release.
+- Do not remove existing `markdown_report_text`; it remains useful for simple
+  reports.
+
+## Proposed MCP Schema
+
+Keep the `panels` parameter as the report layout surface, but allow it to contain
+layout blocks as well as chart blocks.
+
+### Top-Level Layout Blocks
+
+Supported top-level `panels` item types:
+
+```text
+heading
+markdown
+panel_grid
+line
+bar
+scatter
+run_comparison
+markdown_table
+markdown_panel
+custom_chart
+custom_chart_table
+```
+
+`heading` and `markdown` are new.
+
+`panel_grid` is new and contains child panels.
+
+Existing chart types remain valid at the top level. If a chart appears at the
+top level, the builder should preserve the current behavior and wrap that single
+chart in its own `PanelGrid`.
+
+### `heading`
+
+```json
+{
+  "type": "heading",
+  "level": 2,
+  "text": "Average precision by class"
+}
+```
+
+Rules:
+
+- `level` supports `1`, `2`, and `3`.
+- Map to `wr.H1`, `wr.H2`, or `wr.H3`.
+- Invalid levels should fall back to `wr.H2`.
+- Empty `text` should skip the block.
+
+### `markdown`
+
+```json
+{
+  "type": "markdown",
+  "text": "These charts compare AP across the selected runs."
+}
+```
+
+Rules:
+
+- Use `wr.MarkdownBlock(text)`.
+- This is intentionally separate from `markdown_panel`.
+- `markdown` is narrative report content.
+- `markdown_panel` remains a chart panel inside a `PanelGrid`.
+
+### `panel_grid`
+
+```json
+{
+  "type": "panel_grid",
+  "title": "Average precision charts",
+  "run_ids": ["run_a", "run_b"],
+  "hide_run_sets": false,
+  "panels": [
+    {
+      "type": "custom_chart",
+      "query": {"summaryTable": {"tableKey": "car_ap"}},
+      "chart_name": "cruise/bar_chart/v2",
+      "chart_fields": {"x": "threshold", "y": "ap"},
+      "chart_strings": {"title": "CAR AP"}
+    },
+    {
+      "type": "custom_chart",
+      "query": {"summaryTable": {"tableKey": "truck_ap"}},
+      "chart_name": "cruise/bar_chart/v2",
+      "chart_fields": {"x": "threshold", "y": "ap"},
+      "chart_strings": {"title": "TRUCK AP"}
+    }
+  ]
+}
+```
+
+Rules:
+
+- Build exactly one `wr.PanelGrid`.
+- Build one shared `wr.Runset`.
+- Convert child panel specs into `wr.LinePlot`, `wr.BarPlot`, `wr.ScatterPlot`,
+  `wr.CustomChart`, `wr.CustomChart.from_table(...)`, or `wr.MarkdownPanel`.
+- Do not allow child `heading`, `markdown`, or nested `panel_grid`.
+- If no child panels render successfully, skip the grid.
+- If some child panels fail, include a fallback `wr.MarkdownPanel` or skip only
+  failed children. Prefer skipping failed children and logging a warning.
+
+## Deterministic Run Selection
+
+The current `run_ids` behavior uses:
+
+```python
+wr.Runset(entity=entity, project=project, query=" ".join(run_ids))
+```
+
+This is not deterministic. It is a project search query and can match unrelated
+runs if a run ID is a substring of another run name or display name.
+
+### Preferred Behavior
+
+For explicit `run_ids`, create a runset filter equivalent to:
+
+```text
+run.name in ["run_a", "run_b"]
+```
+
+Implementation should prefer a native `wandb-workspaces` filter string that
+round-trips through `Runset._to_model()` on `wandb-workspaces>=0.4.2`.
+
+Recommended helper:
+
+```python
+def _run_ids_to_filter(run_ids: list[str]) -> str:
+    quoted = ", ".join(json.dumps(run_id) for run_id in run_ids)
+    return f"name in [{quoted}]"
+```
+
+Then:
+
+```python
+wr.Runset(entity=entity_name, project=project_name, filters=_run_ids_to_filter(run_ids))
+```
+
+If `wandb-workspaces` expects section-qualified run keys, adjust to the canonical
+syntax proven by tests. The test should assert the serialized runset contains an
+`IN` filter on the run name field.
+
+### Filter Passthrough
+
+Also allow callers to pass `filters` directly:
+
+```json
+{
+  "type": "panel_grid",
+  "filters": "name in [\"run_a\", \"run_b\"]",
+  "panels": [...]
+}
+```
+
+Rules:
+
+- If `filters` is present, it wins over `run_ids`.
+- If `analysis_run_id` is present, preserve current behavior unless tests prove
+  a deterministic filter is safe.
+- Do not attempt to parse arbitrary filters in MCP. Pass the string through to
+  `wr.Runset(filters=...)`.
+
+## Implementation Plan
+
+All code changes should stay in:
+
+```text
+src/wandb_mcp_server/mcp_tools/create_report.py
+tests/test_create_report_panels.py
+README.md
+```
+
+### 1. Add Layout Mode Detection
+
+Introduce:
+
+```python
+_LAYOUT_BLOCK_TYPES = {"heading", "markdown", "panel_grid"}
+```
+
+Then:
+
+```python
+def _is_layout_mode(panels: list[dict[str, Any]]) -> bool:
+    return any(panel.get("type", "").lower() in _LAYOUT_BLOCK_TYPES for panel in panels)
+```
+
+In `create_report()`:
+
+- If `panels` is absent, behavior unchanged.
+- If `panels` is present and not layout mode, behavior unchanged:
+  - build panel blocks
+  - prepend one `wr.H2("Charts")`
+- If layout mode:
+  - build layout blocks in order
+  - do not insert `wr.H2("Charts")`
+  - append layout blocks directly after markdown content
+
+This keeps backward compatibility for old callers.
+
+### 2. Add `_build_layout_blocks(...)`
+
+```python
+def _build_layout_blocks(
+    specs: list[dict[str, Any]],
+    entity_name: str,
+    project_name: str,
+) -> list[Any]:
+    ...
+```
+
+Responsibilities:
+
+- Preserve input order.
+- Dispatch `heading`.
+- Dispatch `markdown`.
+- Dispatch `panel_grid`.
+- For existing chart block types at top level, call existing `_build_panel_block`
+  so mixed old/new layouts work.
+- Log and continue on individual block errors.
+
+### 3. Add `_build_heading_block(...)`
+
+```python
+def _build_heading_block(spec: dict[str, Any]):
+    text = spec.get("text") or spec.get("title") or ""
+    level = int(spec.get("level", 2))
+    ...
+```
+
+Mapping:
+
+- `1` -> `wr.H1`
+- `2` -> `wr.H2`
+- `3` -> `wr.H3`
+
+### 4. Add `_build_markdown_block(...)`
+
+```python
+def _build_markdown_block(spec: dict[str, Any]):
+    text = spec.get("text") or spec.get("markdown") or ""
+    return wr.MarkdownBlock(text) if text else None
+```
+
+### 5. Split Panel Construction From Grid Wrapping
+
+Current builders return `wr.PanelGrid` for most chart panel specs. For
+`panel_grid`, the child builder needs to return only panel objects.
+
+Add:
+
+```python
+def _build_panel_object(spec: dict[str, Any]):
+    ...
+```
+
+It should produce:
+
+- `wr.LinePlot`
+- `wr.BarPlot`
+- `wr.ScatterPlot`
+- `wr.MarkdownPanel`
+- `wr.CustomChart`
+- `wr.CustomChart.from_table(...)`
+
+Then:
+
+- Existing standalone `_build_native_panel(...)` can wrap the object in
+  `_build_panel_grid(...)`.
+- New `_build_panel_grid_block(...)` can collect many panel objects and wrap them
+  in one `wr.PanelGrid`.
+
+Avoid duplicating custom chart construction logic.
+
+### 6. Add `_build_panel_grid_block(...)`
+
+```python
+def _build_panel_grid_block(
+    spec: dict[str, Any],
+    entity_name: str,
+    project_name: str,
+):
+    runset = _build_runset(spec, entity_name, project_name, include_run_ids=True)
+    child_panels = [...]
+    return wr.PanelGrid(
+        runsets=[runset],
+        hide_run_sets=bool(spec.get("hide_run_sets", False)),
+        panels=child_panels,
+    )
+```
+
+Rules:
+
+- `panels` must be a non-empty list.
+- Child chart errors should not fail the whole report if at least one child
+  succeeds.
+- Unknown child block types should be ignored with a warning.
+- `title` on the grid is optional and should not automatically create a heading.
+  Use an explicit `heading` block for visible titles.
+
+### 7. Update `_build_runset(...)`
+
+Order of precedence:
+
+1. Explicit `filters`
+2. Explicit `analysis_run_id`
+3. Explicit `run_ids`
+4. Default unfiltered runset
+
+Pseudo-code:
+
+```python
+filters = panel_spec.get("filters")
+if filters:
+    return wr.Runset(entity=entity_name, project=project_name, filters=filters)
+
+run_id = panel_spec.get("analysis_run_id")
+if run_id:
+    return wr.Runset(entity=entity_name, project=project_name, query=run_id)
+
+run_ids = panel_spec.get("run_ids", [])
+if include_run_ids and run_ids:
+    return wr.Runset(
+        entity=entity_name,
+        project=project_name,
+        filters=_run_ids_to_filter(run_ids),
+    )
+```
+
+If `filters` as string fails with `wandb-workspaces`, use the v2 dict shape that
+the workspaces tests prove serializes correctly. Do not ship an untested filter
+shape.
+
+## Example MCP Input
+
+```json
+{
+  "entity_name": "my-team",
+  "project_name": "my-project",
+  "title": "Detector model card",
+  "markdown_report_text": "# Detector model card\n\n[TOC]",
+  "panels": [
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Average precision"
+    },
+    {
+      "type": "markdown",
+      "text": "Average precision by class for the selected runs."
+    },
+    {
+      "type": "panel_grid",
+      "run_ids": ["run_a", "run_b"],
+      "hide_run_sets": false,
+      "panels": [
+        {
+          "type": "custom_chart",
+          "query": {"summaryTable": {"tableKey": "car_ap"}},
+          "chart_name": "cruise/bar_chart/v2",
+          "chart_fields": {"x": "threshold", "y": "ap"},
+          "chart_strings": {"title": "CAR AP"}
+        },
+        {
+          "type": "custom_chart",
+          "query": {"summaryTable": {"tableKey": "truck_ap"}},
+          "chart_name": "cruise/bar_chart/v2",
+          "chart_fields": {"x": "threshold", "y": "ap"},
+          "chart_strings": {"title": "TRUCK AP"}
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "level": 2,
+      "text": "Error analysis"
+    },
+    {
+      "type": "markdown",
+      "text": "False-positive and false-negative breakdowns."
+    },
+    {
+      "type": "panel_grid",
+      "filters": "name in [\"run_a\", \"run_b\"]",
+      "panels": [
+        {
+          "type": "custom_chart_table",
+          "table_name": "error_table",
+          "chart_name": "cruise/error_chart",
+          "chart_fields": {"x": "class", "y": "count"},
+          "chart_strings": {"title": "Errors by class"}
+        }
+      ]
+    }
+  ]
+}
+```
+
+Expected report block order:
+
+```text
+P("*Report created via W&B MCP Server*")
+H1("Detector model card")
+TableOfContents()
+H2("Average precision")
+MarkdownBlock(...)
+PanelGrid(panels=[CustomChart, CustomChart], runsets=[shared_runset])
+H2("Error analysis")
+MarkdownBlock(...)
+PanelGrid(panels=[CustomChart], runsets=[shared_runset])
+```
+
+## Tests
+
+Add or update tests in:
+
+```text
+tests/test_create_report_panels.py
+```
+
+### Unit Tests
+
+1. `test_layout_heading_block`
+   - `{"type": "heading", "level": 2, "text": "Section"}`
+   - Returns `wr.H2("Section")`.
+
+2. `test_layout_markdown_block`
+   - `{"type": "markdown", "text": "Intro"}`
+   - Returns `wr.MarkdownBlock("Intro")`.
+
+3. `test_panel_grid_groups_multiple_custom_charts`
+   - One `panel_grid` with two `custom_chart` children.
+   - Asserts one `wr.PanelGrid`.
+   - Asserts two custom chart panel objects.
+   - Asserts one shared runset.
+
+4. `test_layout_preserves_interleaved_block_order`
+   - `heading`, `markdown`, `panel_grid`, `heading`, `markdown`, `panel_grid`
+   - Asserts exact block order.
+   - Asserts no automatic `H2("Charts")` is inserted in layout mode.
+
+5. `test_legacy_flat_panels_still_get_charts_heading`
+   - Existing flat `line` panel behavior unchanged.
+
+6. `test_run_ids_use_deterministic_filter`
+   - `run_ids=["run_a", "run_b"]`
+   - Asserts serialized runset contains an `IN` filter on run name.
+   - Do this with real `wandb_workspaces` objects, not only `MagicMock`.
+
+7. `test_explicit_filters_win_over_run_ids`
+   - Provide both `filters` and `run_ids`.
+   - Assert `filters` is passed through and `run_ids` ignored.
+
+8. `test_unknown_child_panel_does_not_break_grid`
+   - One valid child panel and one unknown child.
+   - Result grid contains only the valid child.
+
+### Integration-Style Object Test
+
+Use real `wandb_workspaces.reports.v2` objects and call `_to_model()` on the
+captured report object to inspect the actual serialized shape:
+
+- `Report.spec.blocks`
+- `PanelGrid.metadata.run_sets`
+- `PanelGrid.metadata.panel_bank_section_config.panels`
+- Custom chart `panel_def_id`
+- Runset filter model
+
+This is the test that protects against mismatches between MCP assumptions and
+`wandb-workspaces` serialization.
+
+## README Update
+
+Update the `Chart panels` section to mention:
+
+- `panel_grid` groups multiple charts under one shared runset.
+- `heading` and `markdown` allow interleaved report sections.
+- `run_ids` are deterministic filters, not fuzzy search.
+- `custom_chart` supports custom Vega panel definitions, including non-`wandb/*`
+  `chart_name` values.
+
+## Tool Description Update
+
+Update `CREATE_WANDB_REPORT_TOOL_DESCRIPTION` in
+`src/wandb_mcp_server/mcp_tools/create_report.py`.
+
+Add a `layout_mode` section:
+
+```text
+Use panel_grid when multiple charts should share the same runset or filters.
+Use heading and markdown blocks to interleave narrative sections with chart grids.
+For production reports, prefer:
+heading -> markdown -> panel_grid -> heading -> markdown -> panel_grid
+```
+
+Add a `run_filtering` section:
+
+```text
+Use run_ids for exact run selection. MCP converts run_ids into deterministic
+run-name filters. Use filters for advanced W&B runset filter expressions.
+```
+
+## Validation
+
+Run:
+
+```bash
+uv run pytest tests/test_create_report_panels.py -v
+uv run pytest tests/test_markdown_parsing.py tests/test_tool_descriptions.py -v
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv build
+```
+
+Fresh wheel smoke:
+
+```bash
+uv venv /tmp/wandb-mcp-report-layout-smoke --python 3.12
+uv pip install --python /tmp/wandb-mcp-report-layout-smoke/bin/python dist/*.whl
+/tmp/wandb-mcp-report-layout-smoke/bin/python -c "import wandb_mcp_server.mcp_tools.create_report; print('ok')"
+```
+
+If a live key is available, run a live smoke that creates a report with:
+
+- one `heading`
+- one `markdown`
+- one `panel_grid`
+- two `custom_chart_table` panels
+- `run_ids` selecting known runs
+
+Delete the report afterward.
+
+## Rollout for `staging/0.3.6`
+
+1. Land this as a single PR against `staging/0.3.6`.
+2. Keep it separate from the automations PR and SDK dependency PR.
+3. Verify PR order:
+   - SDK/workspaces compatibility branch is already in `staging/0.3.6`.
+   - Automations PR can land independently.
+   - Report layout PR can land independently.
+4. After merge, tell the customer:
+   - Custom Vega charts were already supported.
+   - Full report composition now supports shared panel grids, interleaved sections,
+     and deterministic run filters.
+
+## Risks
+
+- `wandb-workspaces` filter string syntax may not match our assumption.
+  - Mitigation: assert the serialized runset model in tests.
+- LLMs may overuse layout mode for simple reports.
+  - Mitigation: keep flat panel behavior and document when to use `panel_grid`.
+- Backward compatibility regression for old `panels` arrays.
+  - Mitigation: explicit tests that old behavior still appends `H2("Charts")`.
+- Silent chart child failures could produce incomplete reports.
+  - Mitigation: log warnings and optionally include a fallback paragraph in the
+    report when an entire grid cannot render.
+
+## Acceptance Criteria
+
+- Existing flat `panels` calls still work.
+- `panel_grid` supports multiple child charts sharing one runset.
+- `heading` and `markdown` blocks interleave correctly with grids.
+- `run_ids` serialize to deterministic run filters.
+- `filters` passthrough is supported and wins over `run_ids`.
+- Real `wandb-workspaces` object serialization tests pass.
+- README and tool description explain the new schema.
+- Build and focused tests pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ log_cli = true
 log_cli_level = "INFO"  # or "DEBUG"
 log_cli_format = "%(levelname)s %(message)s"
 log_cli_date_format = "%H:%M:%S"
+markers = [
+    "integration: marks tests that require live external services",
+]
 filterwarnings = [
     # Ignore Sentry Hub deprecation from weave
     'ignore:::weave\.trace\.trace_sentry',

--- a/scripts/report_layout_live_harness.py
+++ b/scripts/report_layout_live_harness.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python
+"""Live harness for validating MCP report layout and custom Vega panels."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_PROJECT = "wandb-mcp-report-layout-live"
+_SUMMARY_TABLE_KEYS = ("car_ap", "truck_ap")
+_RENDERABLE_TABLE_KEYS = ("loss_curve", "accuracy_curve", "pr_curve_table")
+_HISTORY_TABLE_KEY = "pr_curve"
+_REPORT_TAG = "mcp-report-layout-live"
+_DATA_MODES = ("api-shape", "renderable")
+
+
+@dataclass(frozen=True)
+class HarnessSettings:
+    """Resolved live harness settings."""
+
+    entity: str
+    project: str
+    api_key: str
+    loaded_env_files: tuple[Path, ...]
+    data_mode: str
+
+
+@dataclass(frozen=True)
+class HarnessResult:
+    """Live harness output."""
+
+    report_url: str
+    run_ids: tuple[str, ...]
+    entity: str
+    project: str
+    data_mode: str
+
+
+def env_file_candidates(explicit_env_file: str | None = None) -> list[Path]:
+    """Return `.env` files to load without exposing their contents."""
+    candidates: list[Path] = []
+    if explicit_env_file:
+        candidates.append(Path(explicit_env_file).expanduser())
+    candidates.extend(
+        [
+            Path.cwd() / ".env",
+            _REPO_ROOT / ".env",
+            _REPO_ROOT.parent / "WandBAgentFactory" / ".env",
+            _REPO_ROOT.parent / "wandb-mcp-server-test" / ".env",
+        ]
+    )
+
+    seen: set[Path] = set()
+    unique_candidates: list[Path] = []
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved not in seen:
+            unique_candidates.append(resolved)
+            seen.add(resolved)
+    return unique_candidates
+
+
+def load_harness_env(explicit_env_file: str | None = None) -> tuple[Path, ...]:
+    """Load local env files in a deterministic order.
+
+    Existing shell variables win over `.env` values so callers can override
+    secrets or test targets from the command line.
+    """
+    loaded: list[Path] = []
+    for env_file in env_file_candidates(explicit_env_file):
+        if env_file.exists():
+            load_dotenv(env_file, override=False)
+            loaded.append(env_file)
+    return tuple(loaded)
+
+
+def resolve_settings(
+    *,
+    explicit_env_file: str | None = None,
+    entity: str | None = None,
+    project: str | None = None,
+    data_mode: str | None = None,
+) -> HarnessSettings:
+    """Resolve live harness settings from args, `.env`, and W&B identity."""
+    loaded_env_files = load_harness_env(explicit_env_file)
+    api_key = os.getenv("WANDB_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("WANDB_API_KEY is required. Set it in the shell or in one of the loaded .env files.")
+
+    resolved_entity = (
+        entity
+        or os.getenv("MCP_REPORT_TEST_ENTITY")
+        or os.getenv("MCP_LOGS_WANDB_ENTITY")
+        or os.getenv("WANDB_ENTITY")
+        or _viewer_username(api_key)
+    )
+    if not resolved_entity:
+        raise RuntimeError(
+            "Could not resolve a W&B entity. Set MCP_REPORT_TEST_ENTITY, MCP_LOGS_WANDB_ENTITY, or WANDB_ENTITY."
+        )
+
+    resolved_project = (
+        project
+        or os.getenv("MCP_REPORT_TEST_PROJECT")
+        or os.getenv("MCP_LOGS_WANDB_PROJECT")
+        or os.getenv("WANDB_PROJECT")
+        or _DEFAULT_PROJECT
+    )
+    resolved_data_mode = data_mode or os.getenv("MCP_REPORT_DATA_MODE") or "api-shape"
+    if resolved_data_mode not in _DATA_MODES:
+        raise RuntimeError(f"data_mode must be one of: {', '.join(_DATA_MODES)}")
+
+    return HarnessSettings(
+        entity=resolved_entity,
+        project=resolved_project,
+        api_key=api_key,
+        loaded_env_files=loaded_env_files,
+        data_mode=resolved_data_mode,
+    )
+
+
+def run_live_report_layout_verification(settings: HarnessSettings) -> HarnessResult:
+    """Seed runs, create a report layout, reload it, and assert viewspec shape."""
+    import wandb
+    import wandb_workspaces.reports.v2 as wr
+
+    from wandb_mcp_server.api_client import WandBApiManager
+    from wandb_mcp_server.mcp_tools.create_report import create_report
+
+    os.environ["WANDB_API_KEY"] = settings.api_key
+    WandBApiManager.set_context_api_key(settings.api_key)
+
+    run_ids = tuple(_seed_runs(settings.entity, settings.project))
+    for run_id in run_ids:
+        _wait_for_summary_tables(settings.entity, settings.project, run_id)
+
+    report = create_report(
+        entity_name=settings.entity,
+        project_name=settings.project,
+        title=f"MCP report layout {settings.data_mode} verification {int(time.time())}",
+        description="Live MCP report layout harness verification.",
+        markdown_report_text="# MCP report layout live verification\n\n[TOC]",
+        panels=_report_layout_panels(run_ids, data_mode=settings.data_mode),
+    )
+    report_url = report["url"]
+
+    report_model = wr.Report.from_url(report_url, as_model=True)
+    _assert_report_model(report_model, run_ids, data_mode=settings.data_mode)
+
+    wandb.termlog(f"MCP report layout harness URL: {report_url}")
+    return HarnessResult(
+        report_url=report_url,
+        run_ids=run_ids,
+        entity=settings.entity,
+        project=settings.project,
+        data_mode=settings.data_mode,
+    )
+
+
+def _viewer_username(api_key: str) -> str:
+    import wandb
+
+    api = wandb.Api(api_key=api_key)
+    viewer = api.viewer
+    return getattr(viewer, "username", "") or getattr(viewer, "entity", "")
+
+
+def _seed_runs(entity: str, project: str) -> list[str]:
+    import wandb
+
+    run_ids: list[str] = []
+    for idx, model_name in enumerate(("baseline", "candidate")):
+        with wandb.init(
+            entity=entity,
+            project=project,
+            name=f"{_REPORT_TAG}-{model_name}-{int(time.time())}",
+            job_type="mcp-report-layout-live",
+            tags=[_REPORT_TAG, model_name],
+            config={"model_name": model_name, "seed": idx},
+        ) as run:
+            run.log(
+                {
+                    "score": 0.71 + idx * 0.08,
+                    "loss": 0.42 - idx * 0.05,
+                    "car_ap": _ap_table("car", idx),
+                    "truck_ap": _ap_table("truck", idx),
+                    _HISTORY_TABLE_KEY: _pr_curve_table(idx),
+                    "loss_curve": _loss_curve_table(idx),
+                    "accuracy_curve": _accuracy_curve_table(idx),
+                    "pr_curve_table": _renderable_pr_curve_table(idx),
+                }
+            )
+            run_ids.append(run.id)
+    return run_ids
+
+
+def _ap_table(label: str, run_offset: int):
+    import wandb
+
+    return wandb.Table(
+        columns=["threshold", "ap", "class"],
+        data=[
+            [0.25, 0.70 + run_offset * 0.05, label],
+            [0.50, 0.77 + run_offset * 0.05, label],
+            [0.75, 0.74 + run_offset * 0.05, label],
+        ],
+    )
+
+
+def _pr_curve_table(run_offset: int):
+    import wandb
+
+    return wandb.Table(
+        columns=["r", "p", "c"],
+        data=[
+            [0.0, 1.00, f"class_{run_offset}"],
+            [0.5, 0.84 + run_offset * 0.04, f"class_{run_offset}"],
+            [1.0, 0.61 + run_offset * 0.04, f"class_{run_offset}"],
+        ],
+    )
+
+
+def _loss_curve_table(run_offset: int):
+    import wandb
+
+    return wandb.Table(
+        columns=["step", "loss"],
+        data=[[step, round(0.95 / (step + 1) + run_offset * 0.04, 4)] for step in range(12)],
+    )
+
+
+def _accuracy_curve_table(run_offset: int):
+    import wandb
+
+    return wandb.Table(
+        columns=["step", "accuracy"],
+        data=[[step, round(0.55 + step * 0.035 + run_offset * 0.05, 4)] for step in range(12)],
+    )
+
+
+def _renderable_pr_curve_table(run_offset: int):
+    import wandb
+
+    return wandb.Table(
+        columns=["recall", "precision"],
+        data=[[round(step / 10, 2), round(1.0 - step * 0.035 + run_offset * 0.02, 4)] for step in range(11)],
+    )
+
+
+def _wait_for_summary_tables(
+    entity: str,
+    project: str,
+    run_id: str,
+    timeout_s: int = 90,
+) -> None:
+    import wandb
+
+    api = wandb.Api(api_key=os.environ["WANDB_API_KEY"])
+    deadline = time.monotonic() + timeout_s
+    expected_keys = set(_SUMMARY_TABLE_KEYS) | set(_RENDERABLE_TABLE_KEYS) | {_HISTORY_TABLE_KEY}
+    last_summary: dict[str, Any] = {}
+
+    while time.monotonic() < deadline:
+        api_run = api.run(f"{entity}/{project}/{run_id}")
+        last_summary = dict(api_run.summary)
+        if expected_keys.issubset(last_summary):
+            return
+        time.sleep(2)
+
+    missing = sorted(expected_keys - set(last_summary))
+    raise AssertionError(f"Timed out waiting for table keys on run {run_id}. Missing: {missing}")
+
+
+def _report_layout_panels(
+    run_ids: tuple[str, ...],
+    *,
+    data_mode: str = "api-shape",
+) -> list[dict[str, Any]]:
+    if data_mode == "renderable":
+        return _renderable_report_layout_panels(run_ids)
+    return [
+        {"type": "heading", "level": 2, "text": "Average precision by class"},
+        {
+            "type": "markdown",
+            "text": "These custom Vega panels share one deterministic runset.",
+        },
+        {
+            "type": "panel_grid",
+            "run_ids": list(run_ids),
+            "hide_run_sets": False,
+            "panels": [
+                {
+                    "type": "custom_chart",
+                    "query": {"summaryTable": {"tableKey": "car_ap"}},
+                    "chart_name": "cruise/bar_chart/v2",
+                    "chart_fields": {"x": "threshold", "y": "ap"},
+                    "chart_strings": {"title": "CAR AP"},
+                },
+                {
+                    "type": "custom_chart",
+                    "query": {"summaryTable": {"tableKey": "truck_ap"}},
+                    "chart_name": "cruise/bar_chart/v2",
+                    "chart_fields": {"x": "threshold", "y": "ap"},
+                    "chart_strings": {"title": "TRUCK AP"},
+                },
+            ],
+        },
+        {"type": "heading", "level": 2, "text": "Precision-recall curve"},
+        {
+            "type": "markdown",
+            "text": "This panel uses a historyTable query for run-history data.",
+        },
+        {
+            "type": "panel_grid",
+            "run_ids": [run_ids[0]],
+            "hide_run_sets": True,
+            "panels": [
+                {
+                    "type": "custom_chart",
+                    "query": {"historyTable": {"tableKey": _HISTORY_TABLE_KEY}},
+                    "chart_name": "wandb/line/v0",
+                    "chart_fields": {"x": "r", "y": "p", "color": "c"},
+                    "chart_strings": {"title": "Precision-Recall Curve"},
+                }
+            ],
+        },
+    ]
+
+
+def _renderable_report_layout_panels(run_ids: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {"type": "heading", "level": 2, "text": "Renderable metric curves"},
+        {
+            "type": "markdown",
+            "text": "These built-in W&B line charts use known-good summary tables.",
+        },
+        {
+            "type": "panel_grid",
+            "run_ids": list(run_ids),
+            "hide_run_sets": False,
+            "panels": [
+                {
+                    "type": "custom_chart_table",
+                    "table_name": "loss_curve",
+                    "chart_name": "wandb/line/v0",
+                    "chart_fields": {"x": "step", "y": "loss"},
+                    "chart_strings": {"title": "Loss curve"},
+                },
+                {
+                    "type": "custom_chart_table",
+                    "table_name": "accuracy_curve",
+                    "chart_name": "wandb/line/v0",
+                    "chart_fields": {"x": "step", "y": "accuracy"},
+                    "chart_strings": {"title": "Accuracy curve"},
+                },
+            ],
+        },
+        {"type": "heading", "level": 2, "text": "Renderable PR curve"},
+        {
+            "type": "markdown",
+            "text": "This built-in W&B line chart uses a summary-table PR curve.",
+        },
+        {
+            "type": "panel_grid",
+            "run_ids": [run_ids[0]],
+            "hide_run_sets": True,
+            "panels": [
+                {
+                    "type": "custom_chart_table",
+                    "table_name": "pr_curve_table",
+                    "chart_name": "wandb/line/v0",
+                    "chart_fields": {"x": "recall", "y": "precision"},
+                    "chart_strings": {"title": "Precision-Recall Curve"},
+                }
+            ],
+        },
+    ]
+
+
+def _assert_report_model(
+    report_model: Any,
+    run_ids: tuple[str, ...],
+    *,
+    data_mode: str,
+) -> None:
+    report_json = report_model.model_dump_json(by_alias=True, exclude_none=True)
+    assert '"text":"Charts"' not in report_json
+    if data_mode == "renderable":
+        assert "Renderable metric curves" in report_json
+        assert "Renderable PR curve" in report_json
+    else:
+        assert "Average precision by class" in report_json
+        assert "Precision-recall curve" in report_json
+
+    panel_grids = [block for block in report_model.spec.blocks if getattr(block, "type", None) == "panel-grid"]
+    assert len(panel_grids) == 2
+
+    first_grid, second_grid = panel_grids
+    assert first_grid.metadata.hide_run_sets is False
+    assert second_grid.metadata.hide_run_sets is True
+    _assert_run_filter(first_grid.metadata.run_sets[0], list(run_ids))
+    _assert_run_filter(second_grid.metadata.run_sets[0], [run_ids[0]])
+
+    if data_mode == "renderable":
+        _assert_renderable_panel_grids(first_grid, second_grid)
+    else:
+        _assert_api_shape_panel_grids(first_grid, second_grid)
+
+
+def _assert_api_shape_panel_grids(first_grid: Any, second_grid: Any) -> None:
+    first_panels = first_grid.metadata.panel_bank_section_config.panels
+    assert len(first_panels) == 2
+    assert [panel.config.panel_def_id for panel in first_panels] == [
+        "cruise/bar_chart/v2",
+        "cruise/bar_chart/v2",
+    ]
+    assert [panel.config.field_settings for panel in first_panels] == [
+        {"x": "threshold", "y": "ap"},
+        {"x": "threshold", "y": "ap"},
+    ]
+    assert [panel.config.string_settings["title"] for panel in first_panels] == [
+        "CAR AP",
+        "TRUCK AP",
+    ]
+    first_panel_json = first_grid.model_dump_json(by_alias=True, exclude_none=True)
+    assert "summaryTable" in first_panel_json
+    assert "car_ap" in first_panel_json
+    assert "truck_ap" in first_panel_json
+
+    second_panels = second_grid.metadata.panel_bank_section_config.panels
+    assert len(second_panels) == 1
+    pr_panel = second_panels[0]
+    assert pr_panel.config.panel_def_id == "wandb/line/v0"
+    assert pr_panel.config.field_settings == {"x": "r", "y": "p", "color": "c"}
+    assert pr_panel.config.string_settings["title"] == "Precision-Recall Curve"
+    second_panel_json = second_grid.model_dump_json(
+        by_alias=True,
+        exclude_none=True,
+    )
+    assert "historyTable" in second_panel_json
+    assert _HISTORY_TABLE_KEY in second_panel_json
+
+
+def _assert_renderable_panel_grids(first_grid: Any, second_grid: Any) -> None:
+    first_panels = first_grid.metadata.panel_bank_section_config.panels
+    assert len(first_panels) == 2
+    assert [panel.config.panel_def_id for panel in first_panels] == [
+        "wandb/line/v0",
+        "wandb/line/v0",
+    ]
+    assert [panel.config.field_settings for panel in first_panels] == [
+        {"x": "step", "y": "loss"},
+        {"x": "step", "y": "accuracy"},
+    ]
+    assert [panel.config.string_settings["title"] for panel in first_panels] == [
+        "Loss curve",
+        "Accuracy curve",
+    ]
+    first_panel_json = first_grid.model_dump_json(by_alias=True, exclude_none=True)
+    assert "summaryTable" in first_panel_json
+    assert "loss_curve" in first_panel_json
+    assert "accuracy_curve" in first_panel_json
+
+    second_panels = second_grid.metadata.panel_bank_section_config.panels
+    assert len(second_panels) == 1
+    pr_panel = second_panels[0]
+    assert pr_panel.config.panel_def_id == "wandb/line/v0"
+    assert pr_panel.config.field_settings == {"x": "recall", "y": "precision"}
+    assert pr_panel.config.string_settings["title"] == "Precision-Recall Curve"
+    second_panel_json = second_grid.model_dump_json(
+        by_alias=True,
+        exclude_none=True,
+    )
+    assert "summaryTable" in second_panel_json
+    assert "pr_curve_table" in second_panel_json
+
+
+def _assert_run_filter(runset: Any, expected_run_ids: list[str]) -> None:
+    assert runset.search.query == ""
+    nodes = list(_iter_filter_nodes(runset.filters))
+    expected_op = "=" if len(expected_run_ids) == 1 else "IN"
+    expected_value: str | list[str] = expected_run_ids[0] if len(expected_run_ids) == 1 else expected_run_ids
+    assert any(
+        node.get("key") == {"section": "run", "name": "name"}
+        and node.get("op") == expected_op
+        and node.get("value") == expected_value
+        for node in nodes
+    )
+
+
+def _iter_filter_nodes(node: Any):
+    if isinstance(node, dict):
+        yield node
+        for child in node.get("filters", []):
+            yield from _iter_filter_nodes(child)
+        return
+
+    filters = getattr(node, "filters", None)
+    if filters:
+        for child in filters:
+            yield from _iter_filter_nodes(child)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", help="Optional explicit .env file path.")
+    parser.add_argument("--entity", help="W&B entity for live verification.")
+    parser.add_argument("--project", help="W&B project for live verification.")
+    parser.add_argument(
+        "--data-mode",
+        choices=_DATA_MODES,
+        default=None,
+        help=(
+            "api-shape validates customer-style custom query shapes; "
+            "renderable uses known-good built-in W&B line charts."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    settings = resolve_settings(
+        explicit_env_file=args.env_file,
+        entity=args.entity,
+        project=args.project,
+        data_mode=args.data_mode,
+    )
+    loaded = ", ".join(str(path) for path in settings.loaded_env_files) or "none"
+    print(f"Loaded env files: {loaded}")
+    print(f"Using W&B target: {settings.entity}/{settings.project}")
+    print(f"Using data mode: {settings.data_mode}")
+    result = run_live_report_layout_verification(settings)
+    print(f"Report URL: {result.report_url}")
+    print(f"Seeded run IDs: {', '.join(result.run_ids)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -121,7 +121,8 @@ Args:
         - {"type": "panel_grid", "run_ids": ["run_a", "run_b"], "hide_run_sets": false,
            "panels": [{...chart panel...}, {...chart panel...}]}
           Creates one PanelGrid whose child panels share a single Runset.
-        Use custom_chart_table for PR curves, ROC curves, confusion matrices, and other table-backed Vega charts.
+        Use custom_chart_table for summary-table-backed charts. Use custom_chart with an explicit historyTable
+        query for PR/ROC curves or other charts logged through run history.
         If panels only contains chart specs, the tool appends them under a Charts heading for backward compatibility.
         If panels contains heading, markdown, or panel_grid blocks, the list is treated as an ordered layout and no
         automatic Charts heading is added. If omitted, report is markdown-only.
@@ -132,9 +133,9 @@ Use native panel types for ordinary run metrics:
 - bar: summary metric comparisons
 - scatter: two summary/config fields
 
-Use custom_chart_table when the source data already exists as a W&B Table or
-summary table key. This is the preferred path for precision/recall curves,
-ROC curves, confusion matrices, and table-backed customer visualizations:
+Use custom_chart_table when the source data already exists as a W&B Table saved
+in run summary. This is the preferred path for final confusion matrices,
+per-class AP tables, and other one-snapshot table-backed visualizations:
 {
   "type": "custom_chart_table",
   "title": "Precision-Recall Curve",
@@ -151,6 +152,19 @@ Use custom_chart only when you know the exact wandb-workspaces query shape:
   "query": {"summaryTable": {"tableKey": "pr_curve_table"}},
   "chart_name": "wandb/line/v0",
   "chart_fields": {"x": "recall", "y": "precision"},
+  "chart_strings": {"title": "Precision-Recall Curve"},
+  "run_ids": ["abc123"],
+  "hide_run_sets": true
+}
+
+For PR curves, ROC curves, and other charts logged through run history, use an
+explicit historyTable query. tableKey is the key passed to run.log(), not a
+column name inside the table:
+{
+  "type": "custom_chart",
+  "query": {"historyTable": {"tableKey": "pr_curve"}},
+  "chart_name": "wandb/line/v0",
+  "chart_fields": {"x": "r", "y": "p", "color": "c"},
   "chart_strings": {"title": "Precision-Recall Curve"},
   "run_ids": ["abc123"],
   "hide_run_sets": true
@@ -188,8 +202,8 @@ Runset scoping:
 
 <manual_validation_recipe>
 To validate a table-backed custom chart manually:
-1. Pick a run that has a logged W&B Table or summary table key, such as a PR or ROC curve table.
-2. Call create_wandb_report_tool with a custom_chart_table panel using that table_name.
+1. Pick a run that has a logged W&B Table key, such as a summary table or PR/ROC history table.
+2. Call create_wandb_report_tool with custom_chart_table for summary tables or custom_chart with historyTable for PR/ROC curves.
 3. Open the returned report URL and confirm the custom Vega chart renders.
 4. If the chart does not render, verify the table_name and chart_fields match the table columns and UI chart config.
 </manual_validation_recipe>

--- a/tests/test_create_report_panels.py
+++ b/tests/test_create_report_panels.py
@@ -28,6 +28,14 @@ class TestCreateReportPanelsDescription:
         assert "<when_to_use>" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
         assert "</when_to_use>" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
 
+    def test_layout_and_history_table_documented(self):
+        description = CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "panel_grid" in description
+        assert "heading" in description
+        assert "markdown" in description
+        assert "historyTable" in description
+        assert "run_ids are converted to deterministic Reports v2 filters" in description
+
 
 class TestBuildPanelBlocks:
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
@@ -194,6 +202,35 @@ class TestBuildPanelBlocks:
             chart_strings={"title": "PR Curve"},
         )
         mock_wr.PanelGrid.assert_called_once_with(runsets=["Runset"], hide_run_sets=True, panels=["CustomChart"])
+
+    @patch("wandb_mcp_server.mcp_tools.create_report.wr")
+    def test_custom_chart_history_table_query(self, mock_wr):
+        mock_wr.PanelGrid = MagicMock()
+        mock_wr.CustomChart = MagicMock(return_value="CustomChart")
+        mock_wr.Runset = MagicMock(return_value="Runset")
+
+        panels = [
+            {
+                "type": "custom_chart",
+                "title": "PR Curve",
+                "query": {"historyTable": {"tableKey": "pr_curve"}},
+                "chart_name": "wandb/line/v0",
+                "chart_fields": {"x": "r", "y": "p", "color": "c"},
+                "chart_strings": {"title": "Precision-Recall Curve"},
+                "run_ids": ["abc123"],
+                "hide_run_sets": True,
+            }
+        ]
+
+        blocks = _build_panel_blocks(panels, "entity", "project")
+
+        assert len(blocks) == 1
+        mock_wr.CustomChart.assert_called_once_with(
+            query={"historyTable": {"tableKey": "pr_curve"}},
+            chart_name="wandb/line/v0",
+            chart_fields={"x": "r", "y": "p", "color": "c"},
+            chart_strings={"title": "Precision-Recall Curve"},
+        )
 
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     def test_custom_chart_table_panel(self, mock_wr):

--- a/tests/test_report_layout_live.py
+++ b/tests/test_report_layout_live.py
@@ -1,0 +1,189 @@
+"""Opt-in live tests for MCP report layout creation.
+
+These tests hit W&B. They are skipped unless `MCP_REPORT_LIVE=1` is set.
+The harness loads `.env` files before checking credentials, so local runs can
+use the same env files as manual MCP validation.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import scripts.report_layout_live_harness as harness
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_env_file_candidates_deduplicates_explicit_path(tmp_path, monkeypatch):
+    """The explicit .env path is first and duplicate paths are removed."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("WANDB_API_KEY=test-key\n")
+    monkeypatch.chdir(tmp_path)
+
+    candidates = harness.env_file_candidates(str(env_file))
+
+    assert candidates[0] == env_file.resolve()
+    assert len(candidates) == len(set(candidates))
+
+
+def test_load_harness_env_does_not_override_existing_shell_env(
+    tmp_path,
+    monkeypatch,
+):
+    """Shell env wins over .env values so callers can override safely."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("WANDB_API_KEY=from-file\nMCP_REPORT_TEST_ENTITY=file-entity\n")
+    monkeypatch.setenv("WANDB_API_KEY", "from-shell")
+    monkeypatch.delenv("MCP_REPORT_TEST_ENTITY", raising=False)
+
+    loaded = harness.load_harness_env(str(env_file))
+
+    assert env_file.resolve() in loaded
+    assert os.environ["WANDB_API_KEY"] == "from-shell"
+    assert os.environ["MCP_REPORT_TEST_ENTITY"] == "file-entity"
+
+
+def test_resolve_settings_prefers_explicit_entity_and_project(monkeypatch):
+    """Explicit CLI-style args should win over .env-derived values."""
+    monkeypatch.setenv("WANDB_API_KEY", "test-key")
+    monkeypatch.setenv("MCP_REPORT_TEST_ENTITY", "env-entity")
+    monkeypatch.setenv("MCP_REPORT_TEST_PROJECT", "env-project")
+
+    settings = harness.resolve_settings(
+        entity="arg-entity",
+        project="arg-project",
+    )
+
+    assert settings.entity == "arg-entity"
+    assert settings.project == "arg-project"
+    assert settings.api_key == "test-key"
+    assert settings.data_mode == "api-shape"
+
+
+def test_resolve_settings_accepts_renderable_data_mode(monkeypatch):
+    """The harness can be switched to known-good visual render data."""
+    monkeypatch.setenv("WANDB_API_KEY", "test-key")
+    monkeypatch.setenv("MCP_REPORT_TEST_ENTITY", "env-entity")
+    monkeypatch.setenv("MCP_REPORT_TEST_PROJECT", "env-project")
+
+    settings = harness.resolve_settings(data_mode="renderable")
+
+    assert settings.data_mode == "renderable"
+
+
+def test_resolve_settings_rejects_unknown_data_mode(monkeypatch):
+    """Invalid data modes fail before seeding live runs."""
+    monkeypatch.setenv("WANDB_API_KEY", "test-key")
+    monkeypatch.setenv("MCP_REPORT_TEST_ENTITY", "env-entity")
+    monkeypatch.setenv("MCP_REPORT_TEST_PROJECT", "env-project")
+
+    with pytest.raises(RuntimeError, match="data_mode must be one of"):
+        harness.resolve_settings(data_mode="unknown")
+
+
+def test_resolve_settings_requires_api_key(monkeypatch):
+    """Missing credentials fail before any W&B network call is attempted."""
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    monkeypatch.setattr(harness, "env_file_candidates", lambda *_: [])
+
+    with pytest.raises(RuntimeError, match="WANDB_API_KEY is required"):
+        harness.resolve_settings(entity="entity", project="project")
+
+
+def test_report_layout_panels_cover_summary_and_history_tables():
+    """The harness payload covers both summaryTable and historyTable paths."""
+    panels = harness._report_layout_panels(
+        ("run_a", "run_b"),
+        data_mode="api-shape",
+    )
+
+    assert [panel["type"] for panel in panels] == [
+        "heading",
+        "markdown",
+        "panel_grid",
+        "heading",
+        "markdown",
+        "panel_grid",
+    ]
+    first_grid = panels[2]
+    second_grid = panels[5]
+
+    assert first_grid["run_ids"] == ["run_a", "run_b"]
+    assert first_grid["hide_run_sets"] is False
+    assert len(first_grid["panels"]) == 2
+    assert all("summaryTable" in child["query"] for child in first_grid["panels"])
+    assert {child["chart_name"] for child in first_grid["panels"]} == {
+        "cruise/bar_chart/v2",
+    }
+
+    assert second_grid["run_ids"] == ["run_a"]
+    assert second_grid["hide_run_sets"] is True
+    assert len(second_grid["panels"]) == 1
+    assert "historyTable" in second_grid["panels"][0]["query"]
+
+
+def test_renderable_report_layout_panels_use_known_good_chart_tables():
+    """Renderable mode uses built-in W&B line chart definitions."""
+    panels = harness._report_layout_panels(
+        ("run_a", "run_b"),
+        data_mode="renderable",
+    )
+
+    first_grid = panels[2]
+    second_grid = panels[5]
+
+    assert first_grid["run_ids"] == ["run_a", "run_b"]
+    assert first_grid["hide_run_sets"] is False
+    assert [child["type"] for child in first_grid["panels"]] == [
+        "custom_chart_table",
+        "custom_chart_table",
+    ]
+    assert {child["chart_name"] for child in first_grid["panels"]} == {
+        "wandb/line/v0",
+    }
+    assert [child["table_name"] for child in first_grid["panels"]] == [
+        "loss_curve",
+        "accuracy_curve",
+    ]
+
+    assert second_grid["run_ids"] == ["run_a"]
+    assert second_grid["hide_run_sets"] is True
+    assert second_grid["panels"][0]["table_name"] == "pr_curve_table"
+
+
+def test_assert_run_filter_accepts_filter_v2_dict():
+    """Filter assertions work against serialized filterV2 dictionaries."""
+    runset = SimpleNamespace(
+        search=SimpleNamespace(query=""),
+        filters={
+            "filterFormat": "filterV2",
+            "filters": [
+                {
+                    "key": {"section": "run", "name": "name"},
+                    "op": "IN",
+                    "value": ["run_a", "run_b"],
+                }
+            ],
+        },
+    )
+
+    harness._assert_run_filter(runset, ["run_a", "run_b"])
+
+
+def test_live_report_layout_harness_creates_expected_report():
+    """Create, reload, and validate a full report layout in W&B."""
+    if os.getenv("MCP_REPORT_LIVE") != "1":
+        pytest.skip("Set MCP_REPORT_LIVE=1 to run live W&B report layout tests.")
+
+    settings = harness.resolve_settings(
+        explicit_env_file=os.getenv("MCP_REPORT_TEST_ENV_FILE"),
+    )
+    result = harness.run_live_report_layout_verification(settings)
+
+    assert result.report_url.startswith("https://")
+    assert f"/{result.entity}/{result.project}/reports/" in result.report_url
+    assert len(result.run_ids) == 2

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -88,3 +88,18 @@ class TestPanelsInCreateReport:
 
     def test_bar_type_documented(self):
         assert "bar" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION.lower()
+
+    def test_layout_types_documented(self):
+        assert "panel_grid" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "heading" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "markdown" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+
+    def test_custom_chart_sources_documented(self):
+        assert "custom_chart" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "custom_chart_table" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "summaryTable" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "historyTable" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+
+    def test_run_filtering_documented(self):
+        assert "run_ids are converted to deterministic Reports v2 filters" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION
+        assert "filters may be passed as a Reports v2 expression string" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION


### PR DESCRIPTION
## Summary
- Adds full report layout support for `create_wandb_report_tool` with ordered `heading`, `markdown`, and `panel_grid` blocks.
- Lets multiple native/custom Vega panels share one `PanelGrid` and one deterministic `Runset`.
- Documents and tests `summaryTable` and `historyTable` custom chart workflows for PR/ROC and table-backed reports.

## Customer Context
Zendesk Case ID 115897 requested better W&B MCP support for custom Vega P/R curve reports. The prior custom chart primitive worked, but agents still fell back to Python because MCP could not assemble full report layouts with shared runsets and interleaved narrative sections.

This closes the customer-reported gaps:
- Multi-panel `PanelGrid` support.
- Interleaved H2 / markdown / panel-grid sections.
- Deterministic `run_ids` filtering through Reports v2 filters instead of fuzzy search queries.

## Changes
- Refactors report panel assembly in `src/wandb_mcp_server/mcp_tools/create_report.py` around panel objects and layout blocks.
- Adds exact run filtering with `name == ...` and `name in [...]` Reports v2 filters.
- Adds tool-description guidance for arbitrary Vega `chart_name` values, `summaryTable`, `historyTable`, `custom_chart_table`, and shared panel grids.
- Adds a live report layout harness with `api-shape` and `renderable` data modes.
- Adds unit and serialization-style coverage for layout ordering, shared runsets, custom Vega panels, filter serialization, and harness behavior.

## Live Validation
API-shape report:
https://wandb.ai/a-sh0ts/mcp-logs/reports/MCP-report-layout-live-verification-1780937429--VmlldzoxNzE2MTg2MQ==

Renderable report:
https://wandb.ai/a-sh0ts/mcp-logs/reports/MCP-report-layout-renderable-verification-1780937800--VmlldzoxNzE2MTkxNA==

## Test Plan
- `uv run pytest tests/test_create_report_panels.py tests/test_report_improvements.py tests/test_markdown_parsing.py tests/test_tool_descriptions.py tests/test_report_layout_live.py -v`
- `uv run ruff check src/ tests/ scripts/report_layout_live_harness.py`
- `uv run ruff format --check src/ tests/ scripts/report_layout_live_harness.py`
- `uv build`
- `uv run python scripts/report_layout_live_harness.py --env-file "/Users/anishshah/Documents/Manual Library/GitHub/WandBAgentFactory/.env" --data-mode renderable`

## Staging Notes
This targets `staging/0.3.6`. PR #96 should merge before this PR because it supersedes #90 and also touches README/dependency metadata. If #96 lands first, this PR should be updated against the new staging head before merge.


Made with [Cursor](https://cursor.com)