### PR TITLE
fix: execute GraphQL with request bearer token

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -667,14 +667,15 @@ def query_paginated_wandb_gql(
     Returns:
         The aggregated GraphQL response dictionary.
     """
-    from wandb_mcp_server.api_client import get_wandb_api
+    from wandb_mcp_server.api_client import WandBApiManager, get_wandb_api
 
+    api_key = WandBApiManager.get_api_key()
     api = get_wandb_api()
     result_dict = {}
     limit_key = None
     with track_tool_execution(
         "query_paginated_wandb_gql",
-        api.viewer,
+        "unknown",
         {
             "query": query,
             "variables": variables,
@@ -752,7 +753,12 @@ def query_paginated_wandb_gql(
                 return {"errors": [{"message": f"Failed to parse initial query: {e}"}]}
 
             try:
-                result1 = execute_graphql(api, query.strip(), page1_vars_func)
+                result1 = execute_graphql(
+                    api,
+                    query.strip(),
+                    page1_vars_func,
+                    api_key=api_key,
+                )
                 result_dict = copy.deepcopy(result1)
                 if "errors" in result_dict:
                     logger.error(f"GraphQL errors in initial response: {result_dict['errors']}")
@@ -860,7 +866,12 @@ def query_paginated_wandb_gql(
 
                 try:
                     logging.info(f"Executing generated query for page {page_num} with vars: {page_vars}")
-                    result_page = execute_graphql(api, generated_paginated_query_string, page_vars)
+                    result_page = execute_graphql(
+                        api,
+                        generated_paginated_query_string,
+                        page_vars,
+                        api_key=api_key,
+                    )
 
                     if "errors" in result_page:
                         logger.error(

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -5,14 +5,36 @@ from __future__ import annotations
 import importlib
 from typing import Any, Mapping
 
+import requests
+
+from wandb_mcp_server.config import WANDB_BASE_URL
+
 
 def execute_graphql(
     api: Any,
     query: str,
     variables: Mapping[str, Any] | None = None,
+    *,
+    api_key: str | None = None,
 ) -> dict[str, Any]:
     """Execute a GraphQL document with the current or legacy W&B SDK transport."""
     variables_dict = dict(variables or {})
+    if api_key:
+        response = requests.post(
+            f"{WANDB_BASE_URL.rstrip('/')}/graphql",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"query": query, "variables": variables_dict},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("GraphQL response was not an object")
+        return payload
+
     service_api = getattr(api, "__dict__", {}).get("_service_api")
     if service_api is not None and hasattr(service_api, "execute_graphql"):
         return service_api.execute_graphql(query, variables=variables_dict)

--- a/tests/test_wandb_graphql.py
+++ b/tests/test_wandb_graphql.py
@@ -60,3 +60,38 @@ def test_execute_graphql_lazily_falls_back_to_wandb_gql(monkeypatch):
 
     assert result == {"ok": True}
     assert api.client.calls == [("parsed:query Test { viewer { id } }", {"x": 1})]
+
+
+def test_execute_graphql_uses_direct_bearer_request(monkeypatch):
+    calls = []
+
+    class Response:
+        def raise_for_status(self):
+            calls.append(("raise_for_status",))
+
+        def json(self):
+            return {"data": {"viewer": {"username": "test"}}}
+
+    def fake_post(url, *, headers, json, timeout):
+        calls.append((url, headers, json, timeout))
+        return Response()
+
+    monkeypatch.setattr("wandb_mcp_server.wandb_graphql.requests.post", fake_post)
+
+    result = execute_graphql(
+        object(),
+        "query Test { viewer { username } }",
+        {"x": 1},
+        api_key="wandb_v1_test",
+    )
+
+    assert result == {"data": {"viewer": {"username": "test"}}}
+    url, headers, payload, timeout = calls[0]
+    assert url == "https://api.wandb.ai/graphql"
+    assert headers["Authorization"] == "Bearer wandb_v1_test"
+    assert payload == {
+        "query": "query Test { viewer { username } }",
+        "variables": {"x": 1},
+    }
+    assert timeout == 30
+    assert calls[1] == ("raise_for_status",)


### PR DESCRIPTION
## Summary
- Executes W&B GraphQL directly with the per-request bearer token when available.
- Avoids the `wandb.Api.viewer` path for `query_wandb_tool`, which returns `relogin required` for valid `wandb_v1_...` API keys.
- Keeps SDK transport fallback for contexts without an explicit API key.

## Test plan
- `uv run pytest tests/test_wandb_graphql.py tests/test_hosted_gql_guardrails.py tests/test_hosted_gql_production_errors.py -q`
- `uv run --no-sync ruff check src/wandb_mcp_server/wandb_graphql.py src/wandb_mcp_server/mcp_tools/query_wandb_gql.py tests/test_wandb_graphql.py`
- Local validation with a real `wandb_v1` key: `query_paginated_wandb_gql('query GetViewerInfo { viewer { id username entity } }')`


Made with [Cursor](https://cursor.com)