### PR TITLE
chore: remove beta scan history references

### DIFF
--- a/scripts/validate_tools_live.py
+++ b/scripts/validate_tools_live.py
@@ -165,8 +165,9 @@ def test_count_traces_live(suite: TestSuite):
 def test_h4_parallel_count(suite: TestSuite):
     """Two sequential counts should be slower than concurrent execution."""
     from concurrent.futures import ThreadPoolExecutor
-    from wandb_mcp_server.mcp_tools.count_traces import count_traces
+
     from wandb_mcp_server.api_client import WandBApiManager
+    from wandb_mcp_server.mcp_tools.count_traces import count_traces
 
     api_key = os.environ["WANDB_API_KEY"]
 
@@ -237,6 +238,7 @@ def test_h3_schema_projection(suite: TestSuite):
     t0 = time.monotonic()
     try:
         from unittest.mock import AsyncMock, patch
+
         from wandb_mcp_server.weave_api.models import QueryResult, TraceMetadata
 
         mock_query = AsyncMock(
@@ -250,8 +252,9 @@ def test_h3_schema_projection(suite: TestSuite):
             patch("wandb_mcp_server.server.count_traces", return_value=5),
             patch("wandb_mcp_server.api_client.WandBApiManager.get_api_key", return_value="fake"),
         ):
-            from wandb_mcp_server.server import register_tools
             from mcp.server.fastmcp import FastMCP
+
+            from wandb_mcp_server.server import register_tools
 
             mcp = FastMCP("test-h3")
             register_tools(mcp)
@@ -312,10 +315,10 @@ def test_m2_or_in_filters(suite: TestSuite):
         suite.record("M2: $or/$in filters", False, time.monotonic() - t0, error=str(e))
 
 
-# ── H5: beta_scan_history wiring ─────────────────────────────────────────────
+# ── H5: scan_history wiring ──────────────────────────────────────────────────
 
 
-def test_h5_beta_scan_wiring(suite: TestSuite):
+def test_h5_scan_history_wiring(suite: TestSuite):
     """Validate the _fetch_step_range function exists and respects env var."""
     t0 = time.monotonic()
     try:
@@ -328,11 +331,9 @@ def test_h5_beta_scan_wiring(suite: TestSuite):
         steps = [r["_step"] for r in sampled]
         assert steps == sorted(steps), "Reservoir sample not sorted"
 
-        suite.record(
-            "H5: beta_scan_history wiring", True, time.monotonic() - t0, "functions exist, reservoir sample works"
-        )
+        suite.record("H5: scan_history wiring", True, time.monotonic() - t0, "functions exist, reservoir sample works")
     except Exception as e:
-        suite.record("H5: beta_scan_history wiring", False, time.monotonic() - t0, error=str(e))
+        suite.record("H5: scan_history wiring", False, time.monotonic() - t0, error=str(e))
 
 
 # ── M1: history row budget ────────────────────────────────────────────────────
@@ -417,7 +418,7 @@ def main():
         test_m4_no_networkx,
         test_h2_cost_sort_cap,
         test_m2_or_in_filters,
-        test_h5_beta_scan_wiring,
+        test_h5_scan_history_wiring,
         test_m1_row_budget,
         test_h3_schema_projection,
         test_count_traces_live,

--- a/src/wandb_mcp_server/mcp_tools/run_history.py
+++ b/src/wandb_mcp_server/mcp_tools/run_history.py
@@ -1,8 +1,8 @@
 """Retrieve sampled time-series metric history for a W&B run.
 
 Uses `wandb.Api().run().history()` for sampled data and a tiered
-strategy for step-range queries: beta_scan_history (parquet) first,
-scan_history (GraphQL) second, history() (sampled) as last resort.
+strategy for step-range queries: scan_history (parquet-backed) first,
+history() (sampled) as last resort.
 """
 
 from __future__ import annotations
@@ -185,26 +185,11 @@ def _fetch_step_range(
     """Fetch history rows for a step range using a tiered strategy.
 
     Strategy order:
-      1. beta_scan_history (parquet via wandb-core, works on all run types)
-      2. scan_history (GraphQL, fails silently when lastHistoryStep == -1)
-      3. history() sampled fallback (always works, ignores step bounds)
+      1. scan_history (parquet-backed when available, falls back to GraphQL;
+         fails silently when lastHistoryStep == -1)
+      2. history() sampled fallback (always works, ignores step bounds)
     """
-    # Strategy 1: beta_scan_history
-    try:
-        beta_kwargs: Dict[str, Any] = {"min_step": min_step or 0}
-        if keys:
-            beta_kwargs["keys"] = keys
-        if max_step is not None:
-            beta_kwargs["max_step"] = max_step
-        beta_kwargs["page_size"] = min(clamped_samples, 1000)
-        rows = _reservoir_sample(run.beta_scan_history(**beta_kwargs), clamped_samples)
-        if rows:
-            return rows
-        logger.info("beta_scan_history returned 0 rows, trying scan_history")
-    except Exception as e:
-        logger.info(f"beta_scan_history unavailable ({type(e).__name__}), trying scan_history")
-
-    # Strategy 2: scan_history
+    # Strategy 1: scan_history
     scan_kwargs: Dict[str, Any] = {}
     if keys:
         scan_kwargs["keys"] = keys
@@ -216,7 +201,7 @@ def _fetch_step_range(
     if rows:
         return rows
 
-    # Strategy 3: history() sampled fallback (ignores step bounds but always works)
+    # Strategy 2: history() sampled fallback (ignores step bounds but always works)
     last_step = getattr(run, "lastHistoryStep", 0) or 0
     if last_step <= 0:
         logger.warning(

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -450,53 +450,32 @@ class TestHistoryTruncation:
 
 
 class TestTieredStepRangeFetch:
-    """Tests for the tiered step-range strategy: beta -> scan -> history fallback."""
+    """Tests for the tiered step-range strategy: scan_history -> history fallback."""
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
-    def test_beta_scan_history_tried_first(self, mock_wandb_mod, mock_api_mgr):
-        """beta_scan_history is the first strategy attempted for step-range queries."""
+    def test_scan_history_tried_first(self, mock_wandb_mod, mock_api_mgr):
+        """scan_history is the first strategy attempted for step-range queries."""
         mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
-        beta_rows = [{"_step": i, "loss": 0.5} for i in range(50)]
+        scan_rows = [{"_step": i, "loss": 0.5} for i in range(50)]
         mock_run = MagicMock()
-        mock_run.name = "beta-run"
+        mock_run.name = "scan-run"
         mock_run.lastHistoryStep = 100
-        mock_run.beta_scan_history.return_value = iter(beta_rows)
+        mock_run.scan_history.return_value = iter(scan_rows)
         mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, max_step=100))
-        mock_run.beta_scan_history.assert_called_once()
-        mock_run.scan_history.assert_not_called()
+        mock_run.scan_history.assert_called_once()
+        mock_run.history.assert_not_called()
         assert result["sampled_points"] == 50
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
-    def test_fallback_to_scan_history_on_beta_error(self, mock_wandb_mod, mock_api_mgr):
-        """If beta_scan_history raises, falls back to scan_history."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
-        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
-
-        fallback_rows = [{"_step": i, "loss": 0.3} for i in range(20)]
-        mock_run = MagicMock()
-        mock_run.name = "fallback-run"
-        mock_run.lastHistoryStep = 50
-        mock_run.beta_scan_history.side_effect = RuntimeError("wandb-core not available")
-        mock_run.scan_history.return_value = iter(fallback_rows)
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
-        mock_wandb_mod.errors = wandb.errors
-
-        result = json.loads(get_run_history("e", "p", "run1", min_step=0))
-        mock_run.beta_scan_history.assert_called_once()
-        mock_run.scan_history.assert_called_once()
-        assert result["sampled_points"] == 20
-
-    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
-    def test_fallback_to_history_when_both_return_empty(self, mock_wandb_mod, mock_api_mgr):
-        """When beta returns empty and scan returns empty with lastHistoryStep<=0, falls back to history()."""
+    def test_fallback_to_history_when_scan_empty(self, mock_wandb_mod, mock_api_mgr):
+        """When scan returns empty with lastHistoryStep<=0, falls back to history()."""
         mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
@@ -504,34 +483,32 @@ class TestTieredStepRangeFetch:
         mock_run = MagicMock()
         mock_run.name = "broken-step-run"
         mock_run.lastHistoryStep = -1
-        mock_run.beta_scan_history.return_value = iter([])
         mock_run.scan_history.return_value = iter([])
         mock_run.history.return_value = history_rows
         mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, max_step=100))
-        mock_run.beta_scan_history.assert_called_once()
         mock_run.scan_history.assert_called_once()
         mock_run.history.assert_called_once()
         assert result["sampled_points"] == 10
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
-    def test_beta_scan_history_passes_keys_and_range(self, mock_wandb_mod, mock_api_mgr):
-        """beta_scan_history receives keys, min_step, max_step."""
+    def test_scan_history_passes_keys_and_range(self, mock_wandb_mod, mock_api_mgr):
+        """scan_history receives keys, min_step, max_step."""
         mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "params-run"
         mock_run.lastHistoryStep = 200
-        mock_run.beta_scan_history.return_value = iter([{"_step": 10, "loss": 0.5}])
+        mock_run.scan_history.return_value = iter([{"_step": 10, "loss": 0.5}])
         mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", keys=["loss"], min_step=10, max_step=100)
-        call_kwargs = mock_run.beta_scan_history.call_args[1]
+        call_kwargs = mock_run.scan_history.call_args[1]
         assert call_kwargs["keys"] == ["loss"]
         assert call_kwargs["min_step"] == 10
         assert call_kwargs["max_step"] == 100
@@ -546,7 +523,6 @@ class TestTieredStepRangeFetch:
         mock_run = MagicMock()
         mock_run.name = "normal-run"
         mock_run.lastHistoryStep = 1000
-        mock_run.beta_scan_history.return_value = iter([])
         mock_run.scan_history.return_value = iter([])
         mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors


### PR DESCRIPTION
Recently ([in version 0.27.1](https://github.com/wandb/wandb/releases/tag/v0.27.1)) the W&B SDK promoted the `beta_scan_history`'s local parquet reading logic into the `scan_history`code path. This effectively deprecates the `beta_scan_history`path which will be removed in a future release.

This PR removes references and calls to `beta_scan_history`to avoid duplicate work, and potential future issue when the code path is removed.