### PR TITLE
chore(release): bump version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wandb_mcp_server"
-version = "0.3.5"
+version = "0.3.6"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",

--- a/src/wandb_mcp_server/__init__.py
+++ b/src/wandb_mcp_server/__init__.py
@@ -4,7 +4,7 @@ Weave MCP Server
 A Model Context Protocol server for Weave traces.
 """
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 # Import the functions we want to expose
 from .server import cli

--- a/uv.lock
+++ b/uv.lock
@@ -2161,7 +2161,7 @@ workspaces = [
 
 [[package]]
 name = "wandb-mcp-server"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bumps package metadata from 0.3.5 to 0.3.6 for the staging release branch.
- Updates `uv.lock` to match the local package version.

## Test Plan
- `uv run python - <<'PY'
import wandb_mcp_server
print(wandb_mcp_server.__version__)
PY`

Printed `0.3.6`.


Made with [Cursor](https://cursor.com)