### PR TITLE
feat: add MCP harness analytics dimensions

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -205,6 +205,48 @@ prompts, descriptions, report text, and messages are redacted to
 Only use `MCP_DATADOG_PARAM_PRIVACY_LEVEL=off` for short-lived debugging in a
 controlled environment. Do not set it as a production default.
 
+## MCP client harness dimensions
+
+Hosted MCP analytics include a small client dimension for Datadog incident
+analysis and Hex adoption analysis. These fields are derived from allowlisted MCP
+signals such as `initialize.params.clientInfo`, session metadata, and
+`User-Agent` fallback. They are untrusted analytics dimensions only and must not
+be used for authentication, authorization, rate-limit bypasses, or protocol
+branching.
+
+Default fields:
+
+| Field | Purpose |
+|---|---|
+| `mcp_client_family` | Broad client bucket, such as `claude`, `cursor`, `openai`, `mistral`, `gemini`, `linear`, or `unknown`. |
+| `mcp_client_app` | More specific client bucket, such as `claude_code`, `codex_cli`, `cursor`, `lechat`, or `gemini_cli`. |
+| `mcp_client_source` | Signal used for classification: `initialize_client_info`, `meta_client_info`, `session_metadata`, `user_agent`, or `unknown`. |
+| `mcp_protocol_version` | MCP protocol version observed on the request. |
+| `mcp_jsonrpc_method` | JSON-RPC method such as `initialize`, `tools.list`, or `tools.call`. |
+
+Debug-only fields such as raw-ish client names, versions, and user-agent product
+tokens are disabled by default. If enabled for classifier maintenance, they must
+remain sampled, bounded, and excluded from Datadog tags and default Hex
+dashboards.
+
+Recommended Datadog views:
+
+- Request error rate by `mcp_client_app`.
+- Tool error rate by `mcp_client_app` and `tool_name`.
+- p95 latency by `mcp_client_app` and `tool_name`.
+- Unknown-client rate by `mcp_client_source`.
+- Initialize failures by `mcp_protocol_version` and `mcp_client_app`.
+
+Recommended Hex analyses:
+
+- Daily active users, sessions, and tool calls by `mcp_client_family` and
+  `mcp_client_app`.
+- Tool adoption and tool mix by client app.
+- Success rate, error rate, and latency by client app and tool.
+- Initialize to tools/list to tools/call funnel health by client app.
+- Unknown-client coverage and classifier candidates.
+- Release-over-release regressions by client app and `release_version`.
+
 ### Identifier hashing at `strict`
 
 `<h:sha256_prefix>` uses the first 12 hex chars of `sha256(value)`.

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -346,6 +346,19 @@ def _deployment_context() -> Dict[str, Any]:
     return context
 
 
+def _harness_context() -> Dict[str, Any]:
+    """Return the current request's low-cardinality MCP harness dimensions."""
+    try:
+        from wandb_mcp_server.harness import current_harness_context
+
+        context = current_harness_context.get()
+        if context is None:
+            return {}
+        return context.analytics_fields()
+    except Exception:
+        return {}
+
+
 class AnalyticsTracker:
     """Emit structured analytics events for the MCP server.
 
@@ -491,6 +504,7 @@ class AnalyticsTracker:
             "timestamp": _utcnow_iso(),
             "release_version": _resolve_release_version(),
             **_deployment_context(),
+            **_harness_context(),
         }
         deployment_id = os.environ.get("MCP_DEPLOYMENT_ID")
         if deployment_id:

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -71,7 +71,17 @@ def _datadog_safe_params(event: Dict[str, Any]) -> Dict[str, Any]:
 def _datadog_safe_labels(event: Dict[str, Any]) -> Dict[str, str]:
     """Return low-cardinality labels safe for Datadog attributes."""
     labels: Dict[str, str] = {"event_type": str(event.get("event_type", "unknown"))}
-    for key in ("tool_name", "mcp_tool_name", "success", "runtime_surface", "transport", "deployment_type"):
+    for key in (
+        "tool_name",
+        "mcp_tool_name",
+        "success",
+        "runtime_surface",
+        "transport",
+        "deployment_type",
+        "mcp_client_family",
+        "mcp_client_app",
+        "mcp_client_source",
+    ):
         value = event.get(key)
         if value is not None:
             labels[key] = str(value)
@@ -115,6 +125,10 @@ def map_to_datadog_log(
         f"event_type:{event_type}",
     ]
     for key in ("runtime_surface", "transport", "deployment_type", "environment"):
+        value = event.get(key)
+        if value is not None:
+            tags.append(f"{key}:{value}")
+    for key in ("mcp_client_family", "mcp_client_app", "mcp_client_source"):
         value = event.get(key)
         if value is not None:
             tags.append(f"{key}:{value}")
@@ -166,6 +180,31 @@ def map_to_datadog_log(
             http_attrs["url_details"] = {"path": event["path"]}
         if http_attrs:
             attributes["http"] = http_attrs
+
+    mcp_client_attrs: Dict[str, Any] = {}
+    for event_key, attr_key in (
+        ("mcp_client_family", "family"),
+        ("mcp_client_app", "app"),
+        ("mcp_client_source", "source"),
+    ):
+        value = event.get(event_key)
+        if value is not None:
+            mcp_client_attrs[attr_key] = value
+    mcp_protocol_attrs: Dict[str, Any] = {}
+    for event_key, attr_key in (
+        ("mcp_protocol_version", "version"),
+        ("mcp_jsonrpc_method", "jsonrpc_method"),
+    ):
+        value = event.get(event_key)
+        if value is not None:
+            mcp_protocol_attrs[attr_key] = value
+    if mcp_client_attrs or mcp_protocol_attrs:
+        mcp_attrs: Dict[str, Any] = {}
+        if mcp_client_attrs:
+            mcp_attrs["client"] = mcp_client_attrs
+        if mcp_protocol_attrs:
+            mcp_attrs["protocol"] = mcp_protocol_attrs
+        attributes["mcp"] = mcp_attrs
 
     error_str = event.get("error")
     if error_str:

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -60,6 +60,11 @@ _BASE_PROPERTY_KEYS: List[str] = [
     "environment",
     "hosted_mode",
     "wandb_base_host",
+    "mcp_client_family",
+    "mcp_client_app",
+    "mcp_client_source",
+    "mcp_protocol_version",
+    "mcp_jsonrpc_method",
 ]
 
 _TOOL_CALL_PROPERTY_KEYS: List[str] = [

--- a/src/wandb_mcp_server/harness.py
+++ b/src/wandb_mcp_server/harness.py
@@ -1,0 +1,309 @@
+"""MCP client harness classification for analytics.
+
+The values produced here are intentionally low-cardinality and untrusted.
+They are for product analytics and operational debugging only.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+_SAFE_RE = re.compile(r"^[a-z0-9_.-]{1,64}$")
+_UNSAFE_CHARS_RE = re.compile(r"[^a-z0-9_.-]+")
+_MAX_DEBUG_FIELD_LENGTH = 64
+
+_DEFAULT_CLIENT_FAMILY = "unknown"
+_DEFAULT_CLIENT_APP = "unknown"
+_DEFAULT_CLIENT_SOURCE = "unknown"
+_DEFAULT_CONFIDENCE = "low"
+
+_DEBUG_FIELDS_ENV = "MCP_HARNESS_DEBUG_FIELDS"
+
+
+@dataclass(frozen=True)
+class HarnessContext:
+    """Low-cardinality MCP client context for analytics events."""
+
+    mcp_client_family: str = _DEFAULT_CLIENT_FAMILY
+    mcp_client_app: str = _DEFAULT_CLIENT_APP
+    mcp_client_source: str = _DEFAULT_CLIENT_SOURCE
+    mcp_protocol_version: str = "unknown"
+    mcp_jsonrpc_method: str = "unknown"
+    mcp_client_name: str = ""
+    mcp_client_version: str = ""
+    mcp_user_agent_product: str = ""
+    mcp_client_confidence: str = _DEFAULT_CONFIDENCE
+    mcp_client_mismatch: str = ""
+
+    def default_fields(self) -> dict[str, str]:
+        """Return fields safe for default analytics sinks."""
+        return {
+            "mcp_client_family": self.mcp_client_family,
+            "mcp_client_app": self.mcp_client_app,
+            "mcp_client_source": self.mcp_client_source,
+            "mcp_protocol_version": self.mcp_protocol_version,
+            "mcp_jsonrpc_method": self.mcp_jsonrpc_method,
+        }
+
+    def debug_fields(self) -> dict[str, str]:
+        """Return bounded fields useful for temporary classifier debugging."""
+        fields = {
+            "mcp_client_name": self.mcp_client_name,
+            "mcp_client_version": self.mcp_client_version,
+            "mcp_user_agent_product": self.mcp_user_agent_product,
+            "mcp_client_confidence": self.mcp_client_confidence,
+            "mcp_client_mismatch": self.mcp_client_mismatch,
+        }
+        return {key: value for key, value in fields.items() if value}
+
+    def analytics_fields(
+        self,
+        *,
+        include_debug: bool | None = None,
+    ) -> dict[str, str]:
+        """Return harness fields for analytics events."""
+        fields = self.default_fields()
+        if include_debug is None:
+            include_debug = _env_bool(_DEBUG_FIELDS_ENV)
+        if include_debug:
+            fields.update(self.debug_fields())
+        return fields
+
+    def session_metadata(self) -> dict[str, str]:
+        """Return normalized fields safe to persist in per-session metadata."""
+        return self.default_fields()
+
+
+current_harness_context: ContextVar[HarnessContext | None] = ContextVar(
+    "mcp_harness_context",
+    default=None,
+)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _sanitize_value(value: object, *, default: str = "unknown") -> str:
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    text = text.replace("/", ".")
+    text = _UNSAFE_CHARS_RE.sub(".", text).strip(".")
+    if not _SAFE_RE.match(text):
+        return default
+    return text[:_MAX_DEBUG_FIELD_LENGTH]
+
+
+def _debug_value(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().lower()
+    if not text:
+        return ""
+    text = text.replace("/", ".")
+    text = _UNSAFE_CHARS_RE.sub(".", text).strip(".")
+    if not text:
+        return ""
+    return text[:_MAX_DEBUG_FIELD_LENGTH]
+
+
+def _header(headers: Mapping[str, str] | None, name: str) -> str:
+    if not headers:
+        return ""
+    lowered = name.lower()
+    for key, value in headers.items():
+        if key.lower() == lowered:
+            return str(value).strip()
+    return ""
+
+
+def _first_user_agent_product(user_agent: str) -> str:
+    if not user_agent:
+        return ""
+    return _debug_value(user_agent.split()[0])
+
+
+def _nested_dict(value: Any, key: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    child = value.get(key)
+    return child if isinstance(child, dict) else {}
+
+
+def _client_info_from_meta(
+    params: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    meta = _nested_dict(params, "_meta")
+    client_info = meta.get("io.modelcontextprotocol/clientInfo")
+    if isinstance(client_info, dict):
+        return client_info, "meta_client_info"
+    return {}, ""
+
+
+def _protocol_from_meta(params: dict[str, Any]) -> str:
+    meta = _nested_dict(params, "_meta")
+    return _sanitize_value(meta.get("io.modelcontextprotocol/protocolVersion"))
+
+
+def _classify_client(value: object) -> tuple[str, str]:
+    text = str(value or "").lower()
+    if not text:
+        return _DEFAULT_CLIENT_FAMILY, _DEFAULT_CLIENT_APP
+    if "wandb-mcp-load-test" in text or "compatibility-check" in text or "load_test" in text:
+        return "load_test", "load_test"
+    if "linear" in text:
+        return "linear", "linear_agent"
+    if "mistral" in text or "lechat" in text or "le-chat" in text:
+        return "mistral", "lechat"
+    if "claude-code" in text or ("claude" in text and "code" in text):
+        return "claude", "claude_code"
+    if "claude-desktop" in text or ("claude" in text and "desktop" in text):
+        return "claude", "claude_desktop"
+    if "claude" in text or "anthropic" in text:
+        return "claude", "claude"
+    if "codex" in text:
+        return "openai", "codex_cli"
+    if "openai" in text or "chatgpt" in text:
+        return "openai", "openai_responses"
+    if "cursor" in text:
+        return "cursor", "cursor"
+    if "gemini" in text:
+        return "gemini", "gemini_cli"
+    if "vscode" in text or "visual-studio-code" in text:
+        return "vscode", "vscode"
+    return _DEFAULT_CLIENT_FAMILY, _DEFAULT_CLIENT_APP
+
+
+def _context_from_client_info(
+    *,
+    client_info: dict[str, Any],
+    source: str,
+    protocol_version: str,
+    jsonrpc_method: str,
+    user_agent_product: str,
+) -> HarnessContext:
+    name = _debug_value(client_info.get("name"))
+    version = _debug_value(client_info.get("version"))
+    family, app = _classify_client(name)
+    return HarnessContext(
+        mcp_client_family=family,
+        mcp_client_app=app,
+        mcp_client_source=source,
+        mcp_protocol_version=protocol_version,
+        mcp_jsonrpc_method=jsonrpc_method,
+        mcp_client_name=name,
+        mcp_client_version=version,
+        mcp_user_agent_product=user_agent_product,
+        mcp_client_confidence="high" if family != "unknown" else "low",
+    )
+
+
+def _context_from_session_metadata(
+    *,
+    session_metadata: Mapping[str, Any],
+    protocol_version: str,
+    jsonrpc_method: str,
+    user_agent_product: str,
+    mismatch: str = "",
+) -> HarnessContext:
+    return HarnessContext(
+        mcp_client_family=_sanitize_value(session_metadata.get("mcp_client_family")),
+        mcp_client_app=_sanitize_value(session_metadata.get("mcp_client_app")),
+        mcp_client_source="session_metadata",
+        mcp_protocol_version=protocol_version,
+        mcp_jsonrpc_method=jsonrpc_method,
+        mcp_user_agent_product=user_agent_product,
+        mcp_client_confidence="high",
+        mcp_client_mismatch=mismatch,
+    )
+
+
+def _context_from_user_agent(
+    *,
+    user_agent: str,
+    protocol_version: str,
+    jsonrpc_method: str,
+) -> HarnessContext:
+    product = _first_user_agent_product(user_agent)
+    family, app = _classify_client(user_agent)
+    return HarnessContext(
+        mcp_client_family=family,
+        mcp_client_app=app,
+        mcp_client_source="user_agent" if user_agent else "unknown",
+        mcp_protocol_version=protocol_version,
+        mcp_jsonrpc_method=jsonrpc_method,
+        mcp_user_agent_product=product,
+        mcp_client_confidence="medium" if family != "unknown" else "low",
+    )
+
+
+def extract_harness_context(
+    headers: Mapping[str, str] | None,
+    body_json: Mapping[str, Any] | None = None,
+    session_metadata: Mapping[str, Any] | None = None,
+) -> HarnessContext:
+    """Extract safe MCP client context from allowlisted request signals."""
+    body = body_json if isinstance(body_json, Mapping) else {}
+    params = body.get("params") if isinstance(body.get("params"), dict) else {}
+    method = _sanitize_value(body.get("method"))
+    protocol_version = _sanitize_value(params.get("protocolVersion")) if params else _DEFAULT_CLIENT_SOURCE
+    if protocol_version == "unknown" and params:
+        protocol_version = _protocol_from_meta(params)
+    if protocol_version == "unknown":
+        protocol_version = _sanitize_value(_header(headers, "MCP-Protocol-Version"))
+
+    user_agent = _header(headers, "User-Agent")
+    user_agent_product = _first_user_agent_product(user_agent)
+
+    if method != "initialize" and session_metadata:
+        meta_client_info, _ = _client_info_from_meta(params)
+        mismatch = ""
+        if meta_client_info:
+            _, meta_app = _classify_client(meta_client_info.get("name"))
+            session_app = _sanitize_value(session_metadata.get("mcp_client_app"))
+            if meta_app != "unknown" and session_app != "unknown" and meta_app != session_app:
+                mismatch = "client_info"
+        return _context_from_session_metadata(
+            session_metadata=session_metadata,
+            protocol_version=protocol_version,
+            jsonrpc_method=method,
+            user_agent_product=user_agent_product,
+            mismatch=mismatch,
+        )
+
+    if method == "initialize":
+        meta_client_info, meta_source = _client_info_from_meta(params)
+        if meta_client_info:
+            return _context_from_client_info(
+                client_info=meta_client_info,
+                source=meta_source,
+                protocol_version=protocol_version,
+                jsonrpc_method=method,
+                user_agent_product=user_agent_product,
+            )
+        raw_client_info = params.get("clientInfo")
+        client_info = raw_client_info if isinstance(raw_client_info, dict) else {}
+        if client_info:
+            return _context_from_client_info(
+                client_info=client_info,
+                source="initialize_client_info",
+                protocol_version=protocol_version,
+                jsonrpc_method=method,
+                user_agent_product=user_agent_product,
+            )
+
+    return _context_from_user_agent(
+        user_agent=user_agent,
+        protocol_version=protocol_version,
+        jsonrpc_method=method,
+    )

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -22,6 +22,7 @@ from wandb_mcp_server.analytics import (
     get_analytics_tracker,
     reset_analytics_tracker,
 )
+from wandb_mcp_server.harness import HarnessContext, current_harness_context
 
 
 @pytest.fixture(autouse=True)
@@ -550,6 +551,62 @@ class TestTrackRequest:
         assert e["path"] == "/mcp/sse"
         assert e["status_code"] == 200
         assert e["duration_ms"] == 55.0
+
+    def test_event_includes_default_harness_fields(self, capture):
+        context = HarnessContext(
+            mcp_client_family="claude",
+            mcp_client_app="claude_code",
+            mcp_client_source="initialize_client_info",
+            mcp_protocol_version="2025-06-18",
+            mcp_jsonrpc_method="tools.call",
+            mcp_client_name="claude-code",
+        )
+        token = current_harness_context.set(context)
+        try:
+            AnalyticsTracker(enabled=True).track_request(
+                request_id="r1",
+                session_id="s1",
+                method="POST",
+                path="/mcp",
+                status_code=200,
+            )
+        finally:
+            current_harness_context.reset(token)
+
+        e = capture.event
+        assert e["mcp_client_family"] == "claude"
+        assert e["mcp_client_app"] == "claude_code"
+        assert e["mcp_client_source"] == "initialize_client_info"
+        assert e["mcp_protocol_version"] == "2025-06-18"
+        assert e["mcp_jsonrpc_method"] == "tools.call"
+        assert "mcp_client_name" not in e
+
+    @patch.dict("os.environ", {"MCP_HARNESS_DEBUG_FIELDS": "true"})
+    def test_debug_harness_fields_are_gated(self, capture):
+        context = HarnessContext(
+            mcp_client_family="claude",
+            mcp_client_app="claude_code",
+            mcp_client_source="initialize_client_info",
+            mcp_protocol_version="2025-06-18",
+            mcp_jsonrpc_method="tools.call",
+            mcp_client_name="claude-code",
+            mcp_client_version="2.1.89",
+        )
+        token = current_harness_context.set(context)
+        try:
+            AnalyticsTracker(enabled=True).track_request(
+                request_id="r1",
+                session_id="s1",
+                method="POST",
+                path="/mcp",
+                status_code=200,
+            )
+        finally:
+            current_harness_context.reset(token)
+
+        e = capture.event
+        assert e["mcp_client_name"] == "claude-code"
+        assert e["mcp_client_version"] == "2.1.89"
 
 
 # -- Global tracker singleton --------------------------------------------------

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -171,6 +171,35 @@ class TestDatadogAttributes:
         assert "deployment_type:hosted" in entry["ddtags"]
         assert "mcp_tool_name:count_weave_traces_tool" in entry["ddtags"]
 
+    def test_mcp_harness_tags_and_attributes(self):
+        event = _make_event(
+            "request",
+            method="POST",
+            path="/mcp",
+            status_code=200,
+            mcp_client_family="claude",
+            mcp_client_app="claude_code",
+            mcp_client_source="session_metadata",
+            mcp_protocol_version="2025-06-18",
+            mcp_jsonrpc_method="tools.call",
+            mcp_client_name="claude-code",
+        )
+        entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")
+
+        assert "mcp_client_family:claude" in entry["ddtags"]
+        assert "mcp_client_app:claude_code" in entry["ddtags"]
+        assert "mcp_client_source:session_metadata" in entry["ddtags"]
+        assert "claude-code" not in entry["ddtags"]
+        assert entry["attributes"]["mcp"]["client"] == {
+            "family": "claude",
+            "app": "claude_code",
+            "source": "session_metadata",
+        }
+        assert entry["attributes"]["mcp"]["protocol"] == {
+            "version": "2025-06-18",
+            "jsonrpc_method": "tools.call",
+        }
+
     def test_session_id_forwarded(self):
         event = _make_event("tool_call", tool_name="x", success=True, session_id="sess_abc")
         entry = map_to_datadog_log(event, dd_env="s", dd_version="v", dd_service="svc")

--- a/tests/test_analytics_segment.py
+++ b/tests/test_analytics_segment.py
@@ -76,6 +76,30 @@ class TestMapToSegmentTrack:
         assert result["properties"]["source"] == "wandb-mcp-server"
         assert result["properties"]["schema_version"] == "1.0"
 
+    def test_harness_fields_are_base_properties(self):
+        event = self._make_event(
+            "request",
+            request_id="r1",
+            method="POST",
+            path="/mcp",
+            status_code=200,
+            mcp_client_family="cursor",
+            mcp_client_app="cursor",
+            mcp_client_source="user_agent",
+            mcp_protocol_version="2025-06-18",
+            mcp_jsonrpc_method="tools.list",
+            mcp_client_name="cursor-internal-debug",
+        )
+        result = map_to_segment_track(event)
+        assert result is not None
+        properties = result["properties"]
+        assert properties["mcp_client_family"] == "cursor"
+        assert properties["mcp_client_app"] == "cursor"
+        assert properties["mcp_client_source"] == "user_agent"
+        assert properties["mcp_protocol_version"] == "2025-06-18"
+        assert properties["mcp_jsonrpc_method"] == "tools.list"
+        assert "mcp_client_name" not in properties
+
     def test_tool_call_preserves_timestamp(self):
         event = self._make_event("tool_call", tool_name="t")
         result = map_to_segment_track(event)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,110 @@
+"""Unit tests for MCP harness classification."""
+
+from wandb_mcp_server.harness import extract_harness_context
+
+
+def test_initialize_client_info_identifies_codex() -> None:
+    context = extract_harness_context(
+        {"User-Agent": "python-httpx/0.28"},
+        {
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "clientInfo": {"name": "codex-mcp-client", "version": "1.2.3"},
+            },
+        },
+    )
+
+    assert context.mcp_client_family == "openai"
+    assert context.mcp_client_app == "codex_cli"
+    assert context.mcp_client_source == "initialize_client_info"
+    assert context.mcp_protocol_version == "2025-03-26"
+    assert context.mcp_jsonrpc_method == "initialize"
+    assert "mcp_client_name" not in context.analytics_fields(include_debug=False)
+
+
+def test_meta_client_info_wins_on_initialize() -> None:
+    context = extract_harness_context(
+        {},
+        {
+            "method": "initialize",
+            "params": {
+                "clientInfo": {"name": "cursor", "version": "1"},
+                "_meta": {
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "claude-code",
+                        "version": "2.1.89",
+                    },
+                    "io.modelcontextprotocol/protocolVersion": "2025-06-18",
+                },
+            },
+        },
+    )
+
+    assert context.mcp_client_family == "claude"
+    assert context.mcp_client_app == "claude_code"
+    assert context.mcp_client_source == "meta_client_info"
+    assert context.mcp_protocol_version == "2025-06-18"
+
+
+def test_session_metadata_wins_over_later_spoofed_meta() -> None:
+    context = extract_harness_context(
+        {"User-Agent": "Cursor/1.0", "MCP-Protocol-Version": "2025-06-18"},
+        {
+            "method": "tools/call",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "cursor",
+                        "version": "1",
+                    }
+                }
+            },
+        },
+        session_metadata={
+            "mcp_client_family": "openai",
+            "mcp_client_app": "codex_cli",
+            "mcp_client_source": "initialize_client_info",
+            "mcp_protocol_version": "2025-03-26",
+            "mcp_jsonrpc_method": "initialize",
+        },
+    )
+
+    assert context.mcp_client_family == "openai"
+    assert context.mcp_client_app == "codex_cli"
+    assert context.mcp_client_source == "session_metadata"
+    assert context.mcp_client_mismatch == "client_info"
+    assert context.mcp_jsonrpc_method == "tools.call"
+
+
+def test_user_agent_is_fallback_only() -> None:
+    context = extract_harness_context(
+        {"User-Agent": "claude-code/2.1.89 (cli)", "MCP-Protocol-Version": "2025-06-18"},
+        {"method": "tools/list"},
+    )
+
+    assert context.mcp_client_family == "claude"
+    assert context.mcp_client_app == "claude_code"
+    assert context.mcp_client_source == "user_agent"
+    assert context.mcp_protocol_version == "2025-06-18"
+    assert context.mcp_jsonrpc_method == "tools.list"
+
+
+def test_oversized_and_control_values_become_safe_debug_values() -> None:
+    context = extract_harness_context(
+        {"User-Agent": "bad\r\nHeader: injected"},
+        {
+            "method": "initialize",
+            "params": {
+                "clientInfo": {
+                    "name": "x" * 500 + "\nsecret@example.com",
+                    "version": "1.0\r\nbad",
+                }
+            },
+        },
+    )
+
+    assert context.mcp_client_family == "unknown"
+    assert context.mcp_client_app == "unknown"
+    assert context.mcp_client_name == ("x" * 64)
+    assert context.mcp_client_version == "1.0.bad"


### PR DESCRIPTION
## Summary
- Adds safe, low-cardinality MCP client harness classification for analytics events.
- Enriches Cloud Logging/Hex and Datadog mappings with client family/app/source and MCP protocol method/version fields.
- Documents recommended Datadog and Hex analyses for harness adoption and incident debugging.

## Test plan
- `uv run pytest tests/test_harness.py tests/test_analytics.py tests/test_analytics_datadog.py tests/test_analytics_segment.py -q`
- `uv run --no-sync ruff check src/wandb_mcp_server/harness.py src/wandb_mcp_server/analytics.py src/wandb_mcp_server/analytics_datadog.py src/wandb_mcp_server/analytics_segment.py tests/test_harness.py tests/test_analytics.py tests/test_analytics_datadog.py tests/test_analytics_segment.py`


Made with [Cursor](https://cursor.com)