### PR TITLE
perf: add projected W&B reads and workload profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
         run: |
           uv run --no-sync pytest \
             tests/test_query_wandb_sdk.py \
+            tests/test_probe_project.py \
+            tests/test_wandb_selective_reads.py \
             tests/test_tool_registration.py \
             tests/test_wandb_graphql.py \
             tests/test_wandb_graphql_read_only.py \

--- a/README.md
+++ b/README.md
@@ -543,9 +543,10 @@ When running the server locally, you can customize its behavior with command lin
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
 | `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS` | Enable Weave Agents (OTel/GenAI) tools (default: `false`) | No |
 | `WANDB_MCP_READ_ONLY` | Omit report creation and analysis logging write tools (default: `false`) | No |
-| `MCP_HOSTED_MODE` | Enable stricter collection/history limits intended for shared HTTP deployments (default: `false`) | No |
-| `MCP_ADMISSION_CONTROL_ENABLED` | Enable actor-aware weighted tool admission (defaults to the value of `MCP_HOSTED_MODE`) | No |
-| `MCP_ADMISSION_ACTOR_CAPACITY` | Maximum concurrent cost units per API-key actor (default: `4`) | No |
+| `MCP_HOSTED_MODE` | Marks an HTTP deployment as hosted; defaults the workload profile to `shared` | No |
+| `MCP_WORKLOAD_PROFILE` | Bounded defaults for `shared`, `dedicated`, or `local` workloads (default: `shared` when hosted, otherwise `local`) | No |
+| `MCP_ADMISSION_CONTROL_ENABLED` | Enable actor-aware weighted tool admission (default: enabled except for the `local` profile) | No |
+| `MCP_ADMISSION_ACTOR_CAPACITY` | Maximum concurrent cost units per API-key actor (profile default: shared `4`, dedicated `8`, local `16`) | No |
 | `MCP_ADMISSION_PROCESS_CAPACITY` | Maximum concurrent cost units per server process (default: `16`) | No |
 | `MCP_ADMISSION_WAIT_MS` | Maximum queue wait before returning retryable `server_busy` (default: `2000`) | No |
 | `MCP_TOOL_TIMEOUT_SECONDS` | Hosted public-tool execution deadline (default: `30`) | No |

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -48,30 +48,109 @@ try:
 except (ValueError, TypeError):
     MAX_ACCUMULATED_BYTES: int = 1024 * 1024 * 1024  # 1GB
 
-# Hosted-mode limits let Cloud Run deployments use stricter guardrails without
-# changing local/stdio defaults for users running the package themselves.
+# Workload profiles keep the common deployment choices simple while retaining
+# the existing per-setting environment overrides for advanced operators.
 MCP_HOSTED_MODE: bool = _env_bool("MCP_HOSTED_MODE", False)
+_default_workload_profile = "shared" if MCP_HOSTED_MODE else "local"
+MCP_WORKLOAD_PROFILE: str = (os.getenv("MCP_WORKLOAD_PROFILE") or _default_workload_profile).strip().lower()
+if MCP_WORKLOAD_PROFILE not in {"shared", "dedicated", "local"}:
+    raise ValueError("MCP_WORKLOAD_PROFILE must be one of: shared, dedicated, local")
+
+_PROFILE_DEFAULTS: dict[str, dict[str, int]] = {
+    "shared": {
+        "collection_items": 100,
+        "full_detail_items": 3,
+        "history_samples": 500,
+        "history_keys": 20,
+        "history_range_steps": 5_000,
+        "project_fields": 500,
+        "probe_runs": 6,
+        "evaluation_rows": 500,
+        "actor_capacity": 4,
+        "process_capacity": 16,
+    },
+    "dedicated": {
+        "collection_items": 250,
+        "full_detail_items": 10,
+        "history_samples": 1_500,
+        "history_keys": 50,
+        "history_range_steps": 20_000,
+        "project_fields": 2_000,
+        "probe_runs": 12,
+        "evaluation_rows": 2_000,
+        "actor_capacity": 8,
+        "process_capacity": 16,
+    },
+    "local": {
+        "collection_items": 1_000,
+        "full_detail_items": 25,
+        "history_samples": 5_000,
+        "history_keys": 100,
+        "history_range_steps": 100_000,
+        "project_fields": 5_000,
+        "probe_runs": 24,
+        "evaluation_rows": 5_000,
+        "actor_capacity": 16,
+        "process_capacity": 16,
+    },
+}
+_profile_defaults = _PROFILE_DEFAULTS[MCP_WORKLOAD_PROFILE]
+
 MCP_TOOL_TIMEOUT_SECONDS: int = _env_int("MCP_TOOL_TIMEOUT_SECONDS", 30)
 MCP_WANDB_REQUEST_TIMEOUT_SECONDS: int = _env_int("MCP_WANDB_REQUEST_TIMEOUT_SECONDS", 20)
-MCP_ADMISSION_CONTROL_ENABLED: bool = _env_bool("MCP_ADMISSION_CONTROL_ENABLED", MCP_HOSTED_MODE)
-MCP_ADMISSION_ACTOR_CAPACITY: int = _env_int("MCP_ADMISSION_ACTOR_CAPACITY", 4)
-MCP_ADMISSION_PROCESS_CAPACITY: int = _env_int("MCP_ADMISSION_PROCESS_CAPACITY", 16)
+MCP_ADMISSION_CONTROL_ENABLED: bool = _env_bool(
+    "MCP_ADMISSION_CONTROL_ENABLED",
+    MCP_WORKLOAD_PROFILE != "local",
+)
+MCP_ADMISSION_ACTOR_CAPACITY: int = _env_int(
+    "MCP_ADMISSION_ACTOR_CAPACITY",
+    _profile_defaults["actor_capacity"],
+)
+MCP_ADMISSION_PROCESS_CAPACITY: int = _env_int(
+    "MCP_ADMISSION_PROCESS_CAPACITY",
+    _profile_defaults["process_capacity"],
+)
 MCP_ADMISSION_WAIT_MS: int = _env_int("MCP_ADMISSION_WAIT_MS", 2000)
-MCP_MAX_QUERY_LIMIT: int = _env_int("MCP_MAX_QUERY_LIMIT", 100 if MCP_HOSTED_MODE else 1000)
-MCP_MAX_FULL_TRACE_LIMIT: int = _env_int("MCP_MAX_FULL_TRACE_LIMIT", 25 if MCP_HOSTED_MODE else 1000)
-MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", 500 if MCP_HOSTED_MODE else 2000)
-MCP_MAX_HISTORY_KEYS: int = _env_int("MCP_MAX_HISTORY_KEYS", 20 if MCP_HOSTED_MODE else 100)
+MCP_MAX_QUERY_LIMIT: int = _env_int("MCP_MAX_QUERY_LIMIT", _profile_defaults["collection_items"])
+MCP_MAX_FULL_TRACE_LIMIT: int = _env_int(
+    "MCP_MAX_FULL_TRACE_LIMIT",
+    25 if MCP_WORKLOAD_PROFILE == "shared" else _profile_defaults["collection_items"],
+)
+MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", _profile_defaults["history_samples"])
+MCP_MAX_HISTORY_KEYS: int = _env_int("MCP_MAX_HISTORY_KEYS", _profile_defaults["history_keys"])
 MCP_MAX_HISTORY_RANGE_STEPS: int = _env_int(
     "MCP_MAX_HISTORY_RANGE_STEPS",
-    5000 if MCP_HOSTED_MODE else 100_000,
+    _profile_defaults["history_range_steps"],
 )
-MCP_MAX_WANDB_QUERY_ITEMS: int = _env_int("MCP_MAX_WANDB_QUERY_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
+MCP_MAX_WANDB_QUERY_ITEMS: int = _env_int(
+    "MCP_MAX_WANDB_QUERY_ITEMS",
+    _profile_defaults["collection_items"],
+)
+MCP_MAX_FULL_DETAIL_ITEMS: int = _env_int(
+    "MCP_MAX_FULL_DETAIL_ITEMS",
+    _profile_defaults["full_detail_items"],
+)
+MCP_MAX_PROJECT_FIELDS: int = _env_int(
+    "MCP_MAX_PROJECT_FIELDS",
+    _profile_defaults["project_fields"],
+)
+MCP_MAX_PROBE_RUNS: int = _env_int(
+    "MCP_MAX_PROBE_RUNS",
+    _profile_defaults["probe_runs"],
+)
+MCP_MAX_EVALUATION_ROWS: int = _env_int(
+    "MCP_MAX_EVALUATION_ROWS",
+    _profile_defaults["evaluation_rows"],
+)
 MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE: int = _env_int(
     "MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE",
-    50 if MCP_HOSTED_MODE else 200,
+    50 if MCP_WORKLOAD_PROFILE == "shared" else 200,
 )
-MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", 100 if MCP_HOSTED_MODE else 1000)
-MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int("MCP_MAX_GQL_ITEMS_PER_PAGE", 50 if MCP_HOSTED_MODE else 200)
+MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", _profile_defaults["collection_items"])
+MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int(
+    "MCP_MAX_GQL_ITEMS_PER_PAGE",
+    50 if MCP_WORKLOAD_PROFILE == "shared" else 200,
+)
 WANDB_MCP_ENABLE_WEAVE_TOOLS: bool = _env_bool("WANDB_MCP_ENABLE_WEAVE_TOOLS", True)
 WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS: bool = _env_bool(
     "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",

--- a/src/wandb_mcp_server/mcp_tools/probe_project.py
+++ b/src/wandb_mcp_server/mcp_tools/probe_project.py
@@ -1,172 +1,378 @@
-"""Probe a W&B project: discover run structure, metric keys, config keys, and recommended strategies."""
+"""Bounded W&B project structure and scale discovery."""
 
+from __future__ import annotations
+
+from collections import Counter
+from itertools import islice
 import json
-from typing import Any, Dict, List
+import re
+from typing import Any, Mapping
 
 from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.config import MCP_MAX_PROBE_RUNS, MCP_MAX_PROJECT_FIELDS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_selective_reads import (
+    SelectiveReadUnavailable,
+    fetch_artifact_inventory,
+    fetch_project_counts,
+    fetch_project_fields,
+    fetch_projected_runs,
+)
+from wandb_mcp_server.wandb_urls import publicize_wandb_url
 
 logger = get_rich_logger(__name__)
 
-PROBE_PROJECT_TOOL_DESCRIPTION = """Probe a W&B project to discover its structure before querying.
+PROBE_PROJECT_TOOL_DESCRIPTION = """Probe a W&B project before issuing detailed queries.
 
-Samples one run to discover available metric keys, config keys, tags, groups,
-and provides recommended query strategies. This is the run-side equivalent
-of infer_trace_schema_tool (which is for Weave traces).
-
-<when_to_use>
-Use when you need a lightweight schema hint for an unfamiliar project. It samples
-at most one run and intentionally does not count or scan the project. Useful for:
-- Discovering which metrics are logged (loss, accuracy, custom metrics)
-- Finding config keys (learning_rate, model, batch_size)
-- Understanding project scale (run count, typical step counts)
-- Getting query strategy recommendations
+Use this read-only tool first for an unfamiliar or large project. It returns
+exact run/state counts, indexed config and summary field names, and bounded
+recent/oldest run samples without loading every run summary.
 
 Typical workflow:
-1. probe_project_tool to discover structure
-2. query_wandb_tool or get_run_history_tool with the discovered keys
-3. create_wandb_report_tool to visualize
-</when_to_use>
+1. probe_project_tool to discover field names and project scale
+2. query_wandb_tool with summary_keys/config_keys for projected run rows
+3. get_run_history_tool with explicit keys and x_axis for time-series values
 
 Parameters
 ----------
 entity_name : str
-    W&B entity (username or team).
+    W&B entity or team.
 project_name : str
-    W&B project name.
+    W&B project.
 sample_runs : int, optional
-    Requested sample size. The workload guardrail clamps this to one run.
+    Total recent/oldest metadata rows to sample. The active workload profile
+    applies a protective cap.
+field_pattern : str, optional
+    Server-side field-name pattern for narrowing very wide schemas.
+include_artifacts : bool, optional
+    Include a compact project artifact type/collection inventory.
 
 Returns
 -------
-JSON with sampled_runs, metric_keys, config_keys, has_history, typical_steps,
-tags, groups, and recommendations.
+JSON containing exact counts, bounded field inventory, run samples,
+sample_scope, exhaustiveness metadata, and compact recommended next calls.
 """
 
-DEFAULT_SAMPLE_RUNS = 5
-MAX_PROBE_RUNS = 1
+DEFAULT_SAMPLE_RUNS = 6
+_FIELD_RESPONSE_LIMIT = 200
+
+
+def _field_family(path: str) -> str:
+    stripped = re.sub(r"^(config|summary_metrics|summaryMetrics|summary)[./]", "", path)
+    return re.split(r"[/.]", stripped, maxsplit=1)[0]
+
+
+def _field_category(path: str) -> tuple[str | None, str]:
+    for prefix, category in (
+        ("config.", "config"),
+        ("config/", "config"),
+        ("summary_metrics.", "summary"),
+        ("summary_metrics/", "summary"),
+        ("summaryMetrics.", "summary"),
+        ("summaryMetrics/", "summary"),
+        ("summary.", "summary"),
+        ("summary/", "summary"),
+    ):
+        if path.startswith(prefix):
+            return category, path[len(prefix) :]
+    return None, path
+
+
+def _sample_item_from_sdk(run: Any) -> dict[str, Any]:
+    entity = getattr(run, "entity", None)
+    project = getattr(run, "project", None)
+    run_id = getattr(run, "id", None)
+    return {
+        "id": run_id,
+        "display_name": getattr(run, "name", None),
+        "state": getattr(run, "state", None),
+        "created_at": getattr(run, "created_at", None),
+        "group": getattr(run, "group", None),
+        "job_type": getattr(run, "job_type", None),
+        "tags": list(getattr(run, "tags", []) or []),
+        "history_line_count": getattr(run, "lastHistoryStep", None),
+        "url": publicize_wandb_url(
+            getattr(run, "url", None),
+            fallback_segments=(entity, project, "runs", run_id),
+        ),
+    }
+
+
+def _sdk_count(api: Any, path: str, filters: Mapping[str, Any] | None = None) -> int:
+    runs = api.runs(
+        path,
+        filters=dict(filters or {}),
+        per_page=1,
+        include_sweeps=False,
+        lazy=True,
+    )
+    return len(runs)
+
+
+def _sdk_fallback(
+    api: Any,
+    *,
+    entity_name: str,
+    project_name: str,
+    applied_samples: int,
+) -> tuple[dict[str, int], list[dict[str, str]], list[dict[str, Any]]]:
+    """Use bounded hydrated SDK pages when the indexed read API is unavailable."""
+    path = f"{entity_name}/{project_name}"
+    counts = {
+        "all": _sdk_count(api, path),
+        **{state: _sdk_count(api, path, {"state": state}) for state in ("finished", "failed", "crashed", "running")},
+    }
+    recent_count = max(1, (applied_samples + 1) // 2)
+    oldest_count = max(0, applied_samples - recent_count)
+    sampled_runs: list[Any] = list(
+        islice(
+            api.runs(
+                path,
+                order="-created_at",
+                per_page=recent_count,
+                include_sweeps=False,
+                lazy=False,
+            ),
+            recent_count,
+        )
+    )
+    if oldest_count:
+        sampled_runs.extend(
+            islice(
+                api.runs(
+                    path,
+                    order="+created_at",
+                    per_page=oldest_count,
+                    include_sweeps=False,
+                    lazy=False,
+                ),
+                oldest_count,
+            )
+        )
+
+    deduped: dict[str, Any] = {}
+    fields: dict[tuple[str, str], str] = {}
+    for run in sampled_runs:
+        run_id = str(getattr(run, "id", ""))
+        if run_id:
+            deduped[run_id] = run
+        for key, value in dict(getattr(run, "config", {}) or {}).items():
+            if not str(key).startswith(("_", "wandb")):
+                fields[("config", str(key))] = type(value).__name__
+        for key, value in dict(getattr(run, "summary", {}) or {}).items():
+            if not str(key).startswith(("_", "wandb/")):
+                fields[("summary", str(key))] = type(value).__name__
+    return (
+        counts,
+        [{"path": f"{category}.{name}", "type": field_type} for (category, name), field_type in sorted(fields.items())],
+        [_sample_item_from_sdk(run) for run in deduped.values()],
+    )
+
+
+def _safe_sample_value(value: Any) -> Any:
+    """Retained compatibility helper for callers that imported it directly."""
+    if isinstance(value, (str, int, float, bool)):
+        if isinstance(value, str) and len(value) > 100:
+            return value[:100] + "..."
+        return value
+    if isinstance(value, (list, tuple)):
+        return f"[{type(value).__name__}, len={len(value)}]"
+    if isinstance(value, dict):
+        return f"{{dict, keys={len(value)}}}"
+    return str(value)[:50]
 
 
 def probe_project(
     entity_name: str,
     project_name: str,
     sample_runs: int = DEFAULT_SAMPLE_RUNS,
+    field_pattern: str | None = None,
+    include_artifacts: bool = False,
 ) -> str:
-    """Probe a W&B project to discover its structure."""
+    """Return a bounded, explicit project-scale and schema snapshot."""
+    if not isinstance(entity_name, str) or not entity_name.strip():
+        raise ValueError("entity_name must be a non-empty string")
+    if not isinstance(project_name, str) or not project_name.strip():
+        raise ValueError("project_name must be a non-empty string")
     if isinstance(sample_runs, bool) or not isinstance(sample_runs, int) or sample_runs < 1:
         raise ValueError("sample_runs must be a positive integer")
-    api = WandBApiManager.get_api()
+    if field_pattern is not None and (not isinstance(field_pattern, str) or not field_pattern.strip()):
+        raise ValueError("field_pattern must be a non-empty string when supplied")
+    if not isinstance(include_artifacts, bool):
+        raise ValueError("include_artifacts must be a boolean")
+
+    applied_samples = min(sample_runs, MCP_MAX_PROBE_RUNS)
     with track_tool_execution(
         "probe_project",
         None,
-        {"entity_name": entity_name, "project_name": project_name, "sample_runs": sample_runs},
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "sample_runs": applied_samples,
+            "has_field_pattern": field_pattern is not None,
+            "include_artifacts": include_artifacts,
+        },
+        mcp_tool_name="probe_project_tool",
     ) as ctx:
-        path = f"{entity_name}/{project_name}"
-
         try:
-            applied_samples = min(max(1, sample_runs), MAX_PROBE_RUNS)
-            runs_iter = api.runs(path, per_page=applied_samples, lazy=True)
-        except Exception as e:
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "project_not_found", "message": str(e)[:500]})
+            api = WandBApiManager.get_api()
+            fallback_caveat: str | None = None
+            try:
+                counts = fetch_project_counts(api, entity=entity_name, project=project_name)
+                fields_page = fetch_project_fields(
+                    api,
+                    entity=entity_name,
+                    project=project_name,
+                    limit=MCP_MAX_PROJECT_FIELDS,
+                    pattern=field_pattern,
+                )
+                recent_count = max(1, (applied_samples + 1) // 2)
+                oldest_count = max(0, applied_samples - recent_count)
+                recent = fetch_projected_runs(
+                    api,
+                    entity=entity_name,
+                    project=project_name,
+                    filters=None,
+                    order="-created_at",
+                    limit=recent_count,
+                    page_size=recent_count + 1,
+                ).items
+                oldest = (
+                    fetch_projected_runs(
+                        api,
+                        entity=entity_name,
+                        project=project_name,
+                        filters=None,
+                        order="+created_at",
+                        limit=oldest_count,
+                        page_size=oldest_count + 1,
+                    ).items
+                    if oldest_count
+                    else []
+                )
+                fields = fields_page.items
+                field_has_more = fields_page.has_more
+                run_samples = list(
+                    {
+                        str(item.get("id")): {
+                            **item,
+                            "url": publicize_wandb_url(
+                                item.get("url"),
+                                fallback_segments=(
+                                    entity_name,
+                                    project_name,
+                                    "runs",
+                                    item.get("id"),
+                                ),
+                            ),
+                        }
+                        for item in [*recent, *oldest]
+                        if item.get("id")
+                    }.values()
+                )
+            except SelectiveReadUnavailable as exc:
+                logger.warning("Project selective read unavailable; using bounded SDK fallback: %s", exc)
+                counts, fields, run_samples = _sdk_fallback(
+                    api,
+                    entity_name=entity_name,
+                    project_name=project_name,
+                    applied_samples=applied_samples,
+                )
+                field_has_more = True
+                fallback_caveat = (
+                    f"{exc}; field inventory was derived from {len(run_samples)} bounded hydrated SDK runs"
+                )
 
-        metric_keys: Dict[str, str] = {}
-        config_keys: Dict[str, Any] = {}
-        all_tags: List[str] = []
-        all_groups: List[str] = []
-        step_counts: List[int] = []
-        states: Dict[str, int] = {}
-        sampled = 0
+            categorized: dict[str, list[dict[str, str]]] = {"config": [], "summary": []}
+            for field in fields:
+                category, name = _field_category(str(field.get("path") or ""))
+                if category and name and not name.startswith(("_", "wandb/")):
+                    categorized[category].append({"path": name, "type": str(field.get("type") or "unknown")})
 
-        try:
-            for run in runs_iter:
-                if sampled >= applied_samples:
-                    break
-
-                state = getattr(run, "state", "unknown")
-                states[state] = states.get(state, 0) + 1
-
-                summary = dict(run.summary) if run.summary else {}
-                for k, v in summary.items():
-                    if k.startswith("_") or k.startswith("wandb/"):
-                        continue
-                    if k not in metric_keys:
-                        metric_keys[k] = type(v).__name__
-
-                config = dict(run.config) if run.config else {}
-                for k, v in config.items():
-                    if k.startswith("_") or k.startswith("wandb"):
-                        continue
-                    if k not in config_keys:
-                        config_keys[k] = _safe_sample_value(v)
-
-                tags = getattr(run, "tags", [])
-                if tags:
-                    all_tags.extend(tags)
-
-                group = getattr(run, "group", None)
-                if group and group not in all_groups:
-                    all_groups.append(group)
-
-                last_step = getattr(run, "lastHistoryStep", 0)
-                if last_step and last_step > 0:
-                    step_counts.append(last_step)
-
-                sampled += 1
-        except Exception as e:
-            logger.warning(f"Error iterating runs: {e}")
-
-        unique_tags = sorted(set(all_tags))
-        has_history = len(step_counts) > 0
-        typical_steps = int(sum(step_counts) / len(step_counts)) if step_counts else 0
-
-        recommendations = []
-        if typical_steps > 10000:
-            recommendations.append(
-                f"Long runs (~{typical_steps} steps) -- use keys=[...] and samples parameter in get_run_history_tool."
+            config_fields = categorized["config"]
+            summary_fields = categorized["summary"]
+            metric_families = Counter(_field_family(item["path"]) for item in summary_fields)
+            tags = sorted({tag for item in run_samples for tag in item.get("tags") or []})
+            groups = sorted({str(item["group"]) for item in run_samples if item.get("group")})
+            has_history = any(
+                isinstance(item.get("history_line_count"), (int, float)) and item["history_line_count"] > 0
+                for item in run_samples
             )
-        if len(metric_keys) > 20:
-            recommendations.append(f"Many metrics ({len(metric_keys)}) -- specify keys to avoid large responses.")
-        if unique_tags:
-            recommendations.append(
-                f"Tags in use: {unique_tags[:10]}. Filter by tag in query_wandb_tool for focused analysis."
-            )
-        if all_groups:
-            recommendations.append(f"Run groups found: {all_groups[:5]}. Group-based comparison may be useful.")
-        if not recommendations:
-            recommendations.append("Small project -- standard queries should work well.")
 
-        return json.dumps(
-            {
+            recommendations = [
+                {
+                    "tool": "query_wandb_tool",
+                    "reason": "Fetch only the run rows and selected fields needed for analysis.",
+                    "parameters": {
+                        "resource": "runs",
+                        "summary_keys": [item["path"] for item in summary_fields[:5]],
+                        "config_keys": [item["path"] for item in config_fields[:5]],
+                    },
+                }
+            ]
+            if summary_fields:
+                recommendations.append(
+                    {
+                        "tool": "get_run_history_tool",
+                        "reason": "Retrieve a bounded time-series after choosing a run.",
+                        "parameters": {"keys": [item["path"] for item in summary_fields[:5]]},
+                    }
+                )
+
+            result: dict[str, Any] = {
+                "source": "wandb_selective_read" if fallback_caveat is None else "wandb_sdk_fallback",
                 "entity": entity_name,
                 "project": project_name,
-                "run_count": None,
-                "run_count_note": "Not counted to avoid scanning the project.",
-                "sampled_runs": sampled,
-                "run_states": states,
-                "metric_keys": metric_keys,
-                "metric_count": len(metric_keys),
-                "config_keys": config_keys,
-                "config_count": len(config_keys),
-                "has_history": has_history,
-                "typical_steps": typical_steps,
-                "tags": unique_tags[:20],
-                "groups": all_groups[:10],
-                "recommendations": recommendations,
-            },
-            default=str,
-        )
+                "workload_profile": MCP_WORKLOAD_PROFILE,
+                "run_count": counts["all"],
+                "state_counts": {state: counts[state] for state in ("finished", "failed", "crashed", "running")},
+                "sampled_runs": len(run_samples),
+                "run_samples": run_samples,
+                "sample_scope": {
+                    "strategy": "recent_and_oldest",
+                    "requested": sample_runs,
+                    "effective": applied_samples,
+                    "cap_applied": applied_samples < sample_runs,
+                    "project_exhaustive": counts["all"] <= len(run_samples),
+                },
+                "config_field_count_returned": len(config_fields),
+                "summary_field_count_returned": len(summary_fields),
+                "config_fields": config_fields[:_FIELD_RESPONSE_LIMIT],
+                "summary_fields": summary_fields[:_FIELD_RESPONSE_LIMIT],
+                "metric_families": dict(metric_families.most_common(50)),
+                "field_inventory": {
+                    "pattern": field_pattern,
+                    "returned_count": len(fields),
+                    "has_more": field_has_more,
+                    "project_exhaustive": not field_has_more,
+                    "response_truncated": (
+                        len(config_fields) > _FIELD_RESPONSE_LIMIT or len(summary_fields) > _FIELD_RESPONSE_LIMIT
+                    ),
+                },
+                "has_history_in_sample": has_history,
+                "tags_in_sample": tags[:20],
+                "groups_in_sample": groups[:20],
+                "recommended_next_calls": recommendations,
+            }
+            if fallback_caveat:
+                result["compatibility_caveat"] = fallback_caveat
+            if include_artifacts:
+                try:
+                    result["artifact_inventory"] = fetch_artifact_inventory(
+                        api,
+                        entity=entity_name,
+                        project=project_name,
+                    )
+                except SelectiveReadUnavailable as exc:
+                    result["artifact_inventory"] = {
+                        "error": "artifact_inventory_unavailable",
+                        "message": str(exc),
+                    }
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            ctx.mark_error(f"{type(exc).__name__}: {exc}")
+            return json.dumps({"error": "project_probe_failed", "message": str(exc)[:500]})
 
 
-def _safe_sample_value(v: Any) -> Any:
-    """Return a JSON-safe sample value for display."""
-    if isinstance(v, (str, int, float, bool)):
-        if isinstance(v, str) and len(v) > 100:
-            return v[:100] + "..."
-        return v
-    if isinstance(v, (list, tuple)):
-        return f"[{type(v).__name__}, len={len(v)}]"
-    if isinstance(v, dict):
-        return f"{{dict, keys={len(v)}}}"
-    return str(v)[:50]
+__all__ = ["DEFAULT_SAMPLE_RUNS", "PROBE_PROJECT_TOOL_DESCRIPTION", "_safe_sample_value", "probe_project"]

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -1,4 +1,4 @@
-"""Structured, read-only W&B Models queries through the public SDK."""
+"""Structured, read-only W&B Models queries with bounded field projection."""
 
 from __future__ import annotations
 
@@ -11,23 +11,36 @@ from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.config import (
     MAX_RESPONSE_TOKENS,
     MCP_HOSTED_MODE,
+    MCP_MAX_FULL_DETAIL_ITEMS,
+    MCP_MAX_HISTORY_KEYS,
     MCP_MAX_WANDB_QUERY_ITEMS,
     MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
+    MCP_WORKLOAD_PROFILE,
     structured_error,
 )
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.wandb_urls import publicize_wandb_url
+from wandb_mcp_server.wandb_selective_reads import (
+    SelectiveReadUnavailable,
+    fetch_projected_run,
+    fetch_projected_runs,
+)
+from wandb_mcp_server.wandb_urls import public_wandb_url, publicize_wandb_url
 
 logger = get_rich_logger(__name__)
 
 WandBResource = Literal["project", "run", "runs", "sweep", "sweeps", "reports"]
+WandBResponseMode = Literal["items", "count"]
 
-QUERY_WANDB_TOOL_DESCRIPTION = """Query W&B Models data through the public W&B Python SDK.
+QUERY_WANDB_TOOL_DESCRIPTION = """Query W&B Models data through bounded W&B read APIs.
 
 Use this read-only tool for project metadata, individual runs, filtered or sorted
 run collections, sweeps, and reports. For run history, artifacts, registries,
 automations, and integrations, prefer the dedicated MCP tools.
+
+For an unfamiliar project, call probe_project_tool first. Then pass only the
+returned summary_keys/config_keys needed for the question. This avoids loading
+every metric from wide runs and usually answers the question in one request.
 
 Prefer the existing specialized tools when they match the request:
 - entity/project discovery: list_entities_tool and query_wandb_entity_projects
@@ -71,14 +84,19 @@ include : list[str], optional
     include summary metrics by default; run collections return metadata by default.
 summary_keys : list[str], optional
     Specific summary metrics to include for run/runs. Supplying keys implies
-    include=["summary"] and avoids loading unrelated metrics. Hosted collections
-    require targeted keys or a limit of at most 3 for full summaries.
+    include=["summary"] and uses a server-side field projection.
+config_keys : list[str], optional
+    Specific config values to include for run/runs. Supplying keys implies
+    include=["config"] and uses a server-side field projection.
+response_mode : "items" | "count", optional
+    "items" returns bounded resources. "count" is supported for resource="runs"
+    and returns only the exact server-side matching count.
 
 Returns
 -------
 dict
-    A stable JSON-safe envelope with source="wandb_sdk". Collection results use
-    items/count/limit/truncated; single-resource results use item.
+    Collection results include returned_count, total_count, has_more, limit, and
+    project_exhaustive. Single-resource results use item.
 
 For schema introspection, unmodeled fields, aliases, cross-resource nesting, or an
 exact GraphQL response shape, an administrator may explicitly enable the separate
@@ -94,8 +112,6 @@ _INCLUDE_FIELDS = {
     "reports": frozenset({"spec"}),
 }
 _OPTIONAL_RESPONSE_FIELDS = ("system_metrics", "config", "spec", "sweep", "summary")
-_HOSTED_FULL_DETAIL_LIMIT = 3
-_MAX_SUMMARY_KEYS = 100
 
 
 class WandBQueryValidationError(ValueError):
@@ -167,29 +183,30 @@ def _serialize_sweep(sweep: Any, include: frozenset[str]) -> Dict[str, Any]:
     return result
 
 
+def _select_mapping_values(value: Any, keys: Optional[List[str]]) -> Dict[str, Any]:
+    if not value:
+        return {}
+    if keys is None:
+        return _json_safe(value)
+    try:
+        mapping = dict(value)
+    except (TypeError, ValueError):
+        return {}
+    return {key: _json_safe(mapping[key]) for key in keys if key in mapping and mapping[key] is not None}
+
+
 def _serialize_summary(run: Any, summary_keys: Optional[List[str]]) -> Dict[str, Any]:
     summary = getattr(run, "summary", None)
-    if not summary:
-        return {}
-    if summary_keys is None:
-        return _json_safe(summary)
-    selected: Dict[str, Any] = {}
-    for key in summary_keys:
-        try:
-            value = summary.get(key)
-        except (AttributeError, TypeError):
-            value = None
-        if value is not None:
-            selected[key] = _json_safe(value)
-    return selected
+    return _select_mapping_values(summary, summary_keys)
 
 
 def _serialize_run(
     run: Any,
     include: frozenset[str],
     *,
-    summary_keys: Optional[List[str]],
-    include_summary: bool,
+    summary_keys: Optional[List[str]] = None,
+    config_keys: Optional[List[str]] = None,
+    include_summary: bool = False,
 ) -> Dict[str, Any]:
     entity = getattr(run, "entity", None)
     project = getattr(run, "project", None)
@@ -215,7 +232,7 @@ def _serialize_run(
     if include_summary:
         result["summary"] = _serialize_summary(run, summary_keys)
     if "config" in include:
-        result["config"] = _json_safe(getattr(run, "config", {}))
+        result["config"] = _select_mapping_values(getattr(run, "config", {}), config_keys)
     if "system_metrics" in include:
         result["system_metrics"] = _json_safe(getattr(run, "system_metrics", {}))
     if "sweep" in include:
@@ -265,7 +282,10 @@ def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
         dropped_items += 1
 
     if omitted_fields or dropped_items:
+        payload["returned_count"] = len(payload["items"])
         payload["count"] = len(payload["items"])
+        payload["has_more"] = True
+        payload["project_exhaustive"] = False
         payload["truncated"] = True
         payload["truncation"] = {
             "applied": True,
@@ -308,6 +328,8 @@ def _validate_request(
     limit: int,
     include: Optional[List[str]],
     summary_keys: Optional[List[str]],
+    config_keys: Optional[List[str]],
+    response_mode: str,
 ) -> frozenset[str]:
     if not isinstance(entity_name, str) or not entity_name.strip():
         raise WandBQueryValidationError("entity_name must be a non-empty string")
@@ -333,33 +355,53 @@ def _validate_request(
         raise WandBQueryValidationError("sweep_id is supported only for resource='sweep'")
     if resource != "reports" and report_name is not None:
         raise WandBQueryValidationError("report_name is supported only for resource='reports'")
+    if response_mode not in {"items", "count"}:
+        raise WandBQueryValidationError("response_mode must be 'items' or 'count'")
+    if response_mode == "count" and resource != "runs":
+        raise WandBQueryValidationError("response_mode='count' is supported only for resource='runs'")
     if include is not None and (not isinstance(include, list) or not all(isinstance(item, str) for item in include)):
         raise WandBQueryValidationError("include must be a list of strings")
     if summary_keys is not None and (
         not isinstance(summary_keys, list)
         or not summary_keys
-        or len(summary_keys) > _MAX_SUMMARY_KEYS
+        or len(summary_keys) > MCP_MAX_HISTORY_KEYS
         or not all(isinstance(item, str) and item.strip() for item in summary_keys)
     ):
-        raise WandBQueryValidationError(f"summary_keys must contain 1-{_MAX_SUMMARY_KEYS} non-empty strings")
+        raise WandBQueryValidationError(f"summary_keys must contain 1-{MCP_MAX_HISTORY_KEYS} non-empty strings")
     if summary_keys is not None and resource not in {"run", "runs"}:
         raise WandBQueryValidationError("summary_keys are supported only for resource='run' or resource='runs'")
+    if config_keys is not None and (
+        not isinstance(config_keys, list)
+        or not config_keys
+        or len(config_keys) > MCP_MAX_HISTORY_KEYS
+        or not all(isinstance(item, str) and item.strip() for item in config_keys)
+    ):
+        raise WandBQueryValidationError(f"config_keys must contain 1-{MCP_MAX_HISTORY_KEYS} non-empty strings")
+    if config_keys is not None and resource not in {"run", "runs"}:
+        raise WandBQueryValidationError("config_keys are supported only for resource='run' or resource='runs'")
+    if response_mode == "count" and (include or summary_keys or config_keys):
+        raise WandBQueryValidationError("response_mode='count' does not accept include, summary_keys, or config_keys")
 
     requested = frozenset(include or [])
     if summary_keys is not None:
         requested = requested | {"summary"}
+    if config_keys is not None:
+        requested = requested | {"config"}
     unsupported = requested - _INCLUDE_FIELDS[resource]
     if unsupported:
         allowed = sorted(_INCLUDE_FIELDS[resource])
         raise WandBQueryValidationError(
             f"unsupported include value(s) for resource={resource!r}: {sorted(unsupported)}; allowed: {allowed}"
         )
-    if MCP_HOSTED_MODE and resource in {"runs", "sweeps", "reports"} and limit > _HOSTED_FULL_DETAIL_LIMIT:
+    full_detail_limit = 3 if MCP_HOSTED_MODE and MCP_WORKLOAD_PROFILE == "local" else MCP_MAX_FULL_DETAIL_ITEMS
+    if resource in {"runs", "sweeps", "reports"} and limit > full_detail_limit:
         untargeted_summary = "summary" in requested and summary_keys is None
-        unbounded_details = requested & {"config", "system_metrics", "spec"}
-        if untargeted_summary or unbounded_details:
+        untargeted_config = "config" in requested and config_keys is None
+        unbounded_details = requested & {"system_metrics", "spec"}
+        if untargeted_summary or untargeted_config or unbounded_details:
             raise WandBQueryValidationError(
-                "hosted collection details require limit<=3; use summary_keys for targeted run metrics"
+                f"{MCP_WORKLOAD_PROFILE} collection details require "
+                f"limit<={full_detail_limit}; use summary_keys/config_keys for projected run fields"
             )
     return requested
 
@@ -370,21 +412,30 @@ def _collection_envelope(
     project_name: str,
     items: List[Dict[str, Any]],
     limit: int,
-    truncated: bool,
+    has_more: bool,
+    total_count: Optional[int],
+    *,
+    source: str = "wandb_sdk",
+    compatibility_caveat: Optional[str] = None,
 ) -> Dict[str, Any]:
-    return _fit_collection_to_budget(
-        {
-            "source": "wandb_sdk",
-            "resource": resource,
-            "entity": entity_name,
-            "project": project_name,
-            "items": items,
-            "count": len(items),
-            "limit": limit,
-            "truncated": truncated,
-            "truncation": {"applied": False},
-        }
-    )
+    payload: Dict[str, Any] = {
+        "source": source,
+        "resource": resource,
+        "entity": entity_name,
+        "project": project_name,
+        "items": items,
+        "returned_count": len(items),
+        "count": len(items),
+        "total_count": total_count,
+        "has_more": has_more,
+        "limit": limit,
+        "project_exhaustive": not has_more,
+        "truncated": has_more,
+        "truncation": {"applied": False},
+    }
+    if compatibility_caveat:
+        payload["compatibility_caveat"] = compatibility_caveat
+    return _fit_collection_to_budget(payload)
 
 
 def _single_envelope(
@@ -392,18 +443,36 @@ def _single_envelope(
     entity_name: str,
     project_name: str,
     item: Dict[str, Any],
+    *,
+    source: str = "wandb_sdk",
+    compatibility_caveat: Optional[str] = None,
 ) -> Dict[str, Any]:
-    return _fit_single_to_budget(
-        {
-            "source": "wandb_sdk",
-            "resource": resource,
-            "entity": entity_name,
-            "project": project_name,
-            "item": item,
-            "truncated": False,
-            "truncation": {"applied": False},
-        }
-    )
+    payload: Dict[str, Any] = {
+        "source": source,
+        "resource": resource,
+        "entity": entity_name,
+        "project": project_name,
+        "item": item,
+        "truncated": False,
+        "truncation": {"applied": False},
+    }
+    if compatibility_caveat:
+        payload["compatibility_caveat"] = compatibility_caveat
+    return _fit_single_to_budget(payload)
+
+
+def _collection_total_count(collection: Any) -> Optional[int]:
+    try:
+        return len(collection)
+    except (TypeError, AttributeError, NotImplementedError):
+        return None
+
+
+def _decorate_projected_run(item: Dict[str, Any]) -> Dict[str, Any]:
+    run_id = item.get("id")
+    if run_id:
+        item["url"] = public_wandb_url(item.get("entity"), item.get("project"), "runs", run_id)
+    return _json_safe(item)
 
 
 def query_wandb(
@@ -418,8 +487,10 @@ def query_wandb(
     limit: int = 50,
     include: Optional[List[str]] = None,
     summary_keys: Optional[List[str]] = None,
+    config_keys: Optional[List[str]] = None,
+    response_mode: WandBResponseMode = "items",
 ) -> Dict[str, Any]:
-    """Execute a structured read using only public W&B SDK operations."""
+    """Execute a structured, bounded W&B read."""
     try:
         include_fields = _validate_request(
             entity_name,
@@ -433,6 +504,8 @@ def query_wandb(
             limit,
             include,
             summary_keys,
+            config_keys,
+            response_mode,
         )
     except WandBQueryValidationError as exc:
         return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=resource)
@@ -450,6 +523,9 @@ def query_wandb(
             "project_name": project_name,
             "resource": resource,
             "limit": applied_limit,
+            "response_mode": response_mode,
+            "projected_summary_keys": len(summary_keys or []),
+            "projected_config_keys": len(config_keys or []),
         },
         mcp_tool_name="query_wandb_tool",
     ) as ctx:
@@ -460,6 +536,45 @@ def query_wandb(
                 return _single_envelope(resource, entity_name, project_name, _serialize_project(project))
 
             if resource == "run":
+                use_projection = bool(summary_keys or config_keys) and not (
+                    include_fields & {"system_metrics", "sweep"} or ("config" in include_fields and config_keys is None)
+                )
+                if use_projection:
+                    try:
+                        item = fetch_projected_run(
+                            api,
+                            entity=entity_name,
+                            project=project_name,
+                            run_id=str(run_id),
+                            summary_keys=summary_keys or (),
+                            config_keys=config_keys or (),
+                        )
+                    except SelectiveReadUnavailable as exc:
+                        run = api.run(f"{path}/{run_id}")
+                        return _single_envelope(
+                            resource,
+                            entity_name,
+                            project_name,
+                            _serialize_run(
+                                run,
+                                include_fields,
+                                summary_keys=summary_keys,
+                                config_keys=config_keys,
+                                include_summary=True,
+                            ),
+                            compatibility_caveat=(
+                                f"{exc}; used one bounded full SDK run because projected fields were unavailable"
+                            ),
+                        )
+                    if item is None:
+                        raise ValueError(f"run not found: {run_id}")
+                    return _single_envelope(
+                        resource,
+                        entity_name,
+                        project_name,
+                        _decorate_projected_run(item),
+                        source="wandb_selective_read",
+                    )
                 run = api.run(f"{path}/{run_id}")
                 return _single_envelope(
                     resource,
@@ -469,19 +584,87 @@ def query_wandb(
                         run,
                         include_fields,
                         summary_keys=summary_keys,
+                        config_keys=config_keys,
                         include_summary=True,
                     ),
                 )
 
             if resource == "runs":
+                if response_mode == "count":
+                    runs = api.runs(
+                        path,
+                        filters=filters,
+                        order=order,
+                        per_page=1,
+                        include_sweeps=False,
+                        lazy=True,
+                    )
+                    total_count = len(runs)
+                    return {
+                        "source": "wandb_sdk",
+                        "resource": resource,
+                        "entity": entity_name,
+                        "project": project_name,
+                        "response_mode": "count",
+                        "total_count": total_count,
+                        "project_exhaustive": True,
+                    }
+
+                use_projection = bool(summary_keys or config_keys) and not (
+                    include_fields & {"system_metrics", "sweep"}
+                    or ("summary" in include_fields and summary_keys is None)
+                    or ("config" in include_fields and config_keys is None)
+                )
+                if use_projection:
+                    try:
+                        projected = fetch_projected_runs(
+                            api,
+                            entity=entity_name,
+                            project=project_name,
+                            filters=filters,
+                            order=order,
+                            limit=applied_limit,
+                            page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
+                            summary_keys=summary_keys or (),
+                            config_keys=config_keys or (),
+                        )
+                    except SelectiveReadUnavailable as exc:
+                        if applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                            return structured_error(
+                                "selective_read_unavailable",
+                                (
+                                    f"{exc}; this backend cannot project selected fields and the requested "
+                                    f"limit exceeds the safe SDK fallback of {MCP_MAX_FULL_DETAIL_ITEMS}"
+                                ),
+                                source="wandb_sdk",
+                                resource=resource,
+                            )
+                        compatibility_caveat = (
+                            f"{exc}; used a bounded full-page SDK fallback without per-run lazy loads"
+                        )
+                    else:
+                        return _collection_envelope(
+                            resource,
+                            entity_name,
+                            project_name,
+                            [_decorate_projected_run(item) for item in projected.items],
+                            applied_limit,
+                            projected.has_more or requested_limit > applied_limit,
+                            projected.total_count,
+                            source="wandb_selective_read",
+                        )
+                else:
+                    compatibility_caveat = None
+
                 runs = api.runs(
                     path,
                     filters=filters,
                     order=order,
                     per_page=per_page,
                     include_sweeps="sweep" in include_fields,
-                    lazy=True,
+                    lazy=not bool(include_fields & {"summary", "config", "system_metrics"}),
                 )
+                total_count = _collection_total_count(runs)
                 page = list(islice(runs, applied_limit + 1))
                 has_more = len(page) > applied_limit or requested_limit > applied_limit
                 items = [
@@ -489,11 +672,23 @@ def query_wandb(
                         run,
                         include_fields,
                         summary_keys=summary_keys,
+                        config_keys=config_keys,
                         include_summary="summary" in include_fields,
                     )
                     for run in page[:applied_limit]
                 ]
-                return _collection_envelope(resource, entity_name, project_name, items, applied_limit, has_more)
+                if total_count is None and not has_more:
+                    total_count = len(items)
+                return _collection_envelope(
+                    resource,
+                    entity_name,
+                    project_name,
+                    items,
+                    applied_limit,
+                    has_more,
+                    total_count,
+                    compatibility_caveat=compatibility_caveat,
+                )
 
             if resource == "sweep":
                 sweep = api.sweep(f"{path}/{sweep_id}")
@@ -501,16 +696,38 @@ def query_wandb(
 
             if resource == "sweeps":
                 sweeps = api.project(project_name, entity=entity_name).sweeps(per_page=per_page)
+                total_count = _collection_total_count(sweeps)
                 page = list(islice(sweeps, applied_limit + 1))
                 has_more = len(page) > applied_limit or requested_limit > applied_limit
                 items = [_serialize_sweep(sweep, include_fields) for sweep in page[:applied_limit]]
-                return _collection_envelope(resource, entity_name, project_name, items, applied_limit, has_more)
+                if total_count is None and not has_more:
+                    total_count = len(items)
+                return _collection_envelope(
+                    resource,
+                    entity_name,
+                    project_name,
+                    items,
+                    applied_limit,
+                    has_more,
+                    total_count,
+                )
 
             reports = api.reports(path, name=report_name, per_page=per_page)
+            total_count = _collection_total_count(reports)
             page = list(islice(reports, applied_limit + 1))
             has_more = len(page) > applied_limit or requested_limit > applied_limit
             items = [_serialize_report(report, include_fields) for report in page[:applied_limit]]
-            return _collection_envelope(resource, entity_name, project_name, items, applied_limit, has_more)
+            if total_count is None and not has_more:
+                total_count = len(items)
+            return _collection_envelope(
+                resource,
+                entity_name,
+                project_name,
+                items,
+                applied_limit,
+                has_more,
+                total_count,
+            )
         except (ValueError, KeyError, IndexError) as exc:
             if resource in {"project", "run", "sweep"}:
                 ctx.mark_error(f"resource_not_found: {exc}")

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -809,6 +809,8 @@ def register_tools(mcp_instance: FastMCP) -> None:
         limit: int = 50,
         include: Optional[List[str]] = None,
         summary_keys: Optional[List[str]] = None,
+        config_keys: Optional[List[str]] = None,
+        response_mode: Literal["items", "count"] = "items",
     ) -> Dict[str, Any]:
         return query_wandb(
             entity_name=entity_name,
@@ -822,6 +824,8 @@ def register_tools(mcp_instance: FastMCP) -> None:
             limit=limit,
             include=include,
             summary_keys=summary_keys,
+            config_keys=config_keys,
+            response_mode=response_mode,
         )
 
     if WANDB_MCP_ENABLE_RAW_GRAPHQL:
@@ -1165,13 +1169,17 @@ def register_tools(mcp_instance: FastMCP) -> None:
     def probe_project_tool(
         entity_name: str,
         project_name: str,
-        sample_runs: int = 5,
+        sample_runs: int = 6,
+        field_pattern: Optional[str] = None,
+        include_artifacts: bool = False,
     ) -> str:
         """Probe a W&B project to discover its structure."""
         return probe_project(
             entity_name=entity_name,
             project_name=project_name,
             sample_runs=sample_runs,
+            field_pattern=field_pattern,
+            include_artifacts=include_artifacts,
         )
 
     # ----- Weave Agents (OTel/GenAI) tools -----

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -1,0 +1,506 @@
+"""Bounded, application-owned W&B reads without caller-supplied GraphQL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Mapping, Sequence
+
+from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
+from wandb_mcp_server.wandb_graphql import execute_graphql
+
+
+PROJECTED_RUNS_QUERY = """
+query MCPProjectedRuns(
+  $entity: String!
+  $project: String!
+  $filters: JSONString
+  $order: String
+  $first: Int!
+  $after: String
+  $summaryKeys: [String!]
+  $configKeys: [String!]
+  $includeSummary: Boolean!
+  $includeConfig: Boolean!
+) {
+  project(name: $project, entityName: $entity) {
+    runCount(filters: $filters)
+    runs(filters: $filters, order: $order, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          displayName
+          state
+          createdAt
+          heartbeatAt
+          computeSeconds
+          historyLineCount
+          group
+          jobType
+          tags
+          user {
+            username
+            name
+          }
+          summaryMetrics(keys: $summaryKeys) @include(if: $includeSummary)
+          config(keys: $configKeys) @include(if: $includeConfig)
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}
+"""
+
+PROJECTED_RUN_QUERY = """
+query MCPProjectedRun(
+  $entity: String!
+  $project: String!
+  $run: String!
+  $summaryKeys: [String!]
+  $configKeys: [String!]
+  $includeSummary: Boolean!
+  $includeConfig: Boolean!
+) {
+  project(name: $project, entityName: $entity) {
+    run(name: $run) {
+      id
+      name
+      displayName
+      state
+      createdAt
+      heartbeatAt
+      computeSeconds
+      historyLineCount
+      group
+      jobType
+      tags
+      user {
+        username
+        name
+      }
+      summaryMetrics(keys: $summaryKeys) @include(if: $includeSummary)
+      config(keys: $configKeys) @include(if: $includeConfig)
+    }
+  }
+}
+"""
+
+PROJECT_FIELDS_QUERY = """
+query MCPProjectFields(
+  $entity: String!
+  $project: String!
+  $first: Int!
+  $after: String
+  $pattern: String
+) {
+  project(name: $project, entityName: $entity) {
+    fields(first: $first, after: $after, pattern: $pattern) {
+      edges {
+        cursor
+        node {
+          path
+          type
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}
+"""
+
+PROJECT_COUNTS_QUERY = """
+query MCPProjectCounts(
+  $entity: String!
+  $project: String!
+  $all: JSONString
+  $finished: JSONString
+  $failed: JSONString
+  $crashed: JSONString
+  $running: JSONString
+) {
+  project(name: $project, entityName: $entity) {
+    total: runCount(filters: $all)
+    finished: runCount(filters: $finished)
+    failed: runCount(filters: $failed)
+    crashed: runCount(filters: $crashed)
+    running: runCount(filters: $running)
+  }
+}
+"""
+
+ARTIFACT_INVENTORY_QUERY = """
+query MCPArtifactInventory($entity: String!, $project: String!, $first: Int!) {
+  project(name: $project, entityName: $entity) {
+    artifactTypes(first: $first) {
+      edges {
+        node {
+          id
+          name
+          artifactCollections(first: 10) {
+            totalCount
+            edges {
+              node {
+                id
+                name
+                description
+              }
+            }
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(frozen=True)
+class ProjectedRunPage:
+    """One bounded projected run collection."""
+
+    items: list[dict[str, Any]]
+    total_count: int
+    has_more: bool
+    requests: int
+
+
+@dataclass(frozen=True)
+class ProjectFieldPage:
+    """One bounded project-field inventory."""
+
+    items: list[dict[str, str]]
+    has_more: bool
+    requests: int
+
+
+class SelectiveReadUnavailable(RuntimeError):
+    """Raised when a backend cannot serve an application-owned read shape."""
+
+
+def _parse_json_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    if not value:
+        return {}
+    try:
+        decoded = json.loads(str(value))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return {str(key): item for key, item in decoded.items()} if isinstance(decoded, Mapping) else {}
+
+
+def _unwrap_config_value(value: Any) -> Any:
+    if isinstance(value, Mapping) and "value" in value and set(value).issubset({"value", "desc"}):
+        return value.get("value")
+    return value
+
+
+def _nested_config_value(config: Mapping[str, Any], key: str) -> Any:
+    if key in config:
+        return _unwrap_config_value(config[key])
+    current: Any = config
+    for part in key.split("."):
+        current = _unwrap_config_value(current)
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return _unwrap_config_value(current)
+
+
+def _normalize_run_node(
+    node: Mapping[str, Any],
+    *,
+    entity: str,
+    project: str,
+    summary_keys: Sequence[str],
+    config_keys: Sequence[str],
+) -> dict[str, Any]:
+    summary = _parse_json_mapping(node.get("summaryMetrics"))
+    config = _parse_json_mapping(node.get("config"))
+    item: dict[str, Any] = {
+        "id": node.get("name") or node.get("id"),
+        "graphql_id": node.get("id"),
+        "display_name": node.get("displayName") or node.get("name"),
+        "state": node.get("state"),
+        "entity": entity,
+        "project": project,
+        "created_at": node.get("createdAt"),
+        "heartbeat_at": node.get("heartbeatAt"),
+        "duration": node.get("computeSeconds"),
+        "history_line_count": node.get("historyLineCount"),
+        "group": node.get("group"),
+        "job_type": node.get("jobType"),
+        "tags": node.get("tags") or [],
+        "user": node.get("user"),
+    }
+    if summary_keys:
+        item["summary"] = {key: summary.get(key) for key in summary_keys if summary.get(key) is not None}
+    if config_keys:
+        item["config"] = {key: value for key in config_keys if (value := _nested_config_value(config, key)) is not None}
+    return item
+
+
+def _project_payload(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    project = data.get("project")
+    if not isinstance(project, Mapping):
+        raise ValueError("W&B project was not found or is not accessible")
+    return project
+
+
+def fetch_projected_runs(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    filters: Mapping[str, Any] | None,
+    order: str,
+    limit: int,
+    page_size: int,
+    summary_keys: Sequence[str] = (),
+    config_keys: Sequence[str] = (),
+) -> ProjectedRunPage:
+    """Fetch selected run fields without hydrating full SDK run objects."""
+    target = max(1, limit + 1)
+    items: list[dict[str, Any]] = []
+    cursor: str | None = None
+    total_count = 0
+    requests = 0
+    has_next_page = False
+
+    while len(items) < target:
+        raise_if_tool_deadline_exceeded()
+        variables = {
+            "entity": entity,
+            "project": project,
+            "filters": json.dumps(dict(filters or {}), separators=(",", ":")),
+            "order": order,
+            "first": min(max(1, page_size), target - len(items)),
+            "after": cursor,
+            "summaryKeys": list(summary_keys),
+            "configKeys": list(config_keys),
+            "includeSummary": bool(summary_keys),
+            "includeConfig": bool(config_keys),
+        }
+        try:
+            data = execute_graphql(api, PROJECTED_RUNS_QUERY, variables)
+        except Exception as exc:
+            raise SelectiveReadUnavailable(f"projected run query unavailable: {type(exc).__name__}") from exc
+        requests += 1
+        project_payload = _project_payload(data)
+        total_count = int(project_payload.get("runCount") or 0)
+        connection = project_payload.get("runs")
+        if not isinstance(connection, Mapping):
+            raise SelectiveReadUnavailable("projected run query returned no run connection")
+        for edge in connection.get("edges") or []:
+            node = edge.get("node") if isinstance(edge, Mapping) else None
+            if isinstance(node, Mapping):
+                items.append(
+                    _normalize_run_node(
+                        node,
+                        entity=entity,
+                        project=project,
+                        summary_keys=summary_keys,
+                        config_keys=config_keys,
+                    )
+                )
+                if len(items) >= target:
+                    break
+        page_info = connection.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        cursor = page_info.get("endCursor")
+        if not has_next_page or not cursor:
+            break
+
+    return ProjectedRunPage(
+        items=items[:limit],
+        total_count=total_count,
+        has_more=len(items) > limit or has_next_page or total_count > limit,
+        requests=requests,
+    )
+
+
+def fetch_projected_run(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    run_id: str,
+    summary_keys: Sequence[str] = (),
+    config_keys: Sequence[str] = (),
+) -> dict[str, Any] | None:
+    """Fetch one run with only the requested summary and config keys."""
+    variables = {
+        "entity": entity,
+        "project": project,
+        "run": run_id,
+        "summaryKeys": list(summary_keys),
+        "configKeys": list(config_keys),
+        "includeSummary": bool(summary_keys),
+        "includeConfig": bool(config_keys),
+    }
+    try:
+        data = execute_graphql(api, PROJECTED_RUN_QUERY, variables)
+    except Exception as exc:
+        raise SelectiveReadUnavailable(f"projected run query unavailable: {type(exc).__name__}") from exc
+    node = _project_payload(data).get("run")
+    if not isinstance(node, Mapping):
+        return None
+    return _normalize_run_node(
+        node,
+        entity=entity,
+        project=project,
+        summary_keys=summary_keys,
+        config_keys=config_keys,
+    )
+
+
+def fetch_project_fields(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    limit: int,
+    page_size: int = 200,
+    pattern: str | None = None,
+) -> ProjectFieldPage:
+    """Read the indexed project field vocabulary without hydrating runs."""
+    target = max(1, limit + 1)
+    items: list[dict[str, str]] = []
+    cursor: str | None = None
+    requests = 0
+    has_next_page = False
+    while len(items) < target:
+        raise_if_tool_deadline_exceeded()
+        try:
+            data = execute_graphql(
+                api,
+                PROJECT_FIELDS_QUERY,
+                {
+                    "entity": entity,
+                    "project": project,
+                    "first": min(max(1, page_size), target - len(items)),
+                    "after": cursor,
+                    "pattern": pattern,
+                },
+            )
+        except Exception as exc:
+            raise SelectiveReadUnavailable(f"project field index unavailable: {type(exc).__name__}") from exc
+        requests += 1
+        connection = _project_payload(data).get("fields")
+        if not isinstance(connection, Mapping):
+            raise SelectiveReadUnavailable("project field query returned no field connection")
+        for edge in connection.get("edges") or []:
+            node = edge.get("node") if isinstance(edge, Mapping) else None
+            if isinstance(node, Mapping) and node.get("path"):
+                items.append({"path": str(node["path"]), "type": str(node.get("type") or "unknown")})
+                if len(items) >= target:
+                    break
+        page_info = connection.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        cursor = page_info.get("endCursor")
+        if not has_next_page or not cursor:
+            break
+    return ProjectFieldPage(
+        items=items[:limit],
+        has_more=len(items) > limit or has_next_page,
+        requests=requests,
+    )
+
+
+def fetch_project_counts(api: Any, *, entity: str, project: str) -> dict[str, int]:
+    """Fetch exact total and state counts in one server-side query."""
+    filters = {
+        "all": {},
+        "finished": {"state": "finished"},
+        "failed": {"state": "failed"},
+        "crashed": {"state": "crashed"},
+        "running": {"state": "running"},
+    }
+    variables = {
+        "entity": entity,
+        "project": project,
+        **{name: json.dumps(value, separators=(",", ":")) for name, value in filters.items()},
+    }
+    try:
+        project_payload = _project_payload(execute_graphql(api, PROJECT_COUNTS_QUERY, variables))
+    except Exception as exc:
+        raise SelectiveReadUnavailable(f"project count query unavailable: {type(exc).__name__}") from exc
+    return {name: int(project_payload.get("total" if name == "all" else name) or 0) for name in filters}
+
+
+def fetch_artifact_inventory(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    type_limit: int = 20,
+) -> dict[str, Any]:
+    """Return a compact, bounded artifact type and collection inventory."""
+    try:
+        project_payload = _project_payload(
+            execute_graphql(
+                api,
+                ARTIFACT_INVENTORY_QUERY,
+                {"entity": entity, "project": project, "first": max(1, min(type_limit, 50))},
+            )
+        )
+    except Exception as exc:
+        raise SelectiveReadUnavailable(f"artifact inventory unavailable: {type(exc).__name__}") from exc
+    connection = project_payload.get("artifactTypes")
+    if not isinstance(connection, Mapping):
+        raise SelectiveReadUnavailable("artifact inventory returned no artifact type connection")
+    rows: list[dict[str, Any]] = []
+    for edge in connection.get("edges") or []:
+        node = edge.get("node") if isinstance(edge, Mapping) else None
+        if not isinstance(node, Mapping):
+            continue
+        collections = node.get("artifactCollections") or {}
+        rows.append(
+            {
+                "type": node.get("name"),
+                "collection_count": int(collections.get("totalCount") or 0),
+                "sample_collections": [
+                    {
+                        "name": collection_node.get("name"),
+                        "description": collection_node.get("description"),
+                    }
+                    for collection_edge in collections.get("edges") or []
+                    if isinstance(collection_edge, Mapping)
+                    and isinstance((collection_node := collection_edge.get("node")), Mapping)
+                ],
+            }
+        )
+    return {
+        "types": rows,
+        "returned_count": len(rows),
+        "has_more": bool((connection.get("pageInfo") or {}).get("hasNextPage")),
+    }
+
+
+__all__ = [
+    "ARTIFACT_INVENTORY_QUERY",
+    "PROJECTED_RUNS_QUERY",
+    "PROJECTED_RUN_QUERY",
+    "PROJECT_COUNTS_QUERY",
+    "PROJECT_FIELDS_QUERY",
+    "ProjectFieldPage",
+    "ProjectedRunPage",
+    "SelectiveReadUnavailable",
+    "fetch_artifact_inventory",
+    "fetch_project_counts",
+    "fetch_project_fields",
+    "fetch_projected_run",
+    "fetch_projected_runs",
+]

--- a/tests/test_oom_protection.py
+++ b/tests/test_oom_protection.py
@@ -4,7 +4,7 @@ import json
 import sys
 from unittest.mock import patch
 
-
+import pytest
 from wandb_mcp_server.config import MAX_ACCUMULATED_BYTES
 
 
@@ -123,4 +123,54 @@ class TestHostedLimitConfig:
         with patch.dict(os.environ, {"MCP_HOSTED_MODE": "true", "MCP_MAX_QUERY_LIMIT": "42"}, clear=False):
             importlib.reload(cfg)
             assert cfg.MCP_MAX_QUERY_LIMIT == 42
+        importlib.reload(cfg)
+
+    def test_dedicated_profile_uses_larger_bounded_defaults(self):
+        import importlib
+        import os
+        import wandb_mcp_server.config as cfg
+
+        with patch.dict(
+            os.environ,
+            {"MCP_HOSTED_MODE": "true", "MCP_WORKLOAD_PROFILE": "dedicated"},
+            clear=False,
+        ):
+            importlib.reload(cfg)
+            assert cfg.MCP_MAX_WANDB_QUERY_ITEMS == 250
+            assert cfg.MCP_MAX_FULL_DETAIL_ITEMS == 10
+            assert cfg.MCP_MAX_HISTORY_SAMPLES == 1_500
+            assert cfg.MCP_MAX_HISTORY_KEYS == 50
+            assert cfg.MCP_ADMISSION_ACTOR_CAPACITY == 8
+            assert cfg.MCP_ADMISSION_PROCESS_CAPACITY == 16
+        importlib.reload(cfg)
+
+    def test_local_profile_disables_admission_by_default(self):
+        import importlib
+        import os
+        import wandb_mcp_server.config as cfg
+
+        with patch.dict(
+            os.environ,
+            {
+                "MCP_HOSTED_MODE": "false",
+                "MCP_WORKLOAD_PROFILE": "local",
+                "MCP_ADMISSION_CONTROL_ENABLED": "",
+            },
+            clear=False,
+        ):
+            os.environ.pop("MCP_ADMISSION_CONTROL_ENABLED")
+            importlib.reload(cfg)
+            assert cfg.MCP_MAX_WANDB_QUERY_ITEMS == 1_000
+            assert cfg.MCP_MAX_HISTORY_SAMPLES == 5_000
+            assert cfg.MCP_ADMISSION_CONTROL_ENABLED is False
+        importlib.reload(cfg)
+
+    def test_invalid_profile_is_rejected(self):
+        import importlib
+        import os
+        import wandb_mcp_server.config as cfg
+
+        with patch.dict(os.environ, {"MCP_WORKLOAD_PROFILE": "unbounded"}, clear=False):
+            with pytest.raises(ValueError, match="MCP_WORKLOAD_PROFILE"):
+                importlib.reload(cfg)
         importlib.reload(cfg)

--- a/tests/test_probe_project.py
+++ b/tests/test_probe_project.py
@@ -1,181 +1,249 @@
-"""Tests for the probe_project tool."""
+"""Tests for bounded project probing."""
 
+from contextlib import contextmanager
 import json
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
 
+import pytest
 
-from wandb_mcp_server.mcp_tools.probe_project import (
-    _safe_sample_value,
-    probe_project,
+from wandb_mcp_server.mcp_tools import probe_project as probe_module
+from wandb_mcp_server.wandb_selective_reads import (
+    ProjectFieldPage,
+    ProjectedRunPage,
+    SelectiveReadUnavailable,
 )
 
 
-class TestSafeSampleValue:
-    def test_short_string(self):
-        assert _safe_sample_value("hello") == "hello"
-
-    def test_long_string_truncated(self):
-        long = "x" * 200
-        result = _safe_sample_value(long)
-        assert result.endswith("...")
-        assert len(result) == 103
-
-    def test_int_passthrough(self):
-        assert _safe_sample_value(42) == 42
-
-    def test_list_representation(self):
-        result = _safe_sample_value([1, 2, 3])
-        assert "list" in result
-        assert "len=3" in result
-
-    def test_dict_representation(self):
-        result = _safe_sample_value({"a": 1, "b": 2})
-        assert "dict" in result
-        assert "keys=2" in result
+@contextmanager
+def _tracking(*args, **kwargs):
+    yield SimpleNamespace(mark_error=lambda error: None)
 
 
-class TestProbeProject:
-    def _make_mock_run(
-        self, *, config=None, summary=None, state="finished", tags=None, group=None, lastHistoryStep=100
-    ):
-        run = MagicMock()
-        run.config = config or {}
-        run.summary = summary or {}
-        run.state = state
-        run.tags = tags or []
-        run.group = group
-        run.lastHistoryStep = lastHistoryStep
-        return run
+@pytest.fixture
+def probe_fakes(monkeypatch):
+    api = SimpleNamespace(runs=lambda *args, **kwargs: pytest.fail("SDK fallback must not run"))
+    monkeypatch.setattr(probe_module.WandBApiManager, "get_api", lambda: api)
+    monkeypatch.setattr(probe_module, "track_tool_execution", _tracking)
+    monkeypatch.setattr(
+        probe_module,
+        "fetch_project_counts",
+        lambda *args, **kwargs: {
+            "all": 12_345,
+            "finished": 12_000,
+            "failed": 100,
+            "crashed": 45,
+            "running": 200,
+        },
+    )
+    monkeypatch.setattr(
+        probe_module,
+        "fetch_project_fields",
+        lambda *args, **kwargs: ProjectFieldPage(
+            items=[
+                {"path": "config.learning_rate", "type": "number"},
+                {"path": "config.model.name", "type": "string"},
+                {"path": "summary_metrics.validation/loss", "type": "number"},
+                {"path": "summaryMetrics.accuracy", "type": "number"},
+                {"path": "summary._runtime", "type": "number"},
+            ],
+            has_more=False,
+            requests=1,
+        ),
+    )
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_key_extraction(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-
-        run1 = self._make_mock_run(
-            config={"lr": 0.01, "model": "bert"},
-            summary={"loss": 0.5, "accuracy": 0.9},
+    def projected(*args, order, limit, **kwargs):
+        suffix = "new" if order.startswith("-") else "old"
+        return ProjectedRunPage(
+            items=[
+                {
+                    "id": f"{suffix}-{index}",
+                    "state": "finished",
+                    "group": "baseline",
+                    "tags": ["production"],
+                    "history_line_count": 100,
+                }
+                for index in range(limit)
+            ],
+            total_count=12_345,
+            has_more=True,
+            requests=1,
         )
-        run2 = self._make_mock_run(
-            config={"lr": 0.001, "batch_size": 32},
-            summary={"loss": 0.3, "f1": 0.85},
+
+    monkeypatch.setattr(probe_module, "fetch_projected_runs", projected)
+    return api
+
+
+def test_probe_uses_exact_counts_indexed_fields_and_recent_oldest_samples(probe_fakes):
+    result = json.loads(probe_module.probe_project("entity", "project", sample_runs=6))
+
+    assert result["run_count"] == 12_345
+    assert result["state_counts"] == {
+        "finished": 12_000,
+        "failed": 100,
+        "crashed": 45,
+        "running": 200,
+    }
+    assert result["sampled_runs"] == 6
+    assert {row["id"].split("-", 1)[0] for row in result["run_samples"]} == {"new", "old"}
+    assert result["summary_fields"] == [
+        {"path": "validation/loss", "type": "number"},
+        {"path": "accuracy", "type": "number"},
+    ]
+    assert result["config_fields"] == [
+        {"path": "learning_rate", "type": "number"},
+        {"path": "model.name", "type": "string"},
+    ]
+    assert result["sample_scope"]["project_exhaustive"] is False
+    assert result["field_inventory"]["project_exhaustive"] is True
+    assert result["has_history_in_sample"] is True
+    assert result["recommended_next_calls"][0]["tool"] == "query_wandb_tool"
+
+
+def test_probe_forwards_field_pattern_and_caps_inventory(monkeypatch, probe_fakes):
+    captured = {}
+
+    def fields(*args, **kwargs):
+        captured.update(kwargs)
+        return ProjectFieldPage(
+            items=[{"path": f"summary_metrics.metric_{index}", "type": "number"} for index in range(500)],
+            has_more=True,
+            requests=3,
         )
 
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+    monkeypatch.setattr(probe_module, "fetch_project_fields", fields)
+    monkeypatch.setattr(probe_module, "MCP_MAX_PROJECT_FIELDS", 500)
 
-        result = json.loads(probe_project("ent", "proj"))
+    result = json.loads(probe_module.probe_project("entity", "project", field_pattern="validation"))
 
-        assert "lr" in result["config_keys"]
-        assert "model" in result["config_keys"]
-        assert "batch_size" not in result["config_keys"]
-        assert "loss" in result["metric_keys"]
-        assert "accuracy" in result["metric_keys"]
-        assert "f1" not in result["metric_keys"]
-        assert result["run_count"] is None
-        assert result["sampled_runs"] == 1
-        mock_api_mgr.get_api.return_value.runs.assert_called_once_with("ent/proj", per_page=1, lazy=True)
+    assert captured["pattern"] == "validation"
+    assert captured["limit"] == 500
+    assert result["summary_field_count_returned"] == 500
+    assert len(result["summary_fields"]) == 200
+    assert result["field_inventory"]["has_more"] is True
+    assert result["field_inventory"]["response_truncated"] is True
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_empty_project(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([])
 
-        result = json.loads(probe_project("ent", "empty-proj"))
+def test_probe_caps_requested_run_samples(monkeypatch, probe_fakes):
+    monkeypatch.setattr(probe_module, "MCP_MAX_PROBE_RUNS", 4)
 
-        assert result["run_count"] is None
-        assert result["metric_keys"] == {}
-        assert result["config_keys"] == {}
-        assert result["has_history"] is False
-        assert any("Small project" in r for r in result["recommendations"])
+    result = json.loads(probe_module.probe_project("entity", "project", sample_runs=100))
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_large_project_is_not_scanned_or_counted(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+    assert result["sampled_runs"] == 4
+    assert result["sample_scope"] == {
+        "strategy": "recent_and_oldest",
+        "requested": 100,
+        "effective": 4,
+        "cap_applied": True,
+        "project_exhaustive": False,
+    }
 
-        runs = [
-            self._make_mock_run(
-                config={"lr": 0.01},
-                summary={"loss": 0.5},
-            )
-            for _ in range(150)
-        ]
-        mock_api_mgr.get_api.return_value.runs.return_value = iter(runs)
 
-        result = json.loads(probe_project("ent", "big-proj", sample_runs=5))
+def test_probe_optional_artifact_inventory(monkeypatch, probe_fakes):
+    monkeypatch.setattr(
+        probe_module,
+        "fetch_artifact_inventory",
+        lambda *args, **kwargs: {
+            "types": [{"type": "model", "collection_count": 3}],
+            "returned_count": 1,
+            "has_more": False,
+        },
+    )
 
-        assert result["run_count"] is None
-        assert result["sampled_runs"] == 1
-        assert not any("Large project" in r for r in result["recommendations"])
+    result = json.loads(probe_module.probe_project("entity", "project", include_artifacts=True))
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_tag_and_group_collection(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+    assert result["artifact_inventory"]["types"][0]["type"] == "model"
 
-        run1 = self._make_mock_run(tags=["baseline", "v1"], group="experiment-1")
-        run2 = self._make_mock_run(tags=["tuned", "v1"], group="experiment-2")
 
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+def test_probe_uses_bounded_non_lazy_sdk_fallback(monkeypatch):
+    calls = []
 
-        result = json.loads(probe_project("ent", "proj"))
+    class FakeRuns:
+        def __init__(self, rows, total):
+            self.rows = rows
+            self.total = total
 
-        assert "baseline" in result["tags"]
-        assert "tuned" not in result["tags"]
-        assert "v1" in result["tags"]
-        assert "experiment-1" in result["groups"]
-        assert "experiment-2" not in result["groups"]
-        assert any("Tags in use" in r for r in result["recommendations"])
-        assert any("Run groups found" in r for r in result["recommendations"])
+        def __iter__(self):
+            return iter(self.rows)
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_filters_internal_keys(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+        def __len__(self):
+            return self.total
 
-        run = self._make_mock_run(
-            config={"lr": 0.01, "_wandb": {}, "wandb_version": "0.1"},
-            summary={"loss": 0.5, "_runtime": 100, "wandb/cpu": 0.8},
-        )
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([run])
+    run = SimpleNamespace(
+        id="run-1",
+        name="Run 1",
+        state="finished",
+        entity="entity",
+        project="project",
+        created_at="2026-01-01",
+        group="group",
+        job_type="train",
+        tags=["tag"],
+        lastHistoryStep=100,
+        url="https://wandb.ai/entity/project/runs/run-1",
+        config={"learning_rate": 0.1},
+        summary={"loss": 0.2},
+    )
 
-        result = json.loads(probe_project("ent", "proj"))
+    def runs(path, **kwargs):
+        calls.append(kwargs)
+        if kwargs.get("lazy") is False:
+            return FakeRuns([run], 1)
+        state = (kwargs.get("filters") or {}).get("state")
+        return FakeRuns([], 1 if state == "finished" else 10 if state is None else 0)
 
-        assert "_wandb" not in result["config_keys"]
-        assert "wandb_version" not in result["config_keys"]
-        assert "lr" in result["config_keys"]
-        assert "_runtime" not in result["metric_keys"]
-        assert "wandb/cpu" not in result["metric_keys"]
-        assert "loss" in result["metric_keys"]
+    api = SimpleNamespace(runs=runs)
+    monkeypatch.setattr(probe_module.WandBApiManager, "get_api", lambda: api)
+    monkeypatch.setattr(probe_module, "track_tool_execution", _tracking)
+    monkeypatch.setattr(
+        probe_module,
+        "fetch_project_counts",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("project fields unsupported")),
+    )
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_project_not_found_error(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
-        mock_api_mgr.get_api.return_value.runs.side_effect = Exception("Project not found")
+    result = json.loads(probe_module.probe_project("entity", "project", sample_runs=2))
 
-        result = json.loads(probe_project("ent", "no-such-proj"))
+    assert result["source"] == "wandb_sdk_fallback"
+    assert result["run_count"] == 10
+    assert result["config_fields"] == [{"path": "learning_rate", "type": "float"}]
+    assert result["summary_fields"] == [{"path": "loss", "type": "float"}]
+    assert "bounded hydrated SDK runs" in result["compatibility_caveat"]
+    assert any(call.get("lazy") is False for call in calls)
 
-        assert result["error"] == "project_not_found"
-        assert "Project not found" in result["message"]
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_typical_steps_calculation(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+def test_probe_returns_structured_error(monkeypatch):
+    monkeypatch.setattr(
+        probe_module.WandBApiManager,
+        "get_api",
+        lambda: (_ for _ in ()).throw(ValueError("project not found")),
+    )
+    monkeypatch.setattr(probe_module, "track_tool_execution", _tracking)
 
-        run1 = self._make_mock_run(lastHistoryStep=1000)
-        run2 = self._make_mock_run(lastHistoryStep=2000)
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2])
+    result = json.loads(probe_module.probe_project("entity", "missing"))
 
-        result = json.loads(probe_project("ent", "proj"))
+    assert result == {"error": "project_probe_failed", "message": "project not found"}
 
-        assert result["has_history"] is True
-        assert result["typical_steps"] == 1000
 
-    @patch("wandb_mcp_server.mcp_tools.probe_project.WandBApiManager")
-    def test_run_states_counted(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="user")
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"entity_name": "", "project_name": "project"},
+        {"entity_name": "entity", "project_name": ""},
+        {"entity_name": "entity", "project_name": "project", "sample_runs": 0},
+        {"entity_name": "entity", "project_name": "project", "field_pattern": ""},
+        {"entity_name": "entity", "project_name": "project", "include_artifacts": "yes"},
+    ],
+)
+def test_probe_validates_before_creating_api(monkeypatch, kwargs):
+    monkeypatch.setattr(
+        probe_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be constructed"),
+    )
 
-        run1 = self._make_mock_run(state="finished")
-        run2 = self._make_mock_run(state="finished")
-        run3 = self._make_mock_run(state="crashed")
-        mock_api_mgr.get_api.return_value.runs.return_value = iter([run1, run2, run3])
+    with pytest.raises(ValueError):
+        probe_module.probe_project(**kwargs)
 
-        result = json.loads(probe_project("ent", "proj"))
 
-        assert result["run_states"] == {"finished": 1}
+def test_safe_sample_value_compatibility_helper():
+    assert probe_module._safe_sample_value("x" * 200).endswith("...")
+    assert probe_module._safe_sample_value([1, 2]) == "[list, len=2]"

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -12,6 +12,7 @@ from wandb.apis.public import Api, Project
 
 from wandb_mcp_server.mcp_tools import query_wandb as sdk_query
 from wandb_mcp_server.server import create_mcp_server
+from wandb_mcp_server.wandb_selective_reads import ProjectedRunPage
 
 
 @contextmanager
@@ -201,20 +202,45 @@ def test_runs_pass_sdk_filters_order_and_bound_collection(fake_api):
     assert all("summary" not in item for item in result["items"])
 
 
-def test_run_collection_can_select_summary_keys_without_full_summary(fake_api):
-    run = _run("run-1")
-    run.summary = {"accuracy": 0.9, "loss": 0.2, **{f"metric_{index}": index for index in range(24_000)}}
-    fake_api.runs = lambda path, **kwargs: iter([run])
+def test_run_collection_can_select_fields_without_full_summary(fake_api, monkeypatch):
+    fake_api.runs = lambda *args, **kwargs: pytest.fail("projected reads must not hydrate SDK runs")
+    projected_calls = []
+
+    def projected(*args, **kwargs):
+        projected_calls.append(kwargs)
+        return ProjectedRunPage(
+            items=[
+                {
+                    "id": "run-1",
+                    "entity": "entity",
+                    "project": "project",
+                    "summary": {"accuracy": 0.9, "loss": 0.2},
+                    "config": {"learning_rate": 0.01},
+                }
+            ],
+            total_count=24_000,
+            has_more=True,
+            requests=1,
+        )
+
+    monkeypatch.setattr(sdk_query, "fetch_projected_runs", projected)
 
     result = sdk_query.query_wandb(
         "entity",
         "project",
         "runs",
-        limit=1,
+        limit=50,
         summary_keys=["accuracy", "loss"],
+        config_keys=["learning_rate"],
     )
 
     assert result["items"][0]["summary"] == {"accuracy": 0.9, "loss": 0.2}
+    assert result["items"][0]["config"] == {"learning_rate": 0.01}
+    assert result["total_count"] == 24_000
+    assert result["returned_count"] == 1
+    assert result["source"] == "wandb_selective_read"
+    assert projected_calls[0]["summary_keys"] == ["accuracy", "loss"]
+    assert projected_calls[0]["config_keys"] == ["learning_rate"]
 
 
 @pytest.mark.asyncio
@@ -223,7 +249,11 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
     server = create_mcp_server("stdio")
     query_tool = next(tool for tool in await server.list_tools() if tool.name == "query_wandb_tool")
 
-    assert "summary_keys" in query_tool.inputSchema["properties"]
+    assert {
+        "summary_keys",
+        "config_keys",
+        "response_mode",
+    } <= query_tool.inputSchema["properties"].keys()
 
     await server.call_tool(
         "query_wandb_tool",
@@ -233,10 +263,34 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
             "resource": "runs",
             "limit": 1,
             "summary_keys": ["accuracy"],
+            "config_keys": ["learning_rate"],
         },
     )
 
     assert fake_api.calls[0][0:2] == ("runs", "entity/project")
+
+
+def test_count_mode_uses_public_sdk_without_iterating(fake_api):
+    class CountOnlyRuns:
+        def __len__(self):
+            return 42
+
+        def __iter__(self):
+            raise AssertionError("count mode must not iterate runs")
+
+    fake_api.runs = lambda path, **kwargs: CountOnlyRuns()
+
+    result = sdk_query.query_wandb(
+        "entity",
+        "project",
+        "runs",
+        filters={"state": "finished"},
+        response_mode="count",
+    )
+
+    assert result["total_count"] == 42
+    assert result["response_mode"] == "count"
+    assert result["project_exhaustive"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_wandb_graphql_read_only.py
+++ b/tests/test_wandb_graphql_read_only.py
@@ -125,6 +125,7 @@ def test_application_graphql_transport_is_confined_to_approved_modules():
     package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
     approved = {
         package_root / "wandb_graphql.py",
+        package_root / "wandb_selective_reads.py",
         package_root / "mcp_tools" / "query_wandb_gql.py",
     }
     violations = [

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -1,0 +1,184 @@
+"""Contract tests for application-owned selective W&B reads."""
+
+from __future__ import annotations
+
+import json
+
+from wandb_mcp_server.wandb_graphql import validate_read_only_graphql
+from wandb_mcp_server.wandb_selective_reads import (
+    ARTIFACT_INVENTORY_QUERY,
+    PROJECTED_RUNS_QUERY,
+    PROJECTED_RUN_QUERY,
+    PROJECT_COUNTS_QUERY,
+    PROJECT_FIELDS_QUERY,
+    fetch_project_counts,
+    fetch_project_fields,
+    fetch_projected_run,
+    fetch_projected_runs,
+)
+
+
+class FakeServiceApi:
+    def __init__(self):
+        self.calls = []
+
+    def execute_graphql(self, query, variables=None):
+        variables = variables or {}
+        self.calls.append((query, variables))
+        if "MCPProjectedRuns" in query:
+            summary = {key: 0.9 if key == "accuracy" else 0.2 for key in variables["summaryKeys"]}
+            config = {key: {"value": 0.01} for key in variables["configKeys"]}
+            return {
+                "project": {
+                    "runCount": 24_000,
+                    "runs": {
+                        "edges": [
+                            {
+                                "cursor": "cursor-1",
+                                "node": {
+                                    "id": "graphql-id",
+                                    "name": "run-1",
+                                    "displayName": "Run 1",
+                                    "state": "finished",
+                                    "createdAt": "2026-01-01",
+                                    "heartbeatAt": "2026-01-02",
+                                    "computeSeconds": 10,
+                                    "historyLineCount": 1_000,
+                                    "group": "baseline",
+                                    "jobType": "train",
+                                    "tags": ["production"],
+                                    "user": {"username": "alice", "name": "Alice"},
+                                    "summaryMetrics": json.dumps(summary),
+                                    "config": json.dumps(config),
+                                },
+                            }
+                        ],
+                        "pageInfo": {"endCursor": "cursor-1", "hasNextPage": False},
+                    },
+                }
+            }
+        if "MCPProjectedRun" in query:
+            return {
+                "project": {
+                    "run": {
+                        "id": "graphql-id",
+                        "name": variables["run"],
+                        "displayName": "Single Run",
+                        "state": "finished",
+                        "summaryMetrics": json.dumps({"loss": 0.2}),
+                        "config": json.dumps({"model.name": {"value": "small"}}),
+                    }
+                }
+            }
+        if "MCPProjectFields" in query:
+            return {
+                "project": {
+                    "fields": {
+                        "edges": [
+                            {
+                                "cursor": "field-1",
+                                "node": {
+                                    "path": "summary_metrics.validation/loss",
+                                    "type": "number",
+                                },
+                            }
+                        ],
+                        "pageInfo": {"endCursor": "field-1", "hasNextPage": False},
+                    }
+                }
+            }
+        if "MCPProjectCounts" in query:
+            return {
+                "project": {
+                    "total": 100,
+                    "finished": 80,
+                    "failed": 5,
+                    "crashed": 3,
+                    "running": 12,
+                }
+            }
+        raise AssertionError("unexpected query")
+
+
+class FakeApi:
+    def __init__(self):
+        self._service_api = FakeServiceApi()
+
+
+def test_every_application_owned_document_is_query_only():
+    for document in (
+        PROJECTED_RUNS_QUERY,
+        PROJECTED_RUN_QUERY,
+        PROJECT_COUNTS_QUERY,
+        PROJECT_FIELDS_QUERY,
+        ARTIFACT_INVENTORY_QUERY,
+    ):
+        validate_read_only_graphql(document)
+
+
+def test_projected_collection_fetches_only_requested_fields_in_one_request():
+    api = FakeApi()
+
+    result = fetch_projected_runs(
+        api,
+        entity="entity",
+        project="project",
+        filters={"state": "finished"},
+        order="-summary_metrics.accuracy",
+        limit=50,
+        page_size=51,
+        summary_keys=["accuracy", "loss"],
+        config_keys=["learning_rate"],
+    )
+
+    assert result.total_count == 24_000
+    assert result.requests == 1
+    assert result.items[0]["summary"] == {"accuracy": 0.9, "loss": 0.2}
+    assert result.items[0]["config"] == {"learning_rate": 0.01}
+    assert len(api._service_api.calls) == 1
+    variables = api._service_api.calls[0][1]
+    assert variables["summaryKeys"] == ["accuracy", "loss"]
+    assert variables["configKeys"] == ["learning_rate"]
+    assert json.loads(variables["filters"]) == {"state": "finished"}
+
+
+def test_single_projected_run_supports_nested_and_literal_config_keys():
+    api = FakeApi()
+
+    result = fetch_projected_run(
+        api,
+        entity="entity",
+        project="project",
+        run_id="run-1",
+        summary_keys=["loss"],
+        config_keys=["model.name"],
+    )
+
+    assert result is not None
+    assert result["id"] == "run-1"
+    assert result["summary"] == {"loss": 0.2}
+    assert result["config"] == {"model.name": "small"}
+
+
+def test_project_field_index_and_counts_are_server_side():
+    api = FakeApi()
+
+    fields = fetch_project_fields(
+        api,
+        entity="entity",
+        project="project",
+        limit=500,
+        pattern="validation",
+    )
+    counts = fetch_project_counts(api, entity="entity", project="project")
+
+    assert fields.items == [{"path": "summary_metrics.validation/loss", "type": "number"}]
+    assert fields.has_more is False
+    assert counts == {
+        "all": 100,
+        "finished": 80,
+        "failed": 5,
+        "crashed": 3,
+        "running": 12,
+    }
+    assert api._service_api.calls[0][1]["pattern"] == "validation"


### PR DESCRIPTION
## Summary

- adds `shared`, `dedicated`, and `local` workload profiles with expert overrides preserved
- adds fixed, application-owned query-only documents for projected run rows, exact project counts, indexed project fields, and bounded artifact inventory
- extends `query_wandb_tool` with `config_keys` and `response_mode`, and normalizes collection scope metadata
- makes `probe_project_tool` use exact counts, the project field index, bounded recent/oldest samples, and optional artifact inventory
- never exposes caller-supplied GraphQL and routes every selective read through the existing read-only transport and internal API URL resolution

## Stack

This cumulative draft targets `staging/0.4.0` as requested and includes the pending #118 and #119 heads. Merge order remains #118 → #119 → this PR. Refresh this diff after those PRs merge; do not squash or bypass review.

## Validation

- Ruff check and format check
- Bandit Medium/High scan
- `uv lock --check`
- Python 3.11: 895 passed, 10 deselected
- Python 3.12: 895 passed, 10 deselected
- W&B latest compatibility: 80 passed, 1 deselected
- focused selective-read/query/probe/security suite
- fresh wheel build, import, default registration, and raw-GraphQL opt-in registration
- read-only live checks using sourced local credentials: exact project counts, field index, projected runs, selected summary/config values, and artifact inventory

## Safety and scale properties

- a projected 50-run request performs one bounded data query plus at most one count in the public query flow; no per-run summary/config loads
- full config/summary SDK fallback is allowed only inside the profile's small full-detail cap
- unsupported Dedicated selective fields return an explicit compatibility error rather than producing N+1 traffic or retrying through the public URL
- raw GraphQL remains opt-in and disabled by default
