### PR TITLE
feat: gate Weave Agent tools behind opt-in flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Query and analyze your Weights & Biases data using natural language through the 
 
 **Weave Agents (OTel) tools** — these read the OpenTelemetry/GenAI agent-spans data plane (the **Agents** tab), which is separate from the classic Weave calls above:
 
+These tools are disabled by default. Enable them with `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=true`.
+
 | Tool | Description | Example Query |
 |------|-------------|---------------|
 | **list_weave_agents_tool** | List agents with aggregated stats (invocations, tokens, duration, errors) | *"Which agents ran this week and how many errors did each have?"* |

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -52,6 +52,10 @@ MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HO
 MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
 WANDB_MCP_ENABLE_WEAVE_TOOLS: bool = _env_bool("WANDB_MCP_ENABLE_WEAVE_TOOLS", True)
+WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS: bool = _env_bool(
+    "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
+    False,
+)
 COST_SORT_FIELDS: frozenset[str] = frozenset({"total_cost", "completion_cost", "prompt_cost"})
 
 

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -20,7 +20,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Union
 
 import wandb
 from dotenv import load_dotenv
@@ -136,8 +136,8 @@ class _AgentTool:
     description: str
 
 
-# Single source of truth for the agent tools: the names spread into
-# _WEAVE_TOOL_NAMES below and the registration loop in register_tools().
+# Single source of truth for the agent tools: the names feed the optional tool
+# group registry below and the registration loop in register_tools().
 _AGENT_TOOLS = (
     _AgentTool("list_weave_agents_tool", list_agents, LIST_AGENTS_TOOL_DESCRIPTION),
     _AgentTool("list_weave_agent_versions_tool", list_agent_versions, LIST_AGENT_VERSIONS_TOOL_DESCRIPTION),
@@ -153,18 +153,46 @@ _AGENT_TOOLS = (
     _AgentTool("get_weave_agent_conversation_tool", get_agent_conversation, GET_AGENT_CONVERSATION_TOOL_DESCRIPTION),
 )
 
-_WEAVE_TOOL_NAMES = {
-    "query_weave_traces_tool",
-    "count_weave_traces_tool",
-    "resolve_trace_roots_tool",
-    "infer_trace_schema_tool",
-    "summarize_evaluation_tool",
-    # Agents (OTel/GenAI) tools -- same trace backend, gated together.
-    *(tool.name for tool in _AGENT_TOOLS),
-}
+_AGENT_TOOL_NAMES = frozenset(tool.name for tool in _AGENT_TOOLS)
+
+_WEAVE_TOOL_NAMES = frozenset(
+    {
+        "query_weave_traces_tool",
+        "count_weave_traces_tool",
+        "resolve_trace_roots_tool",
+        "infer_trace_schema_tool",
+        "summarize_evaluation_tool",
+    }
+)
 
 
-def _remove_registered_tools(mcp_instance: FastMCP, tool_names: set[str]) -> None:
+@dataclass(frozen=True, slots=True)
+class _OptionalToolGroup:
+    """A group of tools controlled by one environment-backed feature flag."""
+
+    key: str
+    env_var: str
+    default_enabled: bool
+    tool_names: frozenset[str]
+
+
+_OPTIONAL_TOOL_GROUPS = (
+    _OptionalToolGroup(
+        key="weave",
+        env_var="WANDB_MCP_ENABLE_WEAVE_TOOLS",
+        default_enabled=True,
+        tool_names=_WEAVE_TOOL_NAMES,
+    ),
+    _OptionalToolGroup(
+        key="weave_agents",
+        env_var="WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
+        default_enabled=False,
+        tool_names=_AGENT_TOOL_NAMES,
+    ),
+)
+
+
+def _remove_registered_tools(mcp_instance: FastMCP, tool_names: Collection[str]) -> None:
     """Remove tools from FastMCP's registry after decorator registration."""
     tool_manager = getattr(mcp_instance, "_tool_manager", None)
     tools = getattr(tool_manager, "_tools", None)
@@ -1098,17 +1126,22 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
     # ----- Weave Agents (OTel/GenAI) tools -----
     # These read the OTel agent-spans data plane (separate from classic Weave
-    # calls), so they are gated with the other Weave tools via _WEAVE_TOOL_NAMES.
-    # Each implementation is a complete tool, so it is registered directly; its
-    # parameter schema is derived from the function signature.
+    # calls), so they are registered directly and independently gated below.
+    # Each implementation is a complete tool; its parameter schema is derived
+    # from the function signature.
     for tool in _AGENT_TOOLS:
         mcp_instance.tool(name=tool.name, description=tool.description)(tool.impl)
 
-    from wandb_mcp_server.config import WANDB_MCP_ENABLE_WEAVE_TOOLS
+    from wandb_mcp_server.config import _env_bool
 
-    if not WANDB_MCP_ENABLE_WEAVE_TOOLS:
-        logger.info("Weave MCP tools disabled by WANDB_MCP_ENABLE_WEAVE_TOOLS=false")
-        _remove_registered_tools(mcp_instance, _WEAVE_TOOL_NAMES)
+    for group in _OPTIONAL_TOOL_GROUPS:
+        if not _env_bool(group.env_var, group.default_enabled):
+            logger.info(
+                "Optional MCP tool group '%s' disabled via %s",
+                group.key,
+                group.env_var,
+            )
+            _remove_registered_tools(mcp_instance, group.tool_names)
 
 
 # ===============================================================================

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -23,8 +23,7 @@ NON_WEAVE_TOOLS = {
     "probe_project_tool",
 }
 
-# Agents (OTel) tools read the same trace backend, so they are gated with the
-# Weave tools.
+# Agents (OTel) tools read a separate agent-spans data plane and are opt-in.
 AGENT_TOOLS = {
     "list_weave_agents_tool",
     "list_weave_agent_versions_tool",
@@ -37,6 +36,11 @@ AGENT_TOOLS = {
 }
 
 
+def _reset_tool_gate_env() -> None:
+    os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+    os.environ.pop("WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS", None)
+
+
 def _registered_tool_names() -> set[str]:
     mcp = FastMCP("test")
     register_tools(mcp)
@@ -44,7 +48,7 @@ def _registered_tool_names() -> set[str]:
 
 
 def test_weave_tools_registered_by_default():
-    os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+    _reset_tool_gate_env()
     import wandb_mcp_server.config as cfg
 
     importlib.reload(cfg)
@@ -52,7 +56,7 @@ def test_weave_tools_registered_by_default():
 
     assert WEAVE_TOOLS.issubset(names)
     assert NON_WEAVE_TOOLS.issubset(names)
-    assert AGENT_TOOLS.issubset(names)
+    assert AGENT_TOOLS.isdisjoint(names)
 
 
 def test_weave_tools_can_be_disabled():
@@ -63,9 +67,44 @@ def test_weave_tools_can_be_disabled():
         importlib.reload(cfg)
         names = _registered_tool_names()
     finally:
-        os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
+        _reset_tool_gate_env()
         importlib.reload(cfg)
 
     assert WEAVE_TOOLS.isdisjoint(names)
     assert AGENT_TOOLS.isdisjoint(names)
+    assert NON_WEAVE_TOOLS.issubset(names)
+
+
+def test_agent_tools_enabled_via_flag():
+    _reset_tool_gate_env()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = "true"
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    assert WEAVE_TOOLS.issubset(names)
+    assert AGENT_TOOLS.issubset(names)
+    assert NON_WEAVE_TOOLS.issubset(names)
+
+
+def test_agent_and_weave_flags_are_independent():
+    _reset_tool_gate_env()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = "false"
+    os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = "true"
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    assert WEAVE_TOOLS.isdisjoint(names)
+    assert AGENT_TOOLS.issubset(names)
     assert NON_WEAVE_TOOLS.issubset(names)


### PR DESCRIPTION
## Summary
- Make the new Weave Agents (OTel) MCP tools opt-in and disabled by default.
- Add a declarative optional-tool-group registry so future gated groups are managed in one place.
- Keep classic Weave tools enabled by default and independently configurable from agent tools.

## Changes
- Add `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=false` default in `config.py`.
- Split agent tool names out of `_WEAVE_TOOL_NAMES` and gate optional tool groups via a registry loop in `server.py`.
- Update tool registration tests for default-off, explicit enablement, and weave/agent flag independence.
- Document the opt-in flag in the README agent tools section.

## Jira link
N/A

## Test plan
- `uv run ruff check src/ tests/`
- `uv run ruff format src/ tests/`
- `uv run --extra test --extra http pytest tests/test_tool_registration.py tests/test_agents.py tests/test_tool_descriptions.py tests/test_hosted_runtime_guardrails.py -v`
- `uv run --extra test --extra http pytest tests/ -q -m "not integration" --ignore=tests/test_report_layout_live.py`
- `uv run --extra test --extra http pytest tests/test_tool_registration.py -v`
- `git diff --check`

## Notes
- This PR is stacked on #105 and targets `hatchery/reaper` so the agent tools ship gated off by default.
- SaaS/hosted deployments should set `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=true` when ready to expose these tools. Dedicated deployments need no new config because the default is off.

Made with [Cursor](https://cursor.com)