### PR TITLE
fix(analytics): reduce Segment request volume

### DIFF
--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -41,7 +41,6 @@ SEGMENT_EVENT_PREFIX = "mcp_server"
 _EVENT_NAME_MAP: Dict[str, str] = {
     "user_session": f"{SEGMENT_EVENT_PREFIX}.session_start",
     "tool_call": f"{SEGMENT_EVENT_PREFIX}.tool_call",
-    "request": f"{SEGMENT_EVENT_PREFIX}.http_request",
 }
 
 _SESSION_PROPERTY_KEYS: List[str] = [
@@ -77,15 +76,6 @@ _TOOL_CALL_PROPERTY_KEYS: List[str] = [
     "duration_ms",
 ]
 
-_REQUEST_PROPERTY_KEYS: List[str] = [
-    "session_id",
-    "request_id",
-    "method",
-    "path",
-    "status_code",
-    "duration_ms",
-]
-
 
 def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Convert an internal analytics event dict to a Segment Track payload.
@@ -108,7 +98,6 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     property_keys = {
         "user_session": _SESSION_PROPERTY_KEYS,
         "tool_call": _TOOL_CALL_PROPERTY_KEYS,
-        "request": _REQUEST_PROPERTY_KEYS,
     }.get(event_type, [])
 
     properties: Dict[str, Any] = {

--- a/src/wandb_mcp_server/auth.py
+++ b/src/wandb_mcp_server/auth.py
@@ -172,12 +172,15 @@ async def mcp_auth_middleware(request: Request, call_next):
     from wandb_mcp_server.session_manager import SessionCapacityError, current_session_id
 
     session_id, is_new_session = _resolve_session_id(request, wandb_api_key)
+    session_was_created = False
 
     try:
         from wandb_mcp_server.session_manager import get_session_manager
 
         mgr = get_session_manager()
+        session_exists = mgr.get_session(session_id) is not None
         mgr.create_session(wandb_api_key, session_id=session_id)
+        session_was_created = not session_exists
     except SessionCapacityError:
         logger.warning("Session capacity exceeded for API key")
         WandBApiManager.reset_context_api_key(api_key_token)
@@ -191,6 +194,7 @@ async def mcp_auth_middleware(request: Request, call_next):
         is_new_session = True
         try:
             mgr.create_session(wandb_api_key, session_id=session_id)
+            session_was_created = True
         except SessionCapacityError:
             logger.warning("Session capacity exceeded on retry")
             WandBApiManager.reset_context_api_key(api_key_token)
@@ -207,16 +211,17 @@ async def mcp_auth_middleware(request: Request, call_next):
     session_ctx_token = current_session_id.set(session_id)
 
     # --- Analytics: session event -----------------------------------------
-    try:
-        from wandb_mcp_server.analytics import get_analytics_tracker
+    if session_was_created:
+        try:
+            from wandb_mcp_server.analytics import get_analytics_tracker
 
-        get_analytics_tracker().track_user_session(
-            session_id=session_id,
-            viewer_info=viewer,
-            api_key_hash=hashlib.sha256(wandb_api_key.encode()).hexdigest(),
-        )
-    except Exception as analytics_err:
-        logger.debug(f"Analytics tracking failed (non-fatal): {analytics_err}")
+            get_analytics_tracker().track_user_session(
+                session_id=session_id,
+                viewer_info=viewer,
+                api_key_hash=hashlib.sha256(wandb_api_key.encode()).hexdigest(),
+            )
+        except Exception as analytics_err:
+            logger.debug(f"Analytics tracking failed (non-fatal): {analytics_err}")
 
     # --- Execute request (errors here propagate as 500, not 401) ----------
     request_start = time.monotonic()

--- a/tests/test_analytics_segment.py
+++ b/tests/test_analytics_segment.py
@@ -78,11 +78,9 @@ class TestMapToSegmentTrack:
 
     def test_harness_fields_are_base_properties(self):
         event = self._make_event(
-            "request",
-            request_id="r1",
-            method="POST",
-            path="/mcp",
-            status_code=200,
+            "tool_call",
+            tool_name="query_wandb_gql",
+            success=True,
             mcp_client_family="cursor",
             mcp_client_app="cursor",
             mcp_client_source="user_agent",
@@ -131,9 +129,7 @@ class TestMapToSegmentTrack:
             path="/mcp/sse",
             status_code=200,
         )
-        result = map_to_segment_track(event)
-        assert result["event"] == f"{SEGMENT_EVENT_PREFIX}.http_request"
-        assert result["properties"]["method"] == "POST"
+        assert map_to_segment_track(event) is None
 
     def test_returns_none_for_unknown_event_type(self):
         event = self._make_event("unknown_type")
@@ -348,7 +344,7 @@ class TestEndToEndIntegration:
         assert payloads[0]["event"] == f"{SEGMENT_EVENT_PREFIX}.session_start"
 
     @patch.dict("os.environ", {"MCP_SEGMENT_DRY_RUN": "true"})
-    def test_tracker_request_reaches_forwarder(self):
+    def test_tracker_request_skips_forwarder(self):
         reset_segment_forwarder()
         forwarder = get_segment_forwarder()
 
@@ -364,9 +360,7 @@ class TestEndToEndIntegration:
         )
 
         payloads = forwarder.get_forwarded_payloads()
-        assert len(payloads) == 1
-        assert payloads[0]["event"] == f"{SEGMENT_EVENT_PREFIX}.http_request"
-        assert payloads[0]["properties"]["status_code"] == 200
+        assert len(payloads) == 0
 
     def test_forwarder_inactive_does_not_accumulate(self):
         """When forwarder is off (default), no payloads should accumulate."""

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -252,6 +252,100 @@ class TestAuthMiddlewareSession:
         assert result is resp
 
 
+class TestAuthMiddlewareSessionAnalytics:
+    @pytest.fixture(autouse=True)
+    def _env(self):
+        with patch.dict("os.environ", {"MCP_ANALYTICS_DISABLED": "false"}):
+            yield
+
+    @pytest.fixture()
+    def _mock_deps(self):
+        """Patch WandBApiManager and session manager to avoid side effects."""
+        with (
+            patch("wandb_mcp_server.api_client.WandBApiManager") as mock_wbm,
+            patch("wandb_mcp_server.session_manager.MultiTenantSessionManager._start_cleanup_task"),
+        ):
+            mock_wbm.set_context_api_key.return_value = "tok"
+            mock_wbm.reset_context_api_key.return_value = None
+            mock_api = MagicMock()
+            mock_api.viewer = SimpleNamespace(
+                username="alice",
+                entity="team",
+                email="a@co.com",
+            )
+            mock_wbm.get_api.return_value = mock_api
+            yield mock_wbm
+
+    @pytest.mark.asyncio
+    async def test_server_issued_session_tracks_once(self, _mock_deps):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+
+        async def call_next(_):
+            return resp
+
+        tracker = MagicMock()
+        with patch(
+            "wandb_mcp_server.analytics.get_analytics_tracker",
+            return_value=tracker,
+        ):
+            result = await mcp_auth_middleware(_make_fake_request(), call_next)
+
+        tracker.track_user_session.assert_called_once()
+        assert tracker.track_user_session.call_args.kwargs["session_id"] == result.headers["Mcp-Session-Id"]
+
+    @pytest.mark.asyncio
+    async def test_client_provided_new_session_tracks_session_start(self, _mock_deps):
+        session = "sess_client_provided"
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+
+        async def call_next(_):
+            return resp
+
+        tracker = MagicMock()
+        with patch(
+            "wandb_mcp_server.analytics.get_analytics_tracker",
+            return_value=tracker,
+        ):
+            await mcp_auth_middleware(
+                _make_fake_request(session_header=session),
+                call_next,
+            )
+
+        tracker.track_user_session.assert_called_once()
+        assert tracker.track_user_session.call_args.kwargs["session_id"] == session
+
+    @pytest.mark.asyncio
+    async def test_legitimate_session_reuse_skips_session_start(self, _mock_deps):
+        session = "sess_reused_by_same_tenant"
+
+        async def call_next(_):
+            r = MagicMock()
+            r.status_code = 200
+            r.headers = {}
+            return r
+
+        tracker = MagicMock()
+        with patch(
+            "wandb_mcp_server.analytics.get_analytics_tracker",
+            return_value=tracker,
+        ):
+            await mcp_auth_middleware(
+                _make_fake_request(session_header=session),
+                call_next,
+            )
+            await mcp_auth_middleware(
+                _make_fake_request(session_header=session),
+                call_next,
+            )
+
+        tracker.track_user_session.assert_called_once()
+        assert tracker.track_user_session.call_args.kwargs["session_id"] == session
+
+
 # ---------------------------------------------------------------------------
 # Session fixation prevention (cross-tenant session ID reuse)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop forwarding high-volume MCP HTTP request analytics to Segment/Mixpanel.
- Keep request telemetry in structured analytics logs and Datadog for operational visibility.
- Emit session-start analytics only when the session manager creates a new session, including first client-provided session IDs.

## Changes
- Remove `request` from the Segment event mapper so `mcp_server.http_request` is skipped by the Segment forwarder.
- Track `user_session` only for newly created sessions instead of every authenticated `/mcp` request.
- Update Segment and session-management tests for the reduced-volume behavior.

## Jira link
N/A

## Test plan
- `uv run ruff check src/ tests/`
- `uv run ruff format src/ tests/`
- `uv run pytest tests/test_analytics_segment.py tests/test_analytics.py tests/test_session_management.py tests/test_analytics_datadog.py -v`
- `git diff --check`

Made with [Cursor](https://cursor.com)