### PR TITLE
security: make query_wandb_tool read-only

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -12,12 +12,16 @@ from graphql.language import printer as gql_printer
 from graphql.language import visitor as gql_visitor
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.wandb_graphql import execute_graphql
+from wandb_mcp_server.wandb_graphql import (
+    GraphQLReadOnlyViolation,
+    execute_graphql,
+    validate_read_only_graphql,
+)
 
 logger = get_rich_logger(__name__)
 
 
-QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute a GraphQL query against the W&B Models API.
+QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute a read-only GraphQL query against the W&B Models API.
 
 Use for experiment tracking runs, metrics, configs, artifacts, sweeps, and model registry.
 For LLM traces or Weave evaluations, use query_weave_traces_tool instead.
@@ -58,8 +62,8 @@ using the GraphQL query language.
 Parameters
 ----------
 query : str
-   he GraphQL query string. This defines the operation (query/mutation),
-                    the data to fetch (selection set), and any variables used.
+    The GraphQL query string. Only query operations are accepted; mutations and
+    subscriptions are rejected before any request is sent to W&B.
 variables : dict[str, Any] | None, optional
     A dictionary of variables to pass to the query.
                                             Keys should match variable names defined in the query
@@ -100,7 +104,9 @@ structure will fail with the error "Query doesn't follow the W&B connection patt
 
 Example of required pagination structure for any collection:
 ```graphql
-runs(first: 10) {  # or artifacts, files, etc.
+query PaginatedRuns($entity: String!, $project: String!) {
+  project(name: $project, entityName: $entity) {
+  runs(first: 10) {  # or artifacts, files, etc.
     edges {
     node {
         id
@@ -113,6 +119,8 @@ runs(first: 10) {  # or artifacts, files, etc.
     endCursor
     hasNextPage
     }
+  }
+  }
 }
 ```
 </required_pagination_structure>
@@ -145,7 +153,19 @@ Bad:
 query AllRuns($entity: String!, $project: String!) {
     project(name: $project, entityName: $entity) {
     # Potentially huge response: requests all fields for all runs
-    runs { edges { node { id name state history summaryMetrics config files { edges { node { name size }}}}}}}
+    runs {
+        edges {
+        node {
+            id
+            name
+            state
+            history
+            summaryMetrics
+            config
+            files { edges { node { name size } } }
+        }
+        }
+    }
     }
 }
 ```
@@ -183,7 +203,7 @@ use the tool again with additional filters or pagination to get a more complete 
 
 **Constructing GraphQL Queries:**
 
-1.  **Operation Type:** Start with `query` for fetching data or `mutation` for modifying data.
+1.  **Operation Type:** Start with `query`. This tool is read-only and rejects `mutation` and `subscription` operations.
 2.  **Operation Name:** (Optional but recommended) A descriptive name (e.g., `ProjectInfo`).
 3.  **Variables Definition:** Define variables used in the query with their types (e.g., `($entity: String!, $project: String!)`). `!` means required.
 4.  **Selection Set:** Specify the fields you want to retrieve, nesting as needed based on the W&B schema.
@@ -196,9 +216,13 @@ use the tool again with additional filters or pagination to get a more complete 
         not `summary`, to access the run's summary dictionary as a JSON string), `historyKeys` (List of String), etc.
 *   **Connections (Lists):** Many lists (like `project.runs`, `artifact.files`) use a connection pattern:
     ```graphql
-    runs(first: Int, after: String, filters: JSONString, order: String) {
-        edges { node { id name ... } cursor }
+    query PaginatedRuns($entity: String!, $project: String!, $first: Int, $after: String, $filters: JSONString, $order: String) {
+      project(name: $project, entityName: $entity) {
+      runs(first: $first, after: $after, filters: $filters, order: $order) {
+        edges { node { id name } cursor }
         pageInfo { hasNextPage endCursor }
+      }
+      }
     }
     ```
     Use `first` for limit, `after` with `pageInfo.endCursor` for pagination, `filters` (as a JSON string) for complex filtering, and `order` for sorting.
@@ -667,6 +691,21 @@ def query_paginated_wandb_gql(
     Returns:
         The aggregated GraphQL response dictionary.
     """
+    try:
+        validate_read_only_graphql(query)
+    except GraphQLReadOnlyViolation as e:
+        return {
+            "errors": [
+                {
+                    "error": "read_only_violation",
+                    "message": str(e),
+                    "operation_types": list(e.operation_types),
+                }
+            ]
+        }
+    except Exception as e:
+        return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
+
     from wandb_mcp_server.api_client import get_wandb_api
 
     api = get_wandb_api()

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -5,13 +5,43 @@ from __future__ import annotations
 import importlib
 from typing import Any, Mapping
 
+from graphql import parse
+from graphql.language import ast as gql_ast
+
+
+class GraphQLReadOnlyViolation(ValueError):
+    """Raised when a GraphQL document contains a non-query operation."""
+
+    def __init__(self, operation_types: set[str]) -> None:
+        self.operation_types = tuple(sorted(operation_types))
+        joined_types = ", ".join(self.operation_types)
+        super().__init__(
+            f"query_wandb_tool accepts GraphQL query operations only; rejected operation type(s): {joined_types}."
+        )
+
+
+def validate_read_only_graphql(query: str) -> gql_ast.DocumentNode:
+    """Parse a GraphQL document and reject mutations and subscriptions."""
+
+    document = parse(query.strip())
+    disallowed_operations = {
+        definition.operation.value
+        for definition in document.definitions
+        if isinstance(definition, gql_ast.OperationDefinitionNode)
+        and definition.operation is not gql_ast.OperationType.QUERY
+    }
+    if disallowed_operations:
+        raise GraphQLReadOnlyViolation(disallowed_operations)
+    return document
+
 
 def execute_graphql(
     api: Any,
     query: str,
     variables: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Execute a GraphQL document with the current or legacy W&B SDK transport."""
+    """Execute a read-only GraphQL document with the current or legacy W&B SDK transport."""
+    validate_read_only_graphql(query)
     variables_dict = dict(variables or {})
     service_api = getattr(api, "__dict__", {}).get("_service_api")
     if service_api is not None and hasattr(service_api, "execute_graphql"):

--- a/tests/test_wandb_graphql_read_only.py
+++ b/tests/test_wandb_graphql_read_only.py
@@ -1,0 +1,145 @@
+"""Read-only contract tests for query_wandb_tool GraphQL execution."""
+
+from contextlib import contextmanager
+from pathlib import Path
+import re
+from types import SimpleNamespace
+
+import pytest
+from graphql import parse
+
+import wandb_mcp_server.api_client as api_client
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+from wandb_mcp_server.wandb_graphql import (
+    GraphQLReadOnlyViolation,
+    execute_graphql,
+    validate_read_only_graphql,
+)
+
+
+@pytest.mark.parametrize(
+    ("document", "operation_types"),
+    [
+        ("mutation Rename { renameProject(input: {}) { project { id } } }", ["mutation"]),
+        ("mutation { deleteRun(input: {}) { success } }", ["mutation"]),
+        ("subscription Updates { projectUpdated { id } }", ["subscription"]),
+        (
+            "query Viewer { viewer { id } } mutation Rename { renameProject(input: {}) { project { id } } }",
+            ["mutation"],
+        ),
+    ],
+)
+def test_non_query_operations_are_rejected_before_api_creation(monkeypatch, document, operation_types):
+    api_created = False
+
+    def fail_if_called():
+        nonlocal api_created
+        api_created = True
+        raise AssertionError("get_wandb_api must not be called for rejected GraphQL")
+
+    monkeypatch.setattr(api_client, "get_wandb_api", fail_if_called)
+
+    result = gql_tool.query_paginated_wandb_gql(document)
+
+    assert api_created is False
+    assert result == {
+        "errors": [
+            {
+                "error": "read_only_violation",
+                "message": (
+                    "query_wandb_tool accepts GraphQL query operations only; "
+                    f"rejected operation type(s): {', '.join(operation_types)}."
+                ),
+                "operation_types": operation_types,
+            }
+        ]
+    }
+
+
+def test_transport_revalidates_before_service_api_execution():
+    executions = []
+    service_api = SimpleNamespace(
+        execute_graphql=lambda query, variables=None: executions.append((query, variables)) or {}
+    )
+    api = SimpleNamespace(_service_api=service_api)
+
+    with pytest.raises(GraphQLReadOnlyViolation):
+        execute_graphql(api, "mutation { deleteRun(input: {}) { success } }")
+
+    assert executions == []
+
+
+def test_transport_revalidates_before_legacy_execution():
+    executions = []
+    client = SimpleNamespace(
+        execute=lambda document, variable_values=None: executions.append((document, variable_values)) or {}
+    )
+    api = SimpleNamespace(client=client)
+
+    with pytest.raises(GraphQLReadOnlyViolation):
+        execute_graphql(api, "subscription { projectUpdated { id } }")
+
+    assert executions == []
+
+
+def test_query_words_that_look_like_mutations_are_allowed(monkeypatch):
+    executions = []
+    service_api = SimpleNamespace(
+        execute_graphql=lambda query, variables=None: executions.append((query, variables))
+        or {"mutation": {"id": "viewer-id"}}
+    )
+    fake_api = SimpleNamespace(_service_api=service_api, viewer=SimpleNamespace(username="tester"))
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: fake_api)
+
+    @contextmanager
+    def fake_tracking(*args, **kwargs):
+        yield SimpleNamespace(mark_error=lambda error: None)
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_tracking)
+    document = """
+    # The word mutation in a comment is harmless.
+    query MutationReport {
+      mutation: viewer { id }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(document, max_items=1, items_per_page=1)
+
+    assert result == {"mutation": {"id": "viewer-id"}}
+    assert len(executions) == 1
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "{ __typename }",
+        "query Introspection { __schema { queryType { name } } }",
+        "query Viewer { viewer { ...ViewerFields } } fragment ViewerFields on User { id }",
+    ],
+)
+def test_read_only_query_shapes_are_allowed(document):
+    parsed = validate_read_only_graphql(document)
+    assert parsed == parse(document)
+
+
+def test_all_documented_graphql_examples_are_read_only():
+    examples = re.findall(r"```graphql\s*(.*?)```", gql_tool.QUERY_WANDB_GQL_TOOL_DESCRIPTION, flags=re.DOTALL)
+
+    assert examples
+    for example in examples:
+        validate_read_only_graphql(example)
+
+
+def test_application_graphql_transport_is_confined_to_approved_modules():
+    package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
+    approved = {
+        package_root / "wandb_graphql.py",
+        package_root / "mcp_tools" / "query_wandb_gql.py",
+    }
+    violations = [
+        path.relative_to(package_root).as_posix()
+        for path in package_root.rglob("*.py")
+        if path not in approved and "execute_graphql" in path.read_text()
+    ]
+
+    assert violations == []


### PR DESCRIPTION
## Summary

- makes `query_wandb_tool` unconditionally read-only without changing its name or signature
- parses the complete GraphQL document before creating a W&B client
- rejects mutations, subscriptions, and mixed-operation documents with a stable `read_only_violation` response
- repeats the same AST validation at the shared GraphQL transport boundary
- keeps queries, anonymous queries, fragments, aliases, pagination, and introspection working

This is PR 1 of the v0.3.7 read-only series. It should merge first into `staging/0.3.7`.

## Validation

- Ruff check and format check
- 29 focused GraphQL/hosted guardrail tests
- 795 non-integration tests on Python 3.12
- no live W&B requests and no `.env` access

The release CI matrix remains the authoritative Python 3.11/3.12 gate.