### PR TITLE
security: add opt-in read-only server mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, "staging/**"]
   pull_request:
-    branches: [main]
+    branches: [main, "staging/**"]
 
 jobs:
   test:
@@ -35,7 +35,7 @@ jobs:
           uv run --no-sync ruff format --check src/ tests/
 
       - name: Run unit tests
-        run: uv run --no-sync pytest tests/ -x -v --tb=short -q
+        run: uv run --no-sync pytest tests/ -m "not integration" -x -v --tb=short -q
         env:
           WANDB_SILENT: "True"
           WEAVE_SILENT: "True"
@@ -47,6 +47,40 @@ jobs:
           uv venv "$SMOKE_ENV" --python ${{ matrix.python-version }}
           uv pip install --python "$SMOKE_ENV/bin/python" dist/*.whl
           "$SMOKE_ENV/bin/python" -c "import wandb_mcp_server; print('ok')"
+        env:
+          WANDB_SILENT: "True"
+          WEAVE_SILENT: "True"
+
+  wandb-latest-compatibility:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install project and latest W&B SDKs
+        run: |
+          uv sync --frozen --extra test --python 3.12
+          uv pip install --python .venv/bin/python --upgrade "wandb[workspaces]" wandb-workspaces
+
+      - name: Show installed W&B SDK versions
+        run: uv run --no-sync python -c "from importlib.metadata import version; print('wandb', version('wandb')); print('wandb-workspaces', version('wandb-workspaces'))"
+
+      - name: Verify latest W&B GraphQL compatibility
+        run: |
+          uv run --no-sync pytest \
+            tests/test_wandb_graphql.py \
+            tests/test_wandb_graphql_read_only.py \
+            tests/test_hosted_gql_guardrails.py \
+            tests/test_hosted_gql_production_errors.py \
+            -k "not locked_wandb_versions_are_installed" \
+            -x -v --tb=short -q
         env:
           WANDB_SILENT: "True"
           WEAVE_SILENT: "True"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Query and analyze your Weights & Biases data using natural language through the 
 | **list_wandb_automations_tool** | List W&B Automations | *"What automations alert on run metrics or status for my team's runs?"* |
 | **list_wandb_integrations_tool** | List registered integrations for W&B automations (e.g. Slack, webhook) | *"Which Slack channels can my automations target?"* |
 
+**Read-only deployment mode:** Set `WANDB_MCP_READ_ONLY=true` to omit the two write tools,
+`create_wandb_report_tool` and `log_analysis_to_wandb`, while keeping every existing read tool.
+`query_wandb_tool` is query-only in every mode, regardless of this setting.
+
 **Weave Agents (OTel) tools** — these read the OpenTelemetry/GenAI agent-spans data plane (the **Agents** tab), which is separate from the classic Weave calls above:
 
 These tools are disabled by default. Enable them with `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=true`.
@@ -525,6 +529,8 @@ When running the server locally, you can customize its behavior with command lin
 | `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
+| `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS` | Enable Weave Agents (OTel/GenAI) tools (default: `false`) | No |
+| `WANDB_MCP_READ_ONLY` | Omit report creation and analysis logging write tools (default: `false`) | No |
 | `MCP_ANALYTICS_DISABLED` | Disable structured MCP analytics events. Useful as a workaround for older stdio builds that wrote analytics to stdout. | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.3.7"
 requires-python = ">=3.11"
 dependencies = [
     "weave>=0.52.35",
-    "wandb[workspaces]>=0.27.1",
+    "wandb[workspaces]>=0.28.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.0.0",
     "simple-parsing>=0.1.7",
     "python-dotenv>=1.0.0",
     "tiktoken>=0.9.0",
-    "wandb-workspaces>=0.4.2",
+    "wandb-workspaces>=0.4.4",
     "requests>=2.31.0",
 ]
 

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -56,6 +56,7 @@ WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS: bool = _env_bool(
     "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
     False,
 )
+WANDB_MCP_READ_ONLY: bool = _env_bool("WANDB_MCP_READ_ONLY", False)
 COST_SORT_FIELDS: frozenset[str] = frozenset({"total_cost", "completion_cost", "prompt_cost"})
 
 

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -23,12 +23,25 @@ logger = get_rich_logger(__name__)
 
 QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute a read-only GraphQL query against the W&B Models API.
 
-Use for experiment tracking runs, metrics, configs, artifacts, sweeps, and model registry.
+Use for read-only W&B Models queries that need GraphQL-specific filtering, sorting,
+nested selections, custom fields, sweeps, reports, or schema introspection.
 For LLM traces or Weave evaluations, use query_weave_traces_tool instead.
-For time-series metric history of a specific run, use get_run_history_tool instead.
+
+Prefer the existing SDK-backed tools when they provide the requested operation:
+- entity/project discovery: list_entities_tool and query_wandb_entity_projects
+- sampled or scanned run history: get_run_history_tool
+- artifact reads: list_artifact_versions_tool and get_artifact_details_tool
+- registry reads: list_registries_tool and list_registry_collections_tool
+- automations and integrations: list_wandb_automations_tool and list_wandb_integrations_tool
+
+Keep this raw GraphQL tool for general run filtering/sorting, custom project fields,
+sweeps, reports, introspection, and arbitrary nested selections where the exact
+response shape is not available from an existing tool. Do not translate arbitrary
+GraphQL into SDK calls: aliases, field selection, and nesting are part of its contract.
 
 <when_to_use>
-Call when user asks about runs, experiments, metrics, sweeps, or artifacts.
+Call when a read requires GraphQL-only filtering, sorting, nesting, custom fields,
+sweeps, reports, introspection, or an exact response shape not covered by an existing tool.
 </when_to_use>
 
 <query_analysis_step>
@@ -358,58 +371,6 @@ use the tool again with additional filters or pagination to get a more complete 
     ```
 <!-- WANDB_GQL_EXAMPLE_END name=GetFilteredRuns -->
 
-<!-- WANDB_GQL_EXAMPLE_START name=GetRunHistoryKeys -->
-*   **Get Run History Keys:** (Run is not a collection, historyKeys is scalar)
-    ```graphql
-    query RunHistoryKeys($entity: String!, $project: String!, $runName: String!) {
-        project(name: $project, entityName: $entity) {
-        run(name: $runName) {
-            id
-            name
-            historyKeys # Returns ["metric1", "metric2", ...]
-        }
-        }
-    }
-    ```
-    ```python
-    variables = {"entity": "my-entity", "project": "my-project", "runName": "run-abc"}
-    ```
-<!-- WANDB_GQL_EXAMPLE_END name=GetRunHistoryKeys -->
-
-<!-- WANDB_GQL_EXAMPLE_START name=GetRunHistorySampled -->
-*   **Get Specific Run History Data:** (Uses `sampledHistory` for specific keys)
-    ```graphql
-    # Corrected: Use specs argument
-    query RunHistorySampled($entity: String!, $project: String!, $runName: String!, $specs: [JSONString!]!) {
-        project(name: $project, entityName: $entity) {
-        run(name: $runName) {
-            id
-            name
-            # Use sampledHistory with specs to get actual values for specific keys
-            sampledHistory(specs: $specs) {
-                step # The step number
-                timestamp # Timestamp of the log
-                item # JSON string containing {key: value} for requested keys at this step
-            }
-        }
-        }
-    }
-    ```
-    ```python
-    # Corrected: Define specs variable with escaped JSON string literal for keys
-    variables = {
-        "entity": "my-entity",
-        "project": "my-project",
-        "runName": "run-abc",
-        "specs": ["{\"keys\": [\"loss\", \"val_accuracy\"]}}"] # List containing escaped JSON string
-    }
-    # Note: sampledHistory returns rows where *at least one* of the specified keys was logged.
-    # The 'item' field is a JSON string, you'll need to parse it (e.g., json.loads(row['item']))
-    # to get the actual key-value pairs for that step. It might not contain all requested keys
-    # if they weren't logged together at that specific step.
-    ```
-<!-- WANDB_GQL_EXAMPLE_END name=GetRunHistorySampled -->
-
 <!-- WANDB_GQL_EXAMPLE_START name=GetRunByDisplayName -->
 *   **Get Run by Display Name:** (Requires filtering and pagination structure)
     ```graphql
@@ -446,60 +407,13 @@ use the tool again with additional filters or pagination to get a more complete 
     ```
 <!-- WANDB_GQL_EXAMPLE_END name=GetRunByDisplayName -->
 
-<!-- WANDB_GQL_EXAMPLE_START name=GetArtifactDetails -->
-*   **Get Artifact Details:** (Artifact is not a collection, but `files` is)
-    ```graphql
-    query ArtifactDetails($entity: String!, $project: String!, $artifactName: String!) {
-        project(name: $project, entityName: $entity) {
-        artifact(name: $artifactName) { # Name format often 'artifact-name:version' or 'artifact-name:alias'
-            id
-            digest
-            description
-            state
-            size
-            createdAt
-            metadata # JSON String
-            aliases { alias } # Corrected: Use 'alias' field instead of 'name'
-            files { # Files is a collection, requires pagination structure
-            edges {
-                node { name url digest } # Corrected: Removed 'size' from File fields
-            }
-            pageInfo { endCursor hasNextPage } # Required for files collection
-            }
-        }
-        }
-    }
-    ```
-    ```python
-    variables = {"entity": "my-entity", "project": "my-project", "artifactName": "my-dataset:v3"}
-    ```
-<!-- WANDB_GQL_EXAMPLE_END name=GetArtifactDetails -->
-
-<!-- WANDB_GQL_EXAMPLE_START name=GetViewerInfo -->
-*   **Get Current User Info (Viewer):** (No variables needed)
-    ```graphql
-    query GetViewerInfo {
-        viewer {
-        id
-        username
-        email
-        entity
-        }
-    }
-    ```
-    ```python
-    # No variables needed for this query
-    variables = {}
-    ```
-<!-- WANDB_GQL_EXAMPLE_END name=GetViewerInfo -->
-
 **Troubleshooting Common Errors:**
 
 *   `"Cannot query field 'summary' on type 'Run'"`: Use the `summaryMetrics` field instead of `summary`. It returns a JSON string containing the summary dictionary.
 *   `"Argument 'filters' has invalid value ... Expected type 'JSONString'"`: Ensure the `filters` argument in your `variables` is a JSON formatted *string*, likely created using `json.dumps()`. Also check the *content* of the filter string for valid W&B filter syntax.
 *   `"400 Client Error: Bad Request"` (especially when using filters): Double-check the *syntax* inside your `filters` JSON string. Ensure operators (`$eq`, `$gt`, etc.) and structure are valid for the W&B API. Invalid field names or operators within the filter string can cause this.
 *   `"Unknown argument 'direction' on field 'runs'"`: Control sort direction using `+` (ascending) or `-` (descending) prefixes in the `order` argument string (e.g., `order: "-createdAt"`), not with a separate `direction` argument.
-*   Errors related to `history` (e.g., `"Unknown argument 'keys' on field 'history'"` or `"Field 'history' must not have a selection..."`): To get *available* metric keys, query the `historyKeys` field (returns `[String!]`). To get *time-series data* for specific keys, use the `sampledHistory(keys: [...])` field as shown in the examples; it returns structured data points. The simple `history` field might return raw data unsuitable for direct querying or is deprecated.
+*   For run history keys or time-series values, use `get_run_history_tool`; it provides sampled or scanned history through the supported SDK path.
 *   `"Query doesn't follow the W&B connection pattern"`: Ensure any field returning a list/collection (like `runs`, `files`, `artifacts`, etc.) includes the full `edges { node { ... } } pageInfo { endCursor hasNextPage }` structure. This is mandatory for pagination.
 *   `"Field must not have a selection"` / `"Field must have a selection"`: Check if the field you are querying is a scalar type (like `String`, `Int`, `JSONString`, `[String!]`) which cannot have sub-fields selected, or an object type which requires you to select sub-fields.
 *   `"Cannot query field 'step' on type 'Run'"`: The `Run` type does not have a direct `step` field. To find the maximum step count or total steps logged, query the `summaryMetrics` field (look for a key like `_step` or similar in the returned JSON string) or use the `historyLineCount` field which indicates the total number of history rows logged (often corresponding to steps).

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -12,12 +12,16 @@ from graphql.language import printer as gql_printer
 from graphql.language import visitor as gql_visitor
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.wandb_graphql import execute_graphql
+from wandb_mcp_server.wandb_graphql import (
+    GraphQLReadOnlyViolation,
+    execute_graphql,
+    validate_read_only_graphql,
+)
 
 logger = get_rich_logger(__name__)
 
 
-QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute a GraphQL query against the W&B Models API.
+QUERY_WANDB_GQL_TOOL_DESCRIPTION = """Execute a read-only GraphQL query against the W&B Models API.
 
 Use for experiment tracking runs, metrics, configs, artifacts, sweeps, and model registry.
 For LLM traces or Weave evaluations, use query_weave_traces_tool instead.
@@ -58,8 +62,8 @@ using the GraphQL query language.
 Parameters
 ----------
 query : str
-   he GraphQL query string. This defines the operation (query/mutation),
-                    the data to fetch (selection set), and any variables used.
+    The GraphQL query string. Only query operations are accepted; mutations and
+    subscriptions are rejected before any request is sent to W&B.
 variables : dict[str, Any] | None, optional
     A dictionary of variables to pass to the query.
                                             Keys should match variable names defined in the query
@@ -100,7 +104,9 @@ structure will fail with the error "Query doesn't follow the W&B connection patt
 
 Example of required pagination structure for any collection:
 ```graphql
-runs(first: 10) {  # or artifacts, files, etc.
+query PaginatedRuns($entity: String!, $project: String!) {
+  project(name: $project, entityName: $entity) {
+  runs(first: 10) {  # or artifacts, files, etc.
     edges {
     node {
         id
@@ -113,6 +119,8 @@ runs(first: 10) {  # or artifacts, files, etc.
     endCursor
     hasNextPage
     }
+  }
+  }
 }
 ```
 </required_pagination_structure>
@@ -145,7 +153,19 @@ Bad:
 query AllRuns($entity: String!, $project: String!) {
     project(name: $project, entityName: $entity) {
     # Potentially huge response: requests all fields for all runs
-    runs { edges { node { id name state history summaryMetrics config files { edges { node { name size }}}}}}}
+    runs {
+        edges {
+        node {
+            id
+            name
+            state
+            history
+            summaryMetrics
+            config
+            files { edges { node { name size } } }
+        }
+        }
+    }
     }
 }
 ```
@@ -183,7 +203,7 @@ use the tool again with additional filters or pagination to get a more complete 
 
 **Constructing GraphQL Queries:**
 
-1.  **Operation Type:** Start with `query` for fetching data or `mutation` for modifying data.
+1.  **Operation Type:** Start with `query`. This tool is read-only and rejects `mutation` and `subscription` operations.
 2.  **Operation Name:** (Optional but recommended) A descriptive name (e.g., `ProjectInfo`).
 3.  **Variables Definition:** Define variables used in the query with their types (e.g., `($entity: String!, $project: String!)`). `!` means required.
 4.  **Selection Set:** Specify the fields you want to retrieve, nesting as needed based on the W&B schema.
@@ -196,9 +216,13 @@ use the tool again with additional filters or pagination to get a more complete 
         not `summary`, to access the run's summary dictionary as a JSON string), `historyKeys` (List of String), etc.
 *   **Connections (Lists):** Many lists (like `project.runs`, `artifact.files`) use a connection pattern:
     ```graphql
-    runs(first: Int, after: String, filters: JSONString, order: String) {
-        edges { node { id name ... } cursor }
+    query PaginatedRuns($entity: String!, $project: String!, $first: Int, $after: String, $filters: JSONString, $order: String) {
+      project(name: $project, entityName: $entity) {
+      runs(first: $first, after: $after, filters: $filters, order: $order) {
+        edges { node { id name } cursor }
         pageInfo { hasNextPage endCursor }
+      }
+      }
     }
     ```
     Use `first` for limit, `after` with `pageInfo.endCursor` for pagination, `filters` (as a JSON string) for complex filtering, and `order` for sorting.
@@ -667,6 +691,21 @@ def query_paginated_wandb_gql(
     Returns:
         The aggregated GraphQL response dictionary.
     """
+    try:
+        validate_read_only_graphql(query)
+    except GraphQLReadOnlyViolation as e:
+        return {
+            "errors": [
+                {
+                    "error": "read_only_violation",
+                    "message": str(e),
+                    "operation_types": list(e.operation_types),
+                }
+            ]
+        }
+    except Exception as e:
+        return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
+
     from wandb_mcp_server.api_client import get_wandb_api
 
     api = get_wandb_api()

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -501,6 +501,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
     Args:
         mcp_instance: The FastMCP instance to register tools on
     """
+    from wandb_mcp_server.config import WANDB_MCP_READ_ONLY
 
     @mcp_instance.tool(description=QUERY_WEAVE_TRACES_TOOL_DESCRIPTION)
     async def query_weave_traces_tool(
@@ -791,69 +792,71 @@ def register_tools(mcp_instance: FastMCP) -> None:
     ) -> Dict[str, Any]:
         return query_paginated_wandb_gql(query, variables, max_items, items_per_page)
 
-    @mcp_instance.tool(description=CREATE_WANDB_REPORT_TOOL_DESCRIPTION)
-    async def create_wandb_report_tool(
-        entity_name: str,
-        project_name: str,
-        title: str,
-        description: Optional[str] = None,
-        markdown_report_text: str = "",
-        plots_html: Optional[Union[Dict[str, str], str]] = None,
-        panels: Optional[List[Dict[str, Any]]] = None,
-    ) -> str:
-        try:
-            result = create_report(
-                entity_name=entity_name,
-                project_name=project_name,
-                title=title,
-                description=description,
-                markdown_report_text=markdown_report_text,
-                plots_html=plots_html,
-                panels=panels,
-            )
+    if not WANDB_MCP_READ_ONLY:
 
-            return f"The report was saved here: {result['url']}"
-        except Exception as e:
-            raise e
-
-    from wandb_mcp_server.mcp_tools.log_analysis import (
-        LOG_ANALYSIS_TOOL_DESCRIPTION,
-        log_analysis,
-    )
-
-    @mcp_instance.tool(description=LOG_ANALYSIS_TOOL_DESCRIPTION)
-    async def log_analysis_to_wandb(
-        entity_name: str,
-        project_name: str,
-        analysis_name: str,
-        data: List[Dict[str, Any]],
-        charts: Optional[List[Dict[str, Any]]] = None,
-        scalars: Optional[Dict[str, float]] = None,
-    ) -> str:
-        from concurrent.futures import ThreadPoolExecutor
-
-        from wandb_mcp_server.api_client import WandBApiManager
-
-        try:
-            api_key = WandBApiManager.get_api_key()
-
-            def _log_with_context():
-                WandBApiManager.set_context_api_key(api_key)
-                return log_analysis(
+        @mcp_instance.tool(description=CREATE_WANDB_REPORT_TOOL_DESCRIPTION)
+        async def create_wandb_report_tool(
+            entity_name: str,
+            project_name: str,
+            title: str,
+            description: Optional[str] = None,
+            markdown_report_text: str = "",
+            plots_html: Optional[Union[Dict[str, str], str]] = None,
+            panels: Optional[List[Dict[str, Any]]] = None,
+        ) -> str:
+            try:
+                result = create_report(
                     entity_name=entity_name,
                     project_name=project_name,
-                    analysis_name=analysis_name,
-                    data=data,
-                    charts=charts,
-                    scalars=scalars,
+                    title=title,
+                    description=description,
+                    markdown_report_text=markdown_report_text,
+                    plots_html=plots_html,
+                    panels=panels,
                 )
 
-            with ThreadPoolExecutor(max_workers=1) as pool:
-                result = await asyncio.get_event_loop().run_in_executor(pool, _log_with_context)
-            return json.dumps(result)
-        except Exception as e:
-            logger.error(f"Error in log_analysis_to_wandb: {e}", exc_info=True)
-            return json.dumps({"error": "log_failed", "message": str(e)[:500]})
+                return f"The report was saved here: {result['url']}"
+            except Exception as e:
+                raise e
+
+        from wandb_mcp_server.mcp_tools.log_analysis import (
+            LOG_ANALYSIS_TOOL_DESCRIPTION,
+            log_analysis,
+        )
+
+        @mcp_instance.tool(description=LOG_ANALYSIS_TOOL_DESCRIPTION)
+        async def log_analysis_to_wandb(
+            entity_name: str,
+            project_name: str,
+            analysis_name: str,
+            data: List[Dict[str, Any]],
+            charts: Optional[List[Dict[str, Any]]] = None,
+            scalars: Optional[Dict[str, float]] = None,
+        ) -> str:
+            from concurrent.futures import ThreadPoolExecutor
+
+            from wandb_mcp_server.api_client import WandBApiManager
+
+            try:
+                api_key = WandBApiManager.get_api_key()
+
+                def _log_with_context():
+                    WandBApiManager.set_context_api_key(api_key)
+                    return log_analysis(
+                        entity_name=entity_name,
+                        project_name=project_name,
+                        analysis_name=analysis_name,
+                        data=data,
+                        charts=charts,
+                        scalars=scalars,
+                    )
+
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    result = await asyncio.get_event_loop().run_in_executor(pool, _log_with_context)
+                return json.dumps(result)
+            except Exception as e:
+                logger.error(f"Error in log_analysis_to_wandb: {e}", exc_info=True)
+                return json.dumps({"error": "log_failed", "message": str(e)[:500]})
 
     @mcp_instance.tool(description=LIST_ENTITIES_TOOL_DESCRIPTION)
     def list_entities_tool() -> str:

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -5,13 +5,43 @@ from __future__ import annotations
 import importlib
 from typing import Any, Mapping
 
+from graphql import parse
+from graphql.language import ast as gql_ast
+
+
+class GraphQLReadOnlyViolation(ValueError):
+    """Raised when a GraphQL document contains a non-query operation."""
+
+    def __init__(self, operation_types: set[str]) -> None:
+        self.operation_types = tuple(sorted(operation_types))
+        joined_types = ", ".join(self.operation_types)
+        super().__init__(
+            f"query_wandb_tool accepts GraphQL query operations only; rejected operation type(s): {joined_types}."
+        )
+
+
+def validate_read_only_graphql(query: str) -> gql_ast.DocumentNode:
+    """Parse a GraphQL document and reject mutations and subscriptions."""
+
+    document = parse(query.strip())
+    disallowed_operations = {
+        definition.operation.value
+        for definition in document.definitions
+        if isinstance(definition, gql_ast.OperationDefinitionNode)
+        and definition.operation is not gql_ast.OperationType.QUERY
+    }
+    if disallowed_operations:
+        raise GraphQLReadOnlyViolation(disallowed_operations)
+    return document
+
 
 def execute_graphql(
     api: Any,
     query: str,
     variables: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Execute a GraphQL document with the current or legacy W&B SDK transport."""
+    """Execute a read-only GraphQL document with the current or legacy W&B SDK transport."""
+    validate_read_only_graphql(query)
     variables_dict = dict(variables or {})
     service_api = getattr(api, "__dict__", {}).get("_service_api")
     if service_api is not None and hasattr(service_api, "execute_graphql"):

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -1,8 +1,7 @@
-"""GraphQL helpers compatible across W&B SDK GraphQL transports."""
+"""Read-only GraphQL helpers for the supported W&B SDK transport."""
 
 from __future__ import annotations
 
-import importlib
 from typing import Any, Mapping
 
 from graphql import parse
@@ -40,12 +39,13 @@ def execute_graphql(
     query: str,
     variables: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Execute a read-only GraphQL document with the current or legacy W&B SDK transport."""
+    """Execute a read-only GraphQL document with W&B's service transport."""
     validate_read_only_graphql(query)
     variables_dict = dict(variables or {})
-    service_api = getattr(api, "__dict__", {}).get("_service_api")
-    if service_api is not None and hasattr(service_api, "execute_graphql"):
-        return service_api.execute_graphql(query, variables=variables_dict)
-
-    gql = importlib.import_module("wandb_gql").gql
-    return api.client.execute(gql(query), variable_values=variables_dict)
+    service_api = getattr(api, "_service_api", None)
+    execute = getattr(service_api, "execute_graphql", None)
+    if not callable(execute):
+        raise RuntimeError(
+            "W&B SDK compatibility error: query_wandb_tool requires wandb>=0.28.0 with ServiceApi.execute_graphql."
+        )
+    return execute(query, variables=variables_dict)

--- a/tests/test_hosted_gql_guardrails.py
+++ b/tests/test_hosted_gql_guardrails.py
@@ -1,12 +1,8 @@
 from contextlib import contextmanager
 from types import SimpleNamespace
 
-from graphql import parse
-from graphql.language.printer import print_ast
-
 import wandb_mcp_server.api_client as api_client
 import wandb_mcp_server.config as cfg
-import wandb_mcp_server.wandb_graphql as graphql_transport
 from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
 
 
@@ -30,14 +26,14 @@ class FakeClient:
         }
         self.executions = []
 
-    def execute(self, document, variable_values=None):
-        self.executions.append((print_ast(document), dict(variable_values or {})))
+    def execute_graphql(self, query, variables=None):
+        self.executions.append((query, dict(variables or {})))
         return self.response
 
 
 class FakeApi:
     def __init__(self, client):
-        self.client = client
+        self._service_api = client
         self.viewer = SimpleNamespace(username="tester")
 
 
@@ -66,11 +62,6 @@ class FakeServiceBackedApi:
 
 def _install_fake_api(monkeypatch, client):
     monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
-    monkeypatch.setattr(
-        graphql_transport.importlib,
-        "import_module",
-        lambda name: SimpleNamespace(gql=parse),
-    )
 
     @contextmanager
     def fake_track_tool_execution(*args, **kwargs):

--- a/tests/test_hosted_gql_production_errors.py
+++ b/tests/test_hosted_gql_production_errors.py
@@ -1,12 +1,8 @@
 from contextlib import contextmanager
 from types import SimpleNamespace
 
-from graphql import parse
-from graphql.language.printer import print_ast
-
 import wandb_mcp_server.api_client as api_client
 import wandb_mcp_server.config as cfg
-import wandb_mcp_server.wandb_graphql as graphql_transport
 from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
 
 
@@ -30,24 +26,19 @@ class FakeClient:
         }
         self.executions = []
 
-    def execute(self, document, variable_values=None):
-        self.executions.append((print_ast(document), dict(variable_values or {})))
+    def execute_graphql(self, query, variables=None):
+        self.executions.append((query, dict(variables or {})))
         return self.response
 
 
 class FakeApi:
     def __init__(self, client):
-        self.client = client
+        self._service_api = client
         self.viewer = SimpleNamespace(username="tester")
 
 
 def _install_fake_api(monkeypatch, client):
     monkeypatch.setattr(api_client, "get_wandb_api", lambda: FakeApi(client))
-    monkeypatch.setattr(
-        graphql_transport.importlib,
-        "import_module",
-        lambda name: SimpleNamespace(gql=parse),
-    )
 
     @contextmanager
     def fake_track_tool_execution(*args, **kwargs):

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -97,6 +97,35 @@ class TestDetailLevelInQueryWeave:
         assert '"full"' in QUERY_WEAVE_TRACES_TOOL_DESCRIPTION
 
 
+class TestQueryWandbSdkRouting:
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "query_wandb_entity_projects",
+            "get_run_history_tool",
+            "list_artifact_versions_tool",
+            "get_artifact_details_tool",
+            "list_registries_tool",
+            "list_registry_collections_tool",
+            "list_wandb_automations_tool",
+            "list_wandb_integrations_tool",
+        ],
+    )
+    def test_recommends_existing_sdk_backed_tools(self, tool_name):
+        assert tool_name in QUERY_WANDB_GQL_TOOL_DESCRIPTION
+
+    @pytest.mark.parametrize(
+        "removed_example",
+        ["GetRunHistoryKeys", "GetRunHistorySampled", "GetArtifactDetails", "GetViewerInfo"],
+    )
+    def test_redundant_graphql_examples_are_removed(self, removed_example):
+        assert f"name={removed_example}" not in QUERY_WANDB_GQL_TOOL_DESCRIPTION
+
+    def test_documents_remaining_raw_graphql_use_cases(self):
+        for use_case in ("filtering", "sorting", "custom project fields", "sweeps", "reports", "introspection"):
+            assert use_case in QUERY_WANDB_GQL_TOOL_DESCRIPTION
+
+
 class TestPanelsInCreateReport:
     def test_panels_documented(self):
         assert "panels" in CREATE_WANDB_REPORT_TOOL_DESCRIPTION

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -16,11 +16,15 @@ WEAVE_TOOLS = {
 
 NON_WEAVE_TOOLS = {
     "query_wandb_tool",
-    "create_wandb_report_tool",
     "get_run_history_tool",
     "list_artifact_versions_tool",
     "compare_runs_tool",
     "probe_project_tool",
+}
+
+WRITE_TOOLS = {
+    "create_wandb_report_tool",
+    "log_analysis_to_wandb",
 }
 
 # Agents (OTel) tools read a separate agent-spans data plane and are opt-in.
@@ -39,6 +43,7 @@ AGENT_TOOLS = {
 def _reset_tool_gate_env() -> None:
     os.environ.pop("WANDB_MCP_ENABLE_WEAVE_TOOLS", None)
     os.environ.pop("WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS", None)
+    os.environ.pop("WANDB_MCP_READ_ONLY", None)
 
 
 def _registered_tool_names() -> set[str]:
@@ -56,6 +61,7 @@ def test_weave_tools_registered_by_default():
 
     assert WEAVE_TOOLS.issubset(names)
     assert NON_WEAVE_TOOLS.issubset(names)
+    assert WRITE_TOOLS.issubset(names)
     assert AGENT_TOOLS.isdisjoint(names)
 
 
@@ -73,6 +79,7 @@ def test_weave_tools_can_be_disabled():
     assert WEAVE_TOOLS.isdisjoint(names)
     assert AGENT_TOOLS.isdisjoint(names)
     assert NON_WEAVE_TOOLS.issubset(names)
+    assert WRITE_TOOLS.issubset(names)
 
 
 def test_agent_tools_enabled_via_flag():
@@ -90,6 +97,7 @@ def test_agent_tools_enabled_via_flag():
     assert WEAVE_TOOLS.issubset(names)
     assert AGENT_TOOLS.issubset(names)
     assert NON_WEAVE_TOOLS.issubset(names)
+    assert WRITE_TOOLS.issubset(names)
 
 
 def test_agent_and_weave_flags_are_independent():
@@ -108,3 +116,49 @@ def test_agent_and_weave_flags_are_independent():
     assert WEAVE_TOOLS.isdisjoint(names)
     assert AGENT_TOOLS.issubset(names)
     assert NON_WEAVE_TOOLS.issubset(names)
+    assert WRITE_TOOLS.issubset(names)
+
+
+def test_read_only_mode_removes_exactly_the_write_tools():
+    _reset_tool_gate_env()
+    import wandb_mcp_server.config as cfg
+
+    importlib.reload(cfg)
+    default_names = _registered_tool_names()
+    os.environ["WANDB_MCP_READ_ONLY"] = "true"
+    try:
+        importlib.reload(cfg)
+        read_only_names = _registered_tool_names()
+        assert cfg.WANDB_MCP_READ_ONLY is True
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    assert default_names - read_only_names == WRITE_TOOLS
+    assert read_only_names - default_names == set()
+    assert WRITE_TOOLS.isdisjoint(read_only_names)
+    assert NON_WEAVE_TOOLS.issubset(read_only_names)
+    assert "query_wandb_tool" in read_only_names
+    assert WEAVE_TOOLS.issubset(read_only_names)
+    assert AGENT_TOOLS.isdisjoint(read_only_names)
+
+
+def test_read_only_mode_is_independent_of_weave_and_agent_gates():
+    _reset_tool_gate_env()
+    os.environ["WANDB_MCP_READ_ONLY"] = "true"
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = "false"
+    os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = "true"
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    assert WRITE_TOOLS.isdisjoint(names)
+    assert WEAVE_TOOLS.isdisjoint(names)
+    assert AGENT_TOOLS.issubset(names)
+    assert NON_WEAVE_TOOLS.issubset(names)
+    assert "query_wandb_tool" in names

--- a/tests/test_wandb_graphql.py
+++ b/tests/test_wandb_graphql.py
@@ -3,18 +3,25 @@
 from __future__ import annotations
 
 import ast
+from importlib.metadata import version
 from pathlib import Path
-import sys
-import types
+
+import pytest
+from wandb.apis.public.service_api import ServiceApi
 
 from wandb_mcp_server.wandb_graphql import execute_graphql
 
 
-def test_query_tool_has_no_top_level_wandb_gql_import():
-    module_path = Path(__file__).parents[1] / "src" / "wandb_mcp_server" / "mcp_tools" / "query_wandb_gql.py"
-    tree = ast.parse(module_path.read_text())
+def test_query_path_has_no_wandb_gql_or_legacy_client_usage():
+    package_path = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
+    query_module = package_path / "mcp_tools" / "query_wandb_gql.py"
+    transport_module = package_path / "wandb_graphql.py"
+    tree = ast.parse(query_module.read_text())
+    transport_source = transport_module.read_text()
 
     assert not any(isinstance(node, ast.ImportFrom) and node.module == "wandb_gql" for node in tree.body)
+    assert "wandb_gql" not in transport_source
+    assert "api.client" not in transport_source
 
 
 def test_execute_graphql_prefers_service_api_without_client():
@@ -38,25 +45,15 @@ def test_execute_graphql_prefers_service_api_without_client():
     assert api._service_api.calls == [("query Test { viewer { id } }", {"x": 1})]
 
 
-def test_execute_graphql_lazily_falls_back_to_wandb_gql(monkeypatch):
-    class Client:
-        def __init__(self):
-            self.calls = []
+def test_supported_sdk_exposes_service_graphql_transport():
+    assert callable(ServiceApi.execute_graphql)
 
-        def execute(self, query, *, variable_values):
-            self.calls.append((query, variable_values))
-            return {"ok": True}
 
-    class Api:
-        def __init__(self):
-            self.client = Client()
-            self.viewer = object()
+def test_execute_graphql_reports_sdk_compatibility_error_without_service_transport():
+    with pytest.raises(RuntimeError, match=r"requires wandb>=0\.28\.0 with ServiceApi\.execute_graphql"):
+        execute_graphql(object(), "query Test { viewer { id } }")
 
-    fake_wandb_gql = types.SimpleNamespace(gql=lambda query: f"parsed:{query}")
-    monkeypatch.setitem(sys.modules, "wandb_gql", fake_wandb_gql)
 
-    api = Api()
-    result = execute_graphql(api, "query Test { viewer { id } }", {"x": 1})
-
-    assert result == {"ok": True}
-    assert api.client.calls == [("parsed:query Test { viewer { id } }", {"x": 1})]
+def test_locked_wandb_versions_are_installed():
+    assert version("wandb") == "0.28.0"
+    assert version("wandb-workspaces") == "0.4.4"

--- a/tests/test_wandb_graphql_read_only.py
+++ b/tests/test_wandb_graphql_read_only.py
@@ -1,0 +1,145 @@
+"""Read-only contract tests for query_wandb_tool GraphQL execution."""
+
+from contextlib import contextmanager
+from pathlib import Path
+import re
+from types import SimpleNamespace
+
+import pytest
+from graphql import parse
+
+import wandb_mcp_server.api_client as api_client
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+from wandb_mcp_server.wandb_graphql import (
+    GraphQLReadOnlyViolation,
+    execute_graphql,
+    validate_read_only_graphql,
+)
+
+
+@pytest.mark.parametrize(
+    ("document", "operation_types"),
+    [
+        ("mutation Rename { renameProject(input: {}) { project { id } } }", ["mutation"]),
+        ("mutation { deleteRun(input: {}) { success } }", ["mutation"]),
+        ("subscription Updates { projectUpdated { id } }", ["subscription"]),
+        (
+            "query Viewer { viewer { id } } mutation Rename { renameProject(input: {}) { project { id } } }",
+            ["mutation"],
+        ),
+    ],
+)
+def test_non_query_operations_are_rejected_before_api_creation(monkeypatch, document, operation_types):
+    api_created = False
+
+    def fail_if_called():
+        nonlocal api_created
+        api_created = True
+        raise AssertionError("get_wandb_api must not be called for rejected GraphQL")
+
+    monkeypatch.setattr(api_client, "get_wandb_api", fail_if_called)
+
+    result = gql_tool.query_paginated_wandb_gql(document)
+
+    assert api_created is False
+    assert result == {
+        "errors": [
+            {
+                "error": "read_only_violation",
+                "message": (
+                    "query_wandb_tool accepts GraphQL query operations only; "
+                    f"rejected operation type(s): {', '.join(operation_types)}."
+                ),
+                "operation_types": operation_types,
+            }
+        ]
+    }
+
+
+def test_transport_revalidates_before_service_api_execution():
+    executions = []
+    service_api = SimpleNamespace(
+        execute_graphql=lambda query, variables=None: executions.append((query, variables)) or {}
+    )
+    api = SimpleNamespace(_service_api=service_api)
+
+    with pytest.raises(GraphQLReadOnlyViolation):
+        execute_graphql(api, "mutation { deleteRun(input: {}) { success } }")
+
+    assert executions == []
+
+
+def test_transport_revalidates_before_legacy_execution():
+    executions = []
+    client = SimpleNamespace(
+        execute=lambda document, variable_values=None: executions.append((document, variable_values)) or {}
+    )
+    api = SimpleNamespace(client=client)
+
+    with pytest.raises(GraphQLReadOnlyViolation):
+        execute_graphql(api, "subscription { projectUpdated { id } }")
+
+    assert executions == []
+
+
+def test_query_words_that_look_like_mutations_are_allowed(monkeypatch):
+    executions = []
+    service_api = SimpleNamespace(
+        execute_graphql=lambda query, variables=None: executions.append((query, variables))
+        or {"mutation": {"id": "viewer-id"}}
+    )
+    fake_api = SimpleNamespace(_service_api=service_api, viewer=SimpleNamespace(username="tester"))
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: fake_api)
+
+    @contextmanager
+    def fake_tracking(*args, **kwargs):
+        yield SimpleNamespace(mark_error=lambda error: None)
+
+    monkeypatch.setattr(gql_tool, "track_tool_execution", fake_tracking)
+    document = """
+    # The word mutation in a comment is harmless.
+    query MutationReport {
+      mutation: viewer { id }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(document, max_items=1, items_per_page=1)
+
+    assert result == {"mutation": {"id": "viewer-id"}}
+    assert len(executions) == 1
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        "{ __typename }",
+        "query Introspection { __schema { queryType { name } } }",
+        "query Viewer { viewer { ...ViewerFields } } fragment ViewerFields on User { id }",
+    ],
+)
+def test_read_only_query_shapes_are_allowed(document):
+    parsed = validate_read_only_graphql(document)
+    assert parsed == parse(document)
+
+
+def test_all_documented_graphql_examples_are_read_only():
+    examples = re.findall(r"```graphql\s*(.*?)```", gql_tool.QUERY_WANDB_GQL_TOOL_DESCRIPTION, flags=re.DOTALL)
+
+    assert examples
+    for example in examples:
+        validate_read_only_graphql(example)
+
+
+def test_application_graphql_transport_is_confined_to_approved_modules():
+    package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
+    approved = {
+        package_root / "wandb_graphql.py",
+        package_root / "mcp_tools" / "query_wandb_gql.py",
+    }
+    violations = [
+        path.relative_to(package_root).as_posix()
+        for path in package_root.rglob("*.py")
+        if path not in approved and "execute_graphql" in path.read_text()
+    ]
+
+    assert violations == []

--- a/tests/test_wandb_graphql_read_only.py
+++ b/tests/test_wandb_graphql_read_only.py
@@ -69,7 +69,7 @@ def test_transport_revalidates_before_service_api_execution():
     assert executions == []
 
 
-def test_transport_revalidates_before_legacy_execution():
+def test_transport_revalidates_before_sdk_compatibility_check():
     executions = []
     client = SimpleNamespace(
         execute=lambda document, variable_values=None: executions.append((document, variable_values)) or {}

--- a/uv.lock
+++ b/uv.lock
@@ -2127,7 +2127,7 @@ wheels = [
 
 [[package]]
 name = "wandb"
-version = "0.27.1"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2141,17 +2141,17 @@ dependencies = [
     { name = "sentry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/35a6e297ca22e0e2cbe77cbd21d33462874b8f508b41f0fae2f4c292ffea/wandb-0.27.1.tar.gz", hash = "sha256:214b3430c1e76e5eb55192c1bb4184a084f969e0c75cb15a709324c069efe10e", size = 40298729, upload-time = "2026-06-04T04:28:23.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a7/683bfbd6cbade3012bc90d3e9c4cfc72dd62566195bf4c30321946d64b77/wandb-0.28.0.tar.gz", hash = "sha256:b20e5af0fe80e2e2a466b0466a1d60cedcc578dce0f036eca04f4a0adcad95b6", size = 40558332, upload-time = "2026-06-23T00:38:50.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/e2/3fa03632b11cbaa8b078a2c50fd985b6009a3ffcc566c3898d430c987cd1/wandb-0.27.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:abd80f9f74a4c28890c2a38d356fb0bceadfce497311ff13431ff387f4f23698", size = 23985424, upload-time = "2026-06-04T04:28:01.685Z" },
-    { url = "https://files.pythonhosted.org/packages/91/4a/4dfa139ccce0f686eef44e3b8a3efc535333e4275e8fddcb68ff03b4f60d/wandb-0.27.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:2fb189f186f2a41df9c559918a3308da22069dca5bc6f021bfface197a9aa1ff", size = 25164981, upload-time = "2026-06-04T04:28:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/16/4e/872bd057b83a6c5da5c4e8c482c41df9338898a3c34d26172eb306388b8c/wandb-0.27.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1c62f0daae156b1f56b2ac78e3dab25a19c8e4ef73b83547c0c877c77d433e9a", size = 24551609, upload-time = "2026-06-04T04:28:06.786Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cd/0cd5ef8723581cef8d6ecb9de29623a3da89c969b04f32809c1f22985ba2/wandb-0.27.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:77ccc56582d07671a867b78ced686096ca53c021d79fed38e5aaf4cebbd0450b", size = 26378746, upload-time = "2026-06-04T04:28:09.015Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3e/9fbaac13e1ffcecb3265dd08b8a76a15c21361ccbc0c65ab745847268240/wandb-0.27.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:af91e99c0dc02de03997169d218698e1175fca1cd06d5af5ef68a855c0cf6968", size = 24724687, upload-time = "2026-06-04T04:28:11.651Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2b/f9c5bffd1f858c2c0a6dd41a8b5dea3d9337d4282dd247e603e1bea98d80/wandb-0.27.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a79f899de9861543bf20f273cdfe513c85d6841e88568aa1de05ce4a0a5a547b", size = 26690886, upload-time = "2026-06-04T04:28:14.364Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/14/91283eb2a17063091858f9f2b822437b16d75e53d742e295db1b479dcca4/wandb-0.27.1-py3-none-win32.whl", hash = "sha256:38dd902b56188789d3b17c03f8f77fef97a0b1c5aecee94c5bd70836e667b2cf", size = 24149484, upload-time = "2026-06-04T04:28:16.712Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7d25ba1386fe6b4dea65342aba7c82a9ac3294cb591b449622b31d75e0c5/wandb-0.27.1-py3-none-win_amd64.whl", hash = "sha256:2d7e4bb60a28756a0a6c78884dbad60bcd07e7cf840cdd8e3a3873bdf2af62af", size = 24149492, upload-time = "2026-06-04T04:28:18.85Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b4/ed3e3410d0a86b9542c4cd3839f47bd72493063240759e7120f38637a9c0/wandb-0.27.1-py3-none-win_arm64.whl", hash = "sha256:356eda1fbce41101286935f5291e7db5ddfd062b23ddbbdd1d45ed03763ba2c4", size = 22059130, upload-time = "2026-06-04T04:28:20.985Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/47/1723605f76c5d6446b6d0db65b83eda1599721bc8c1e65bd76cc1682b1a7/wandb-0.28.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:c3dab1205a5aca4abbad1eca08902cdba86add0edfa83d8d61b4429d0e79fa87", size = 24335272, upload-time = "2026-06-23T00:38:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ff/42b539bc75bc48fc86981dccde89327ba9b71504b805b9ba42cba7c26de9/wandb-0.28.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:ae255da18726ee8e731ef82cbc85035b901a28ae14cf91604c361b44b8d44ce0", size = 25557959, upload-time = "2026-06-23T00:38:28.993Z" },
+    { url = "https://files.pythonhosted.org/packages/15/55/c3db03d04aeab3726066a418b2ef6a1f8119774ee510f4fbe992f52b7472/wandb-0.28.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:6dbcba12ab168aa37561f2f32dcdef8713495fc25fa7d30fdc9bfb37989694dd", size = 24878557, upload-time = "2026-06-23T00:38:31.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5d/1385ce3c219cb5bd30d4027687e3f8d25969c7dfd09adad1cbd5080e1a72/wandb-0.28.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:325b2d0bd88be6eda5db10542499bad3710927f2569c81a84dc5eeaffc76825c", size = 26764727, upload-time = "2026-06-23T00:38:33.775Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/23b6c17a6d3d5422b007707961c4496b2f6f892624d2910c9f7742fcc202/wandb-0.28.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8954bc1c62ae43914dce2bebfd1d9957f72350f8fbb78e5cdfe2ca9b6be8a7b8", size = 25051656, upload-time = "2026-06-23T00:38:36.281Z" },
+    { url = "https://files.pythonhosted.org/packages/89/67/9be00fb2db2281063af24a148636d2dd363d337317642ab5d8e93572c794/wandb-0.28.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9fec6c908554c2dad33110c1312bc3028cc2e430f0679f16b84f82c8ea801e3b", size = 27074113, upload-time = "2026-06-23T00:38:38.737Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b1/f7a96c09cab0c5131b1e6466659b093b401e1653cbe6bb77b462fc1c361d/wandb-0.28.0-py3-none-win32.whl", hash = "sha256:8834ef3a7c8c43b701654162783caa7ad37af48a0ff06fc35d0d65a411f76ccd", size = 24525206, upload-time = "2026-06-23T00:38:42.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c4/c7bed5e981679c74e9fbb22c03ff31c42e95f266199d03d8d325f4d0e6df/wandb-0.28.0-py3-none-win_amd64.whl", hash = "sha256:ac1f82292e2da4f98297b78c3a46726b3a6c5734ecb75fc39b8db2c8a4989159", size = 24525214, upload-time = "2026-06-23T00:38:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/77/b5ce9696c8cb955521a7941fbc443e78b2f504894c6ae1a2d0b1de6e12ae/wandb-0.28.0-py3-none-win_arm64.whl", hash = "sha256:c5b0faf1b84cf79ebabed77538c1940a4c6053e815f767a4004e877a1354bed1", size = 22378208, upload-time = "2026-06-23T00:38:47.148Z" },
 ]
 
 [package.optional-dependencies]
@@ -2213,8 +2213,8 @@ requires-dist = [
     { name = "simple-parsing", specifier = ">=0.1.7" },
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.24.0" },
-    { name = "wandb", extras = ["workspaces"], specifier = ">=0.27.1" },
-    { name = "wandb-workspaces", specifier = ">=0.4.2" },
+    { name = "wandb", extras = ["workspaces"], specifier = ">=0.28.0" },
+    { name = "wandb-workspaces", specifier = ">=0.4.4" },
     { name = "weave", specifier = ">=0.52.35" },
 ]
 provides-extras = ["test", "http"]
@@ -2227,15 +2227,15 @@ dev = [
 
 [[package]]
 name = "wandb-workspaces"
-version = "0.4.2"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "wandb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/c2/4f4b202d09917fff2271cb6464150932fe2474e27f949bd69704a8470a01/wandb_workspaces-0.4.2.tar.gz", hash = "sha256:bade2052aef40a286f833c962b7016c608bab62f61c9397f07ae3963da5997ff", size = 231126, upload-time = "2026-06-05T18:50:53.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/eb/b2669ea4e5883b55c44555607eaa552a839b101aa14a6d01818c0ed55c82/wandb_workspaces-0.4.4.tar.gz", hash = "sha256:084a006ca2735cb77634fd5b7d4e1c1d57c642d8601739797258349710db9edc", size = 238003, upload-time = "2026-06-25T20:17:47.845Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/ef/2a75bb3403f6c300355772b601324c4c8bfd83ff3eb12ca465be5d1f8190/wandb_workspaces-0.4.2-py3-none-any.whl", hash = "sha256:60739ebba89e254fd3e469591df014161c81e52970b93760bc42d56cf24d91fb", size = 107339, upload-time = "2026-06-05T18:50:52.428Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/531a070834fd33c729d5b6b56f5a6ce74c5aa0f07831420343349eae1475/wandb_workspaces-0.4.4-py3-none-any.whl", hash = "sha256:60ab10d4f648cf7c142fd8cbf105840685bb5013c39c921471c6c061a57ce4b0", size = 111957, upload-time = "2026-06-25T20:17:46.574Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- adds `WANDB_MCP_READ_ONLY=false` without changing the default toolset
- when enabled, never registers `create_wandb_report_tool` or `log_analysis_to_wandb`
- keeps every existing read tool, including the permanently query-only `query_wandb_tool`
- keeps read-only mode independent from classic Weave and opt-in Agent tool gates
- documents deployment behavior and the new environment variable

This is cumulative PR 3 of the v0.3.7 read-only series and includes draft #110 and #111. Merge #110, then #111, then refresh this PR before merging it into `staging/0.3.7`.

## Validation

- registration diff test proves exactly the two write tools are omitted
- 93 focused registration, GraphQL, guardrail, report, and logging tests
- 812 non-integration tests on Python 3.12
- Ruff check and format check
- no live W&B requests and no `.env` access

The GitHub workflow provides the authoritative Python 3.11/3.12 matrix, wheel smoke tests, and latest-W&B compatibility gate.