### PR TITLE
perf: improve W&B history and run-analysis accuracy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
             tests/test_query_wandb_sdk.py \
             tests/test_probe_project.py \
             tests/test_wandb_selective_reads.py \
+            tests/test_run_history.py \
+            tests/test_compare_runs.py \
+            tests/test_diagnose_run.py \
             tests/test_tool_registration.py \
             tests/test_wandb_graphql.py \
             tests/test_wandb_graphql_read_only.py \

--- a/src/wandb_mcp_server/admission.py
+++ b/src/wandb_mcp_server/admission.py
@@ -7,7 +7,7 @@ import time
 from collections import defaultdict, deque
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Deque
+from typing import Any, Deque, Mapping
 
 
 current_tool_deadline: ContextVar[float | None] = ContextVar("mcp_tool_deadline", default=None)
@@ -143,24 +143,57 @@ LIGHT_TOOLS = frozenset(
 
 EXPENSIVE_TOOLS = frozenset(
     {
-        "query_wandb_tool",
-        "get_run_history_tool",
-        "probe_project_tool",
-        "compare_runs_tool",
-        "diagnose_run_tool",
-        "count_weave_traces_tool",
-        "infer_trace_schema_tool",
         "resolve_trace_roots_tool",
         "create_wandb_report_tool",
         "log_analysis_to_wandb",
     }
 )
 
+HEAVY_TOOLS = frozenset(
+    {
+        "probe_project_tool",
+        "compare_runs_tool",
+        "diagnose_run_tool",
+        "infer_trace_schema_tool",
+        "summarize_evaluation_tool",
+        "query_weave_traces_tool",
+        "query_wandb_graphql_tool",
+        "compare_artifact_versions_tool",
+    }
+)
 
-def tool_cost(name: str) -> tuple[str, int]:
-    """Return the stable telemetry cost class and admission weight for a tool."""
+
+def tool_cost(name: str, arguments: Mapping[str, Any] | None = None) -> tuple[str, int]:
+    """Return the request-aware telemetry cost class and admission weight."""
+    arguments = arguments or {}
+    if name == "query_wandb_tool":
+        if arguments.get("response_mode") == "count":
+            return "light", 1
+        resource = arguments.get("resource")
+        include = set(arguments.get("include") or [])
+        full_summary = "summary" in include and not arguments.get("summary_keys")
+        full_config = "config" in include and not arguments.get("config_keys")
+        if full_summary or full_config or include & {"system_metrics", "spec"}:
+            return "heavy", 4
+        if resource in {"project", "run", "sweep"} and not include:
+            return "light", 1
+        return "expensive", 2
+    if name == "get_run_history_tool":
+        if (
+            arguments.get("target_x") is not None
+            or arguments.get("min_step") is not None
+            or arguments.get("max_step") is not None
+        ):
+            return "heavy", 4
+        return "expensive", 2
+    if name == "get_artifact_details_tool" and arguments.get("include_files"):
+        return "heavy", 4
+    if name == "count_weave_traces_tool":
+        return "light", 1
     if name in LIGHT_TOOLS:
         return "light", 1
+    if name in HEAVY_TOOLS:
+        return "heavy", 4
     if name in EXPENSIVE_TOOLS:
         return "expensive", 2
     return "heavy", 4

--- a/src/wandb_mcp_server/instrumented_server.py
+++ b/src/wandb_mcp_server/instrumented_server.py
@@ -146,7 +146,7 @@ class InstrumentedFastMCP(FastMCP):
         error: str | None = None
         lease = None
         deadline_token = None
-        cost_class, weight = tool_cost(name)
+        cost_class, weight = tool_cost(name, arguments)
         admission_outcome = "disabled"
         queue_ms = 0.0
         try:

--- a/src/wandb_mcp_server/mcp_tools/compare_runs.py
+++ b/src/wandb_mcp_server/mcp_tools/compare_runs.py
@@ -4,16 +4,20 @@ import json
 import math
 from typing import Any, Dict, List, Optional
 
+from wandb_mcp_server.admission import ToolDeadlineExceeded
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.config import MCP_MAX_HISTORY_KEYS, MCP_MAX_HISTORY_SAMPLES
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_selective_reads import fetch_project_fields, fetch_projected_run
 
 logger = get_rich_logger(__name__)
 
 COMPARE_RUNS_TOOL_DESCRIPTION = """Compare two W&B runs side-by-side.
 
-Returns config differences, summary metric deltas, and metadata comparison.
+Returns projected config differences, summary metric deltas, metadata, and
+optional sampled history overlap. It never loads complete wide summaries simply
+to discover comparison fields.
 
 <when_to_use>
 Call when the user asks "what changed between run A and B?", "which run is better?",
@@ -41,6 +45,14 @@ history_keys : list of str, optional
     Specific metric keys to compare in history. If None, uses common keys.
 history_samples : int, optional
     Number of history samples per run. Default: 50.
+config_keys : list of str, optional
+    Exact config fields to compare. When omitted, a bounded set is selected from
+    the project field index and disclosed in the response.
+summary_keys : list of str, optional
+    Exact summary fields to compare. When omitted, a bounded numeric set is
+    selected from the project field index and disclosed in the response.
+x_axis : str, optional
+    X-axis used for optional history sampling. Defaults to "_step".
 
 Returns
 -------
@@ -48,6 +60,8 @@ JSON with config_diff, summary_diff, metadata_diff, and optional history_compari
 """
 
 DEFAULT_HISTORY_SAMPLES = 50
+_AUTO_CONFIG_LIMIT = 10
+_AUTO_SUMMARY_LIMIT = 20
 
 
 def _safe_val(v: Any) -> Any:
@@ -91,6 +105,54 @@ def _diff_dicts(a: Dict, b: Dict) -> Dict[str, Any]:
     }
 
 
+def _normalized_indexed_key(path: str, category: str) -> str | None:
+    prefixes = {
+        "config": ("config.", "config/"),
+        "summary": ("summary.", "summary/", "summary_metrics.", "summary_metrics/", "summaryMetrics."),
+    }
+    for prefix in prefixes[category]:
+        if path.startswith(prefix):
+            return path[len(prefix) :]
+    return None
+
+
+def _indexed_comparison_keys(api: Any, entity_name: str, project_name: str) -> tuple[list[str], list[str], bool]:
+    fields = fetch_project_fields(
+        api,
+        entity=entity_name,
+        project=project_name,
+        limit=max(MCP_MAX_HISTORY_KEYS * 20, 200),
+    )
+    config_keys: list[str] = []
+    numeric_summary_keys: list[str] = []
+    numeric_types = {"number", "integer", "float", "int", "number[]"}
+    for field in fields.items:
+        path = field["path"]
+        if key := _normalized_indexed_key(path, "config"):
+            if not key.startswith(("_", "wandb")):
+                config_keys.append(key)
+            continue
+        if key := _normalized_indexed_key(path, "summary"):
+            if not key.startswith(("_", "wandb/")) and field.get("type", "").lower() in numeric_types:
+                numeric_summary_keys.append(key)
+    priority = ("loss", "accuracy", "score", "precision", "recall", "f1", "auc")
+    numeric_summary_keys.sort(key=lambda key: (not any(token in key.lower() for token in priority), key))
+    return (
+        list(dict.fromkeys(config_keys))[:_AUTO_CONFIG_LIMIT],
+        list(dict.fromkeys(numeric_summary_keys))[:_AUTO_SUMMARY_LIMIT],
+        not fields.has_more,
+    )
+
+
+def _validate_key_list(name: str, value: Optional[List[str]]) -> None:
+    if value is not None and (
+        not isinstance(value, list)
+        or len(value) > MCP_MAX_HISTORY_KEYS
+        or not all(isinstance(key, str) and key.strip() for key in value)
+    ):
+        raise ValueError(f"{name} must contain at most {MCP_MAX_HISTORY_KEYS} non-empty strings")
+
+
 def compare_runs(
     entity_name: str,
     project_name: str,
@@ -99,17 +161,22 @@ def compare_runs(
     include_history_overlap: bool = False,
     history_keys: Optional[List[str]] = None,
     history_samples: int = DEFAULT_HISTORY_SAMPLES,
+    config_keys: Optional[List[str]] = None,
+    summary_keys: Optional[List[str]] = None,
+    x_axis: str = "_step",
 ) -> str:
     """Compare two W&B runs."""
     if isinstance(history_samples, bool) or not isinstance(history_samples, int) or history_samples < 1:
         raise ValueError("history_samples must be a positive integer")
     history_samples = min(history_samples, MCP_MAX_HISTORY_SAMPLES)
-    if history_keys is not None and (
-        not isinstance(history_keys, list)
-        or not all(isinstance(key, str) and key.strip() for key in history_keys)
-        or len(history_keys) > MCP_MAX_HISTORY_KEYS
+    for name, value in (
+        ("history_keys", history_keys),
+        ("config_keys", config_keys),
+        ("summary_keys", summary_keys),
     ):
-        raise ValueError(f"history_keys must contain at most {MCP_MAX_HISTORY_KEYS} non-empty strings")
+        _validate_key_list(name, value)
+    if not isinstance(x_axis, str) or not x_axis.strip():
+        raise ValueError("x_axis must be a non-empty string")
     api = WandBApiManager.get_api()
     with track_tool_execution(
         "compare_runs",
@@ -119,85 +186,177 @@ def compare_runs(
             "project_name": project_name,
             "run_id_a": run_id_a,
             "run_id_b": run_id_b,
+            "config_key_count": len(config_keys or []),
+            "summary_key_count": len(summary_keys or []),
+            "history_key_count": len(history_keys or []),
+            "include_history_overlap": include_history_overlap,
         },
     ) as ctx:
+        selected_config = list(config_keys or [])
+        selected_summary = list(summary_keys or [])
+        selection_source = "explicit"
+        field_index_exhaustive: bool | None = None
         try:
             path = f"{entity_name}/{project_name}"
-            run_a = api.run(f"{path}/{run_id_a}")
-            run_b = api.run(f"{path}/{run_id_b}")
-        except Exception as e:
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
+            if config_keys is None or summary_keys is None:
+                auto_config, auto_summary, field_index_exhaustive = _indexed_comparison_keys(
+                    api, entity_name, project_name
+                )
+                if config_keys is None:
+                    selected_config = auto_config
+                if summary_keys is None:
+                    selected_summary = auto_summary
+                selection_source = "project_field_index"
 
-        config_a = dict(run_a.config) if run_a.config else {}
-        config_b = dict(run_b.config) if run_b.config else {}
-        summary_a = dict(run_a.summary) if run_a.summary else {}
-        summary_b = dict(run_b.summary) if run_b.summary else {}
+            projected_a = fetch_projected_run(
+                api,
+                entity=entity_name,
+                project=project_name,
+                run_id=run_id_a,
+                config_keys=selected_config,
+                summary_keys=selected_summary,
+            )
+            projected_b = fetch_projected_run(
+                api,
+                entity=entity_name,
+                project=project_name,
+                run_id=run_id_b,
+                config_keys=selected_config,
+                summary_keys=selected_summary,
+            )
+            if projected_a is None or projected_b is None:
+                raise ValueError("one or both runs were not found")
+            compatibility_caveat = None
+        except Exception as selective_error:
+            if isinstance(selective_error, ToolDeadlineExceeded):
+                raise
+            try:
+                run_a = api.run(f"{path}/{run_id_a}")
+                run_b = api.run(f"{path}/{run_id_b}")
+            except Exception as e:
+                ctx.mark_error(f"{type(e).__name__}: {e}")
+                return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
 
-        # Filter out internal keys from summary
-        skip_prefixes = ("_", "wandb/")
-        summary_a = {k: v for k, v in summary_a.items() if not any(k.startswith(p) for p in skip_prefixes)}
-        summary_b = {k: v for k, v in summary_b.items() if not any(k.startswith(p) for p in skip_prefixes)}
+            run_config_a = dict(getattr(run_a, "config", {}) or {})
+            run_config_b = dict(getattr(run_b, "config", {}) or {})
+            run_summary_a = dict(getattr(run_a, "summary", {}) or {})
+            run_summary_b = dict(getattr(run_b, "summary", {}) or {})
+            if config_keys is None:
+                selected_config = sorted(
+                    key for key in (set(run_config_a) | set(run_config_b)) if not key.startswith(("_", "wandb"))
+                )[:_AUTO_CONFIG_LIMIT]
+            if summary_keys is None:
+                selected_summary = sorted(
+                    key
+                    for key in (set(run_summary_a) | set(run_summary_b))
+                    if not key.startswith(("_", "wandb/"))
+                    and isinstance(run_summary_a.get(key, run_summary_b.get(key)), (int, float))
+                )[:_AUTO_SUMMARY_LIMIT]
+            projected_a = {
+                "id": run_id_a,
+                "display_name": getattr(run_a, "name", run_id_a),
+                "state": getattr(run_a, "state", "unknown"),
+                "created_at": getattr(run_a, "created_at", None),
+                "heartbeat_at": getattr(run_a, "heartbeat_at", None),
+                "tags": getattr(run_a, "tags", []),
+                "group": getattr(run_a, "group", None),
+                "config": {key: run_config_a[key] for key in selected_config if key in run_config_a},
+                "summary": {key: run_summary_a[key] for key in selected_summary if key in run_summary_a},
+            }
+            projected_b = {
+                "id": run_id_b,
+                "display_name": getattr(run_b, "name", run_id_b),
+                "state": getattr(run_b, "state", "unknown"),
+                "created_at": getattr(run_b, "created_at", None),
+                "heartbeat_at": getattr(run_b, "heartbeat_at", None),
+                "tags": getattr(run_b, "tags", []),
+                "group": getattr(run_b, "group", None),
+                "config": {key: run_config_b[key] for key in selected_config if key in run_config_b},
+                "summary": {key: run_summary_b[key] for key in selected_summary if key in run_summary_b},
+            }
+            selection_source = "bounded_sdk_compatibility"
+            compatibility_caveat = (
+                f"{type(selective_error).__name__}: selective fields unavailable; "
+                "loaded exactly two SDK runs and retained only the disclosed bounded keys"
+            )
+
+        config_a = dict(projected_a.get("config") or {})
+        config_b = dict(projected_b.get("config") or {})
+        summary_a = dict(projected_a.get("summary") or {})
+        summary_b = dict(projected_b.get("summary") or {})
 
         result: Dict[str, Any] = {
             "run_a": {
                 "id": run_id_a,
-                "name": getattr(run_a, "name", run_id_a),
-                "state": getattr(run_a, "state", "unknown"),
+                "name": projected_a.get("display_name") or run_id_a,
+                "state": projected_a.get("state") or "unknown",
             },
             "run_b": {
                 "id": run_id_b,
-                "name": getattr(run_b, "name", run_id_b),
-                "state": getattr(run_b, "state", "unknown"),
+                "name": projected_b.get("display_name") or run_id_b,
+                "state": projected_b.get("state") or "unknown",
             },
             "config_diff": _diff_dicts(config_a, config_b),
             "summary_diff": _diff_dicts(summary_a, summary_b),
             "metadata_diff": {
                 "run_a": {
-                    "created_at": str(getattr(run_a, "created_at", "")),
-                    "heartbeat_at": str(getattr(run_a, "heartbeat_at", "")),
-                    "tags": getattr(run_a, "tags", []),
-                    "group": getattr(run_a, "group", None),
+                    "created_at": str(projected_a.get("created_at") or ""),
+                    "heartbeat_at": str(projected_a.get("heartbeat_at") or ""),
+                    "tags": projected_a.get("tags") or [],
+                    "group": projected_a.get("group"),
                 },
                 "run_b": {
-                    "created_at": str(getattr(run_b, "created_at", "")),
-                    "heartbeat_at": str(getattr(run_b, "heartbeat_at", "")),
-                    "tags": getattr(run_b, "tags", []),
-                    "group": getattr(run_b, "group", None),
+                    "created_at": str(projected_b.get("created_at") or ""),
+                    "heartbeat_at": str(projected_b.get("heartbeat_at") or ""),
+                    "tags": projected_b.get("tags") or [],
+                    "group": projected_b.get("group"),
                 },
             },
+            "selection": {
+                "source": selection_source,
+                "config_keys": selected_config,
+                "summary_keys": selected_summary,
+                "field_index_exhaustive": field_index_exhaustive,
+            },
+            "coverage": {
+                "config_fields_compared": len(selected_config),
+                "summary_fields_compared": len(selected_summary),
+                "full_run_fields_exhaustive": False,
+                "history_sampled": include_history_overlap,
+            },
         }
+        if compatibility_caveat:
+            result["compatibility_caveat"] = compatibility_caveat
 
         if include_history_overlap:
             try:
-                if history_keys is None:
-                    common_keys = sorted(
-                        key
-                        for key in summary_a.keys() & summary_b.keys()
-                        if isinstance(summary_a[key], (int, float)) and isinstance(summary_b[key], (int, float))
-                    )[:MCP_MAX_HISTORY_KEYS]
-                else:
-                    common_keys = history_keys
-
-                hist_a = (
-                    list(run_a.history(keys=common_keys, samples=history_samples, pandas=False)) if common_keys else []
-                )
-                hist_b = (
-                    list(run_b.history(keys=common_keys, samples=history_samples, pandas=False)) if common_keys else []
-                )
-
+                run_a = api.run(f"{path}/{run_id_a}")
+                run_b = api.run(f"{path}/{run_id_b}")
+                common_keys = list(history_keys or selected_summary)[:MCP_MAX_HISTORY_KEYS]
+                history_kwargs = {
+                    "keys": common_keys,
+                    "samples": history_samples,
+                    "pandas": False,
+                    "x_axis": x_axis,
+                }
+                hist_a = list(run_a.history(**history_kwargs)) if common_keys else []
+                hist_b = list(run_b.history(**history_kwargs)) if common_keys else []
                 result["history_comparison"] = {
                     "keys": common_keys,
+                    "x_axis": x_axis,
+                    "requested_samples_per_run": history_samples,
                     "run_a_rows": len(hist_a),
                     "run_b_rows": len(hist_b),
+                    "sampled": True,
+                    "project_exhaustive": False,
                     "run_a_sample": [
-                        {k: _safe_val(r.get(k)) for k in ["_step"] + common_keys[:5]} for r in hist_a[:10]
+                        {key: _safe_val(row.get(key)) for key in [x_axis] + common_keys[:5]} for row in hist_a[:10]
                     ],
                     "run_b_sample": [
-                        {k: _safe_val(r.get(k)) for k in ["_step"] + common_keys[:5]} for r in hist_b[:10]
+                        {key: _safe_val(row.get(key)) for key in [x_axis] + common_keys[:5]} for row in hist_b[:10]
                     ],
                 }
             except Exception as e:
-                result["history_comparison"] = {"error": str(e)[:300]}
+                result["history_comparison"] = {"error": str(e)[:300], "sampled": True}
 
         return json.dumps(result, default=str)

--- a/src/wandb_mcp_server/mcp_tools/diagnose_run.py
+++ b/src/wandb_mcp_server/mcp_tools/diagnose_run.py
@@ -4,10 +4,12 @@ import json
 import math
 from typing import Any, Dict, List, Optional
 
+from wandb_mcp_server.admission import ToolDeadlineExceeded
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.config import MCP_MAX_HISTORY_KEYS, MCP_MAX_HISTORY_SAMPLES
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_selective_reads import fetch_project_fields, fetch_projected_run
 
 logger = get_rich_logger(__name__)
 
@@ -20,8 +22,9 @@ tail statistics. Returns actionable recommendations.
 Call when the user asks "is my run okay?", "has it converged?", "is it
 overfitting?", or wants a health check on a training run.
 
-This tool samples the run's history and applies standard ML diagnostic
-heuristics. Use get_run_history_tool for raw metric data instead.
+This tool selects a bounded metric set from the project field index, samples
+only those history keys, and discloses the selection and coverage behind every
+conclusion. Use get_run_history_tool for raw metric data instead.
 </when_to_use>
 
 Parameters
@@ -36,6 +39,14 @@ loss_key : str, optional
     Name of the loss metric. Auto-detected if not provided.
 val_loss_key : str, optional
     Name of the validation loss metric. Auto-detected if not provided.
+config_keys : list of str, optional
+    Projected config context to include. When omitted, a bounded indexed set is selected.
+summary_keys : list of str, optional
+    Summary/history metrics to analyze. When omitted, bounded numeric fields are selected.
+x_axis : str, optional
+    X-axis used for history sampling. Defaults to "_step".
+samples : int, optional
+    Number of sampled history rows, capped by the active workload profile.
 
 Returns
 -------
@@ -44,6 +55,7 @@ overfit_signal, nan_warnings, tail_stats, and recommendations.
 """
 
 DIAGNOSIS_SAMPLES = min(500, MCP_MAX_HISTORY_SAMPLES)
+_DIAGNOSIS_CONFIG_LIMIT = 10
 
 
 def _auto_detect_key(keys: List[str], patterns: List[str]) -> Optional[str]:
@@ -106,39 +118,158 @@ def _detect_overfit(train_vals: List[float], val_vals: List[float]) -> Dict[str,
     }
 
 
+def _strip_field_prefix(path: str, prefixes: tuple[str, ...]) -> str | None:
+    for prefix in prefixes:
+        if path.startswith(prefix):
+            return path[len(prefix) :]
+    return None
+
+
+def _indexed_diagnosis_keys(api: Any, entity_name: str, project_name: str) -> tuple[list[str], list[str], bool]:
+    fields = fetch_project_fields(
+        api,
+        entity=entity_name,
+        project=project_name,
+        limit=max(200, MCP_MAX_HISTORY_KEYS * 20),
+    )
+    configs: list[str] = []
+    metrics: list[str] = []
+    numeric_types = {"number", "integer", "float", "int", "number[]"}
+    for field in fields.items:
+        path = field["path"]
+        config_key = _strip_field_prefix(path, ("config.", "config/"))
+        if config_key and not config_key.startswith(("_", "wandb")):
+            configs.append(config_key)
+            continue
+        summary_key = _strip_field_prefix(
+            path,
+            ("summary.", "summary/", "summary_metrics.", "summary_metrics/", "summaryMetrics."),
+        )
+        if (
+            summary_key
+            and not summary_key.startswith(("_", "wandb/"))
+            and field.get("type", "").lower() in numeric_types
+        ):
+            metrics.append(summary_key)
+    priority = ("loss", "accuracy", "score", "precision", "recall", "f1", "auc", "grad")
+    metrics.sort(key=lambda key: (not any(token in key.lower() for token in priority), key))
+    return (
+        list(dict.fromkeys(configs))[:_DIAGNOSIS_CONFIG_LIMIT],
+        list(dict.fromkeys(metrics))[:MCP_MAX_HISTORY_KEYS],
+        not fields.has_more,
+    )
+
+
+def _validate_optional_keys(name: str, value: Optional[List[str]]) -> None:
+    if value is not None and (
+        not isinstance(value, list)
+        or len(value) > MCP_MAX_HISTORY_KEYS
+        or not all(isinstance(key, str) and key.strip() for key in value)
+    ):
+        raise ValueError(f"{name} must contain at most {MCP_MAX_HISTORY_KEYS} non-empty strings")
+
+
 def diagnose_run(
     entity_name: str,
     project_name: str,
     run_id: str,
     loss_key: Optional[str] = None,
     val_loss_key: Optional[str] = None,
+    config_keys: Optional[List[str]] = None,
+    summary_keys: Optional[List[str]] = None,
+    x_axis: str = "_step",
+    samples: int = DIAGNOSIS_SAMPLES,
 ) -> str:
     """Diagnose a W&B run's training health."""
+    for name, value in (("config_keys", config_keys), ("summary_keys", summary_keys)):
+        _validate_optional_keys(name, value)
+    if not isinstance(x_axis, str) or not x_axis.strip():
+        raise ValueError("x_axis must be a non-empty string")
+    if isinstance(samples, bool) or not isinstance(samples, int) or samples < 1:
+        raise ValueError("samples must be a positive integer")
+    effective_samples = min(samples, MCP_MAX_HISTORY_SAMPLES)
     api = WandBApiManager.get_api()
     with track_tool_execution(
         "diagnose_run",
         None,
-        {"entity_name": entity_name, "project_name": project_name, "run_id": run_id},
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "run_id": run_id,
+            "config_key_count": len(config_keys or []),
+            "summary_key_count": len(summary_keys or []),
+            "x_axis_is_custom": x_axis != "_step",
+            "samples": effective_samples,
+        },
     ) as ctx:
+        selected_config = list(config_keys or [])
+        selected_summary = list(summary_keys or [])
+        selection_source = "explicit"
+        field_index_exhaustive: bool | None = None
+        compatibility_caveat: str | None = None
         try:
+            if config_keys is None or summary_keys is None:
+                auto_config, auto_summary, field_index_exhaustive = _indexed_diagnosis_keys(
+                    api, entity_name, project_name
+                )
+                if config_keys is None:
+                    selected_config = auto_config
+                if summary_keys is None:
+                    selected_summary = auto_summary
+                selection_source = "project_field_index"
+            projected = fetch_projected_run(
+                api,
+                entity=entity_name,
+                project=project_name,
+                run_id=run_id,
+                config_keys=selected_config,
+                summary_keys=selected_summary,
+            )
+            if projected is None:
+                raise ValueError(f"Run {run_id} not found")
             run = api.run(f"{entity_name}/{project_name}/{run_id}")
         except Exception as e:
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
-
-        summary = dict(run.summary) if getattr(run, "summary", None) else {}
-        summary_keys = sorted(
-            key for key, value in summary.items() if not key.startswith("_") and isinstance(value, (int, float))
-        )[:MCP_MAX_HISTORY_KEYS]
-
-        if loss_key is None:
-            loss_key = _auto_detect_key(summary_keys, ["train_loss", "train/loss", "loss"])
-        if val_loss_key is None:
-            val_loss_key = _auto_detect_key(
-                summary_keys, ["val_loss", "val/loss", "eval_loss", "eval/loss", "validation_loss"]
+            if isinstance(e, ToolDeadlineExceeded):
+                raise
+            try:
+                run = api.run(f"{entity_name}/{project_name}/{run_id}")
+            except Exception as run_error:
+                ctx.mark_error(f"{type(run_error).__name__}: {run_error}")
+                return json.dumps({"error": "run_not_found", "message": str(run_error)[:500]})
+            summary = dict(getattr(run, "summary", {}) or {})
+            config = dict(getattr(run, "config", {}) or {})
+            if config_keys is None:
+                selected_config = sorted(key for key in config if not key.startswith(("_", "wandb")))[
+                    :_DIAGNOSIS_CONFIG_LIMIT
+                ]
+            if summary_keys is None:
+                selected_summary = sorted(
+                    key
+                    for key, value in summary.items()
+                    if not key.startswith(("_", "wandb/")) and isinstance(value, (int, float))
+                )[:MCP_MAX_HISTORY_KEYS]
+            projected = {
+                "id": run_id,
+                "display_name": getattr(run, "name", run_id),
+                "state": getattr(run, "state", "unknown"),
+                "config": {key: config.get(key) for key in selected_config},
+                "summary": {key: summary.get(key) for key in selected_summary},
+            }
+            selection_source = "bounded_sdk_compatibility"
+            compatibility_caveat = (
+                f"{type(e).__name__}: indexed/projected fields unavailable; "
+                "used the one required SDK run and retained only the disclosed bounded keys"
             )
 
-        requested_keys = list(dict.fromkeys([key for key in (loss_key, val_loss_key, *summary_keys) if key]))[
+        if loss_key is None:
+            loss_key = _auto_detect_key(selected_summary, ["train_loss", "train/loss", "loss"])
+        if val_loss_key is None:
+            val_loss_key = _auto_detect_key(
+                selected_summary,
+                ["val_loss", "val/loss", "validation/loss", "eval_loss", "eval/loss", "validation_loss"],
+            )
+
+        requested_keys = list(dict.fromkeys([key for key in (loss_key, val_loss_key, *selected_summary) if key]))[
             :MCP_MAX_HISTORY_KEYS
         ]
         if not requested_keys:
@@ -148,15 +279,22 @@ def diagnose_run(
                     "message": "No bounded numeric metric set was available; provide loss_key and val_loss_key.",
                     "run_id": run_id,
                     "run_name": getattr(run, "name", run_id),
+                    "selection": {
+                        "source": selection_source,
+                        "config_keys": selected_config,
+                        "summary_keys": selected_summary,
+                        "field_index_exhaustive": field_index_exhaustive,
+                    },
                 }
             )
 
         try:
             history_rows = list(
                 run.history(
-                    samples=DIAGNOSIS_SAMPLES,
+                    samples=effective_samples,
                     keys=requested_keys,
                     pandas=False,
+                    x_axis=x_axis,
                 )
             )
         except Exception as e:
@@ -170,6 +308,19 @@ def diagnose_run(
                     "message": "Run has no logged history steps.",
                     "run_id": run_id,
                     "run_name": getattr(run, "name", run_id),
+                    "selection": {
+                        "source": selection_source,
+                        "config_keys": selected_config,
+                        "summary_keys": selected_summary,
+                        "field_index_exhaustive": field_index_exhaustive,
+                    },
+                    "coverage": {
+                        "sampled": True,
+                        "requested_samples": samples,
+                        "effective_samples": effective_samples,
+                        "returned_rows": 0,
+                        "x_axis": x_axis,
+                    },
                 }
             )
 
@@ -267,6 +418,26 @@ def diagnose_run(
                 "detected_keys": {"loss": loss_key, "val_loss": val_loss_key},
                 "total_history_rows": len(history_rows),
                 "recommendations": recommendations,
+                "projected_context": {
+                    "config": projected.get("config") or {},
+                    "summary": projected.get("summary") or {},
+                },
+                "selection": {
+                    "source": selection_source,
+                    "config_keys": selected_config,
+                    "summary_keys": selected_summary,
+                    "field_index_exhaustive": field_index_exhaustive,
+                },
+                "coverage": {
+                    "sampled": True,
+                    "requested_samples": samples,
+                    "effective_samples": effective_samples,
+                    "returned_rows": len(history_rows),
+                    "x_axis": x_axis,
+                    "project_exhaustive": False,
+                    "conclusions_apply_to_sample": True,
+                },
+                "compatibility_caveat": compatibility_caveat,
             },
             default=str,
         )

--- a/src/wandb_mcp_server/mcp_tools/run_history.py
+++ b/src/wandb_mcp_server/mcp_tools/run_history.py
@@ -7,8 +7,10 @@ history() (sampled) as last resort.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
-from typing import Any, Dict, List, Optional
+import math
+from typing import Any, Dict, List, Literal, Optional
 
 import wandb
 
@@ -19,19 +21,22 @@ from wandb_mcp_server.config import (
     MCP_MAX_HISTORY_KEYS,
     MCP_MAX_HISTORY_RANGE_STEPS,
     MCP_MAX_HISTORY_SAMPLES,
+    MCP_WORKLOAD_PROFILE,
     MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
     WANDB_API_BASE_URL,
 )
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_selective_reads import SelectiveReadUnavailable, fetch_metric_value_steps
 
 logger = get_rich_logger(__name__)
 
-GET_RUN_HISTORY_TOOL_DESCRIPTION = """Retrieve sampled time-series metric data from a W&B run.
+GET_RUN_HISTORY_TOOL_DESCRIPTION = """Retrieve bounded time-series metric data from a W&B run.
 
-Returns step-indexed rows of logged metrics (loss, accuracy, learning_rate, etc.)
-for a specific run. The data is sampled to `samples` evenly-spaced points so even
-runs with millions of steps return a manageable response.
+Use SDK sampling for overviews, bounded scans for internal-step ranges, and an
+exact custom-axis lookup for a logged x-axis value. Every response states the
+retrieval method, whether values are sampled or exact, rows scanned, coverage,
+and any profile or response-budget truncation.
 
 <when_to_use>
 Call this tool when the user asks about training curves, metric trends over time,
@@ -65,6 +70,17 @@ min_step : int, optional
     Minimum step to include. Defaults to None (start from beginning).
 max_step : int, optional
     Maximum step to include. Defaults to None (include all steps).
+x_axis : str, optional
+    History x-axis. Defaults to "_step". Set this to a logged monotonic metric
+    such as "validation/step" for custom-axis sampling or target lookup.
+target_x : float, optional
+    Retrieve the row where x_axis logged this exact value. If no exact value was
+    logged, returns target_not_logged.
+tolerance : float, optional
+    When target_x was not logged exactly, permit a bounded nearest-value
+    refinement within this absolute tolerance.
+stream : "default" or "system", optional
+    Select normal run history or system metrics. Defaults to "default".
 
 Returns
 -------
@@ -75,14 +91,29 @@ JSON with:
   - total_steps: last logged step number
   - sampled_points: number of rows returned
   - keys_returned: list of metric keys in the response
+  - retrieval_method, exact, sampled, rows_scanned, coverage, truncation
 
 Examples
 --------
 >>> get_run_history_tool("my-team", "my-project", "gtng2y4l", keys=["loss", "val_loss"])
->>> get_run_history_tool("my-team", "my-project", "h0fm5qp5", samples=100)
+>>> get_run_history_tool(
+...     "my-team", "my-project", "h0fm5qp5",
+...     keys=["validation/loss"], x_axis="validation/step", target_x=1000,
+... )
 """
 
-MAX_HISTORY_ROWS = 2000
+MAX_HISTORY_ROWS = MCP_MAX_HISTORY_SAMPLES
+_EXACT_EPSILON = 1e-9
+
+
+@dataclass(frozen=True)
+class _HistoryFetch:
+    rows: list[dict[str, Any]]
+    method: str
+    sampled: bool
+    exact: bool
+    rows_scanned: int
+    compatibility_caveat: str | None = None
 
 
 def get_run_history(
@@ -93,26 +124,54 @@ def get_run_history(
     samples: int = 500,
     min_step: Optional[int] = None,
     max_step: Optional[int] = None,
+    x_axis: str = "_step",
+    target_x: float | None = None,
+    tolerance: float | None = None,
+    stream: Literal["default", "system"] = "default",
 ) -> str:
-    """Fetch sampled metric history for a W&B run."""
+    """Fetch bounded metric history for a W&B run."""
 
     if isinstance(samples, bool) or not isinstance(samples, int) or samples < 1:
         raise ValueError("samples must be a positive integer")
+    if not isinstance(x_axis, str) or not x_axis.strip():
+        raise ValueError("x_axis must be a non-empty string")
+    if stream not in {"default", "system"}:
+        raise ValueError("stream must be 'default' or 'system'")
+    if target_x is not None and (
+        isinstance(target_x, bool) or not isinstance(target_x, (int, float)) or not math.isfinite(float(target_x))
+    ):
+        raise ValueError("target_x must be a finite number")
+    if tolerance is not None and (
+        target_x is None
+        or isinstance(tolerance, bool)
+        or not isinstance(tolerance, (int, float))
+        or not math.isfinite(float(tolerance))
+        or tolerance < 0
+    ):
+        raise ValueError("tolerance must be a finite non-negative number and requires target_x")
+    if target_x is not None and (min_step is not None or max_step is not None):
+        raise ValueError("target_x cannot be combined with min_step or max_step")
+    if stream == "system" and target_x is not None:
+        raise ValueError("target_x is supported only for the default history stream")
+    if stream == "system" and (min_step is not None or max_step is not None):
+        raise ValueError("step-range scans are supported only for the default history stream")
     if keys is not None and (
         not isinstance(keys, list)
         or not all(isinstance(key, str) and key.strip() for key in keys)
         or len(keys) > MCP_MAX_HISTORY_KEYS
     ):
         raise ValueError(f"keys must contain at most {MCP_MAX_HISTORY_KEYS} non-empty strings")
-    if MCP_HOSTED_MODE and not keys:
-        raise ValueError("Hosted MCP requires explicit history keys (1-20 metrics).")
+    if (MCP_WORKLOAD_PROFILE == "shared" or MCP_HOSTED_MODE) and not keys:
+        raise ValueError(
+            f"The shared workload profile requires explicit history keys (1-{MCP_MAX_HISTORY_KEYS} metrics)."
+        )
     if min_step is not None and max_step is not None:
         if max_step < min_step:
             raise ValueError("max_step must be greater than or equal to min_step")
         if max_step - min_step + 1 > MCP_MAX_HISTORY_RANGE_STEPS:
             raise ValueError(f"history step range cannot exceed {MCP_MAX_HISTORY_RANGE_STEPS} steps")
-    elif MCP_HOSTED_MODE and (min_step is not None or max_step is not None):
-        raise ValueError("Hosted MCP step-range queries require both min_step and max_step")
+    elif (MCP_WORKLOAD_PROFILE == "shared" or MCP_HOSTED_MODE) and (min_step is not None or max_step is not None):
+        raise ValueError("The shared workload profile requires both min_step and max_step for range scans")
 
     with track_tool_execution(
         "get_run_history",
@@ -123,6 +182,10 @@ def get_run_history(
             "run_id": run_id,
             "keys": keys,
             "samples": samples,
+            "stream": stream,
+            "x_axis_is_custom": x_axis != "_step",
+            "has_target_x": target_x is not None,
+            "has_tolerance": tolerance is not None,
         },
     ):
         api_key = WandBApiManager.get_api_key()
@@ -142,24 +205,73 @@ def get_run_history(
         except Exception as e:
             raise ValueError(f"Failed to access run {entity_name}/{project_name}/{run_id}: {type(e).__name__}")
 
-        hosted_limit_applied = MCP_HOSTED_MODE and samples > MCP_MAX_HISTORY_SAMPLES
-        clamped_samples = min(
-            samples, MAX_HISTORY_ROWS, MCP_MAX_HISTORY_SAMPLES if MCP_HOSTED_MODE else MAX_HISTORY_ROWS
-        )
+        profile_limit_applied = samples > MCP_MAX_HISTORY_SAMPLES
+        clamped_samples = min(samples, MCP_MAX_HISTORY_SAMPLES)
 
         try:
-            if min_step is not None or max_step is not None:
-                rows = _fetch_step_range(run, clamped_samples, keys, min_step, max_step)
+            if target_x is not None:
+                fetched = _fetch_target_x(
+                    wandb_api,
+                    run,
+                    entity_name=entity_name,
+                    project_name=project_name,
+                    run_id=run_id,
+                    keys=keys,
+                    x_axis=x_axis,
+                    target_x=float(target_x),
+                    tolerance=float(tolerance) if tolerance is not None else None,
+                )
+                if not fetched.rows:
+                    return json.dumps(
+                        {
+                            "error": "target_not_logged",
+                            "message": f"No logged {x_axis!r} value matched target {target_x}.",
+                            "run_id": run_id,
+                            "x_axis": x_axis,
+                            "target_x": target_x,
+                            "tolerance": tolerance,
+                            "retrieval_method": fetched.method,
+                            "exact": False,
+                            "sampled": False,
+                            "rows_scanned": fetched.rows_scanned,
+                            "compatibility_caveat": fetched.compatibility_caveat,
+                        }
+                    )
+            elif min_step is not None or max_step is not None:
+                rows, rows_scanned, used_sampled_fallback = _fetch_step_range_with_metadata(
+                    run,
+                    clamped_samples,
+                    keys,
+                    min_step,
+                    max_step,
+                    stream=stream,
+                )
+                fetched = _HistoryFetch(
+                    rows=rows,
+                    method="sdk_sample_fallback" if used_sampled_fallback else "sdk_bounded_scan",
+                    sampled=used_sampled_fallback or rows_scanned > len(rows),
+                    exact=False,
+                    rows_scanned=rows_scanned,
+                )
             else:
                 history_kwargs: Dict[str, Any] = {"samples": clamped_samples, "pandas": False}
                 if keys:
                     history_kwargs["keys"] = keys
+                history_kwargs["x_axis"] = x_axis
+                history_kwargs["stream"] = stream
                 rows = list(run.history(**history_kwargs))
+                fetched = _HistoryFetch(
+                    rows=rows,
+                    method="sdk_sample",
+                    sampled=True,
+                    exact=False,
+                    rows_scanned=len(rows),
+                )
         except Exception as e:
             raise ValueError(f"Failed to fetch history for run {run_id}: {e}")
 
         clean_rows = []
-        for row in rows:
+        for row in fetched.rows:
             clean_row = {}
             for k, v in row.items():
                 if k.startswith("_") and k not in ("_step", "_timestamp", "_runtime"):
@@ -183,6 +295,11 @@ def get_run_history(
         clean_rows = _enforce_row_budget(clean_rows, budget_chars)
         truncated = len(clean_rows) < original_count
 
+        x_values = [
+            float(row[x_axis])
+            for row in clean_rows
+            if isinstance(row.get(x_axis), (int, float)) and math.isfinite(float(row[x_axis]))
+        ]
         result_dict: Dict[str, Any] = {
             "rows": clean_rows,
             "run_id": run_id,
@@ -190,17 +307,38 @@ def get_run_history(
             "total_steps": total_steps,
             "sampled_points": len(clean_rows),
             "keys_returned": sorted(keys_in_response),
+            "retrieval_method": fetched.method,
+            "exact": fetched.exact,
+            "sampled": fetched.sampled,
+            "requested_samples": samples,
+            "effective_samples": clamped_samples,
+            "rows_scanned": fetched.rows_scanned,
+            "stream": stream,
+            "x_axis": x_axis,
+            "coverage": {
+                "first_x": x_values[0] if x_values else None,
+                "last_x": x_values[-1] if x_values else None,
+                "requested_min_step": min_step,
+                "requested_max_step": max_step,
+                "target_x": target_x,
+                "tolerance": tolerance,
+            },
+            "truncated": truncated or profile_limit_applied,
         }
         if truncated:
             result_dict["truncation_note"] = (
                 f"Downsampled from {original_count} to {len(clean_rows)} rows to fit token budget. "
                 "Use keys= to select fewer metrics or reduce samples."
             )
-        if hosted_limit_applied:
-            result_dict["hosted_limit_note"] = (
-                f"Hosted MCP limits history responses to {MCP_MAX_HISTORY_SAMPLES} sampled rows. "
-                "Reduce samples or use keys= to select fewer metrics."
+        if profile_limit_applied:
+            result_dict["profile_limit_note"] = (
+                f"The {MCP_WORKLOAD_PROFILE} workload profile limits history responses to "
+                f"{MCP_MAX_HISTORY_SAMPLES} rows."
             )
+            if MCP_HOSTED_MODE:
+                result_dict["hosted_limit_note"] = result_dict["profile_limit_note"]
+        if fetched.compatibility_caveat:
+            result_dict["compatibility_caveat"] = fetched.compatibility_caveat
         return json.dumps(result_dict)
 
 
@@ -211,6 +349,57 @@ def _fetch_step_range(
     min_step: Optional[int],
     max_step: Optional[int],
 ) -> List[Dict[str, Any]]:
+    """Compatibility wrapper returning only rows from a bounded step scan."""
+    rows, _, _ = _fetch_step_range_with_metadata(
+        run,
+        clamped_samples,
+        keys,
+        min_step,
+        max_step,
+        stream="default",
+    )
+    return rows
+
+
+def _scan_history_rows(
+    run: Any,
+    *,
+    keys: list[str] | None,
+    min_step: int | None,
+    max_step: int | None,
+    scan_limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    scan_kwargs: Dict[str, Any] = {}
+    if keys:
+        scan_kwargs["keys"] = keys
+    if min_step is not None:
+        scan_kwargs["min_step"] = min_step
+    if max_step is not None:
+        # Public SDK scan_history treats max_step as exclusive; the MCP
+        # interface documents max_step as inclusive.
+        scan_kwargs["max_step"] = max_step + 1
+    scan_kwargs["page_size"] = min(1000, max(1, scan_limit))
+    scanned_rows: list[dict[str, Any]] = []
+    rows_scanned = 0
+    for index, row in enumerate(run.scan_history(**scan_kwargs)):
+        if index >= scan_limit:
+            break
+        if index % 100 == 0:
+            raise_if_tool_deadline_exceeded()
+        rows_scanned += 1
+        scanned_rows.append(row)
+    return scanned_rows, rows_scanned
+
+
+def _fetch_step_range_with_metadata(
+    run: Any,
+    clamped_samples: int,
+    keys: Optional[List[str]],
+    min_step: Optional[int],
+    max_step: Optional[int],
+    *,
+    stream: Literal["default", "system"],
+) -> tuple[List[Dict[str, Any]], int, bool]:
     """Fetch history rows for a step range using a tiered strategy.
 
     Strategy order:
@@ -218,28 +407,19 @@ def _fetch_step_range(
          fails silently when lastHistoryStep == -1)
       2. history() sampled fallback (always works, ignores step bounds)
     """
-    # Strategy 1: scan_history
-    scan_kwargs: Dict[str, Any] = {}
-    if keys:
-        scan_kwargs["keys"] = keys
-    if min_step is not None:
-        scan_kwargs["min_step"] = min_step
-    if max_step is not None:
-        scan_kwargs["max_step"] = max_step
     scan_limit = MCP_MAX_HISTORY_RANGE_STEPS
     if min_step is not None and max_step is not None:
         scan_limit = min(scan_limit, max_step - min_step + 1)
-    scan_kwargs["page_size"] = min(1000, scan_limit)
-    scanned_rows: List[Dict[str, Any]] = []
-    for index, row in enumerate(run.scan_history(**scan_kwargs)):
-        if index >= scan_limit:
-            break
-        if index % 100 == 0:
-            raise_if_tool_deadline_exceeded()
-        scanned_rows.append(row)
+    scanned_rows, rows_scanned = _scan_history_rows(
+        run,
+        keys=keys,
+        min_step=min_step,
+        max_step=max_step,
+        scan_limit=scan_limit,
+    )
     rows = _evenly_sample(scanned_rows, clamped_samples)
     if rows:
-        return rows
+        return rows, rows_scanned, False
 
     # Strategy 2: history() sampled fallback (ignores step bounds but always works)
     last_step = getattr(run, "lastHistoryStep", 0) or 0
@@ -250,12 +430,114 @@ def _fetch_step_range(
             last_step,
             clamped_samples,
         )
-        history_kwargs: Dict[str, Any] = {"samples": clamped_samples, "pandas": False}
+        history_kwargs: Dict[str, Any] = {"samples": clamped_samples, "pandas": False, "stream": stream}
         if keys:
             history_kwargs["keys"] = keys
-        return list(run.history(**history_kwargs))
+        fallback_rows = list(run.history(**history_kwargs))
+        return fallback_rows, len(fallback_rows), True
 
-    return rows
+    return rows, rows_scanned, False
+
+
+def _numeric_x(row: Dict[str, Any], x_axis: str) -> float | None:
+    value = row.get(x_axis)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    return numeric if math.isfinite(numeric) else None
+
+
+def _select_target_row(
+    rows: list[dict[str, Any]],
+    *,
+    x_axis: str,
+    target_x: float,
+    tolerance: float | None,
+) -> tuple[list[dict[str, Any]], bool]:
+    candidates = [(abs(value - target_x), row) for row in rows if (value := _numeric_x(row, x_axis)) is not None]
+    exact = [row for distance, row in candidates if distance <= _EXACT_EPSILON]
+    if exact:
+        return [exact[0]], True
+    if tolerance is None or not candidates:
+        return [], False
+    distance, nearest = min(candidates, key=lambda candidate: candidate[0])
+    return ([nearest], False) if distance <= tolerance else ([], False)
+
+
+def _fetch_target_x(
+    api: Any,
+    run: Any,
+    *,
+    entity_name: str,
+    project_name: str,
+    run_id: str,
+    keys: list[str] | None,
+    x_axis: str,
+    target_x: float,
+    tolerance: float | None,
+) -> _HistoryFetch:
+    requested_keys = list(dict.fromkeys([x_axis, *(keys or [])]))
+    if x_axis == "_step":
+        if not target_x.is_integer():
+            return _HistoryFetch([], "sdk_exact_step_scan", False, False, 0)
+        target_step = int(target_x)
+        rows, rows_scanned = _scan_history_rows(
+            run,
+            keys=requested_keys,
+            min_step=target_step,
+            max_step=target_step,
+            scan_limit=1,
+        )
+        selected, exact = _select_target_row(rows, x_axis=x_axis, target_x=target_x, tolerance=tolerance)
+        return _HistoryFetch(selected, "sdk_exact_step_scan", False, exact, rows_scanned)
+
+    try:
+        candidate_steps = fetch_metric_value_steps(
+            api,
+            entity=entity_name,
+            project=project_name,
+            run_id=run_id,
+            metric=x_axis,
+            values=[target_x],
+        )
+    except SelectiveReadUnavailable as exc:
+        rows, rows_scanned = _scan_history_rows(
+            run,
+            keys=requested_keys,
+            min_step=None,
+            max_step=None,
+            scan_limit=MCP_MAX_HISTORY_RANGE_STEPS,
+        )
+        selected, exact = _select_target_row(rows, x_axis=x_axis, target_x=target_x, tolerance=tolerance)
+        return _HistoryFetch(
+            selected,
+            "sdk_bounded_compatibility_scan",
+            False,
+            exact,
+            rows_scanned,
+            f"{exc}; searched at most {MCP_MAX_HISTORY_RANGE_STEPS} rows without public-URL retry",
+        )
+
+    candidate_step = candidate_steps[0] if candidate_steps else None
+    if candidate_step is None:
+        return _HistoryFetch([], "steps_for_metric_values", False, False, 0)
+
+    refinement_radius = 2 if tolerance is not None else 0
+    rows, rows_scanned = _scan_history_rows(
+        run,
+        keys=requested_keys,
+        min_step=max(0, candidate_step - refinement_radius),
+        max_step=candidate_step + refinement_radius,
+        scan_limit=2 * refinement_radius + 1,
+    )
+    selected, exact = _select_target_row(rows, x_axis=x_axis, target_x=target_x, tolerance=tolerance)
+    return _HistoryFetch(
+        selected,
+        "steps_for_metric_values",
+        False,
+        exact,
+        rows_scanned,
+    )
 
 
 def _evenly_sample(rows: List[Dict[str, Any]], max_rows: int) -> List[Dict[str, Any]]:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -987,6 +987,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
         samples: int = 500,
         min_step: Optional[int] = None,
         max_step: Optional[int] = None,
+        x_axis: str = "_step",
+        target_x: Optional[float] = None,
+        tolerance: Optional[float] = None,
+        stream: Literal["default", "system"] = "default",
     ) -> str:
         """Retrieve sampled time-series metric data from a W&B run."""
         try:
@@ -998,6 +1002,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 samples=samples,
                 min_step=min_step,
                 max_step=max_step,
+                x_axis=x_axis,
+                target_x=target_x,
+                tolerance=tolerance,
+                stream=stream,
             )
         except Exception as e:
             logger.error(f"Error in get_run_history_tool: {e}")
@@ -1104,6 +1112,9 @@ def register_tools(mcp_instance: FastMCP) -> None:
         include_history_overlap: bool = False,
         history_keys: Optional[List[str]] = None,
         history_samples: int = 50,
+        config_keys: Optional[List[str]] = None,
+        summary_keys: Optional[List[str]] = None,
+        x_axis: str = "_step",
     ) -> str:
         """Compare two W&B runs side-by-side."""
         return compare_runs(
@@ -1114,6 +1125,9 @@ def register_tools(mcp_instance: FastMCP) -> None:
             include_history_overlap=include_history_overlap,
             history_keys=history_keys,
             history_samples=history_samples,
+            config_keys=config_keys,
+            summary_keys=summary_keys,
+            x_axis=x_axis,
         )
 
     from wandb_mcp_server.mcp_tools.summarize_evaluation import (
@@ -1150,6 +1164,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
         run_id: str,
         loss_key: Optional[str] = None,
         val_loss_key: Optional[str] = None,
+        config_keys: Optional[List[str]] = None,
+        summary_keys: Optional[List[str]] = None,
+        x_axis: str = "_step",
+        samples: int = 500,
     ) -> str:
         """Diagnose a W&B run's training health."""
         return diagnose_run(
@@ -1158,6 +1176,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
             run_id=run_id,
             loss_key=loss_key,
             val_loss_key=val_loss_key,
+            config_keys=config_keys,
+            summary_keys=summary_keys,
+            x_axis=x_axis,
+            samples=samples,
         )
 
     from wandb_mcp_server.mcp_tools.probe_project import (

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -165,6 +165,22 @@ query MCPArtifactInventory($entity: String!, $project: String!, $first: Int!) {
 }
 """
 
+METRIC_VALUE_STEPS_QUERY = """
+query MCPMetricValueSteps(
+  $entity: String!
+  $project: String!
+  $run: String!
+  $metric: String!
+  $values: [Float!]!
+) {
+  project(name: $project, entityName: $entity) {
+    run(name: $run) {
+      stepsForMetricValues(metric: $metric, values: $values)
+    }
+  }
+}
+"""
+
 
 @dataclass(frozen=True)
 class ProjectedRunPage:
@@ -489,8 +505,46 @@ def fetch_artifact_inventory(
     }
 
 
+def fetch_metric_value_steps(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    run_id: str,
+    metric: str,
+    values: Sequence[float],
+) -> list[int | None]:
+    """Resolve monotonic metric values to candidate internal history steps.
+
+    The backend resolver returns candidate steps rather than proof that a target
+    value was logged. Callers must read and compare the returned history rows.
+    """
+    try:
+        data = execute_graphql(
+            api,
+            METRIC_VALUE_STEPS_QUERY,
+            {
+                "entity": entity,
+                "project": project,
+                "run": run_id,
+                "metric": metric,
+                "values": [float(value) for value in values],
+            },
+        )
+    except Exception as exc:
+        raise SelectiveReadUnavailable(f"metric value step lookup unavailable: {type(exc).__name__}") from exc
+    node = _project_payload(data).get("run")
+    if not isinstance(node, Mapping):
+        raise ValueError("W&B run was not found or is not accessible")
+    steps = node.get("stepsForMetricValues")
+    if not isinstance(steps, list):
+        raise SelectiveReadUnavailable("metric value step lookup returned no step list")
+    return [int(step) if isinstance(step, (int, float)) else None for step in steps]
+
+
 __all__ = [
     "ARTIFACT_INVENTORY_QUERY",
+    "METRIC_VALUE_STEPS_QUERY",
     "PROJECTED_RUNS_QUERY",
     "PROJECTED_RUN_QUERY",
     "PROJECT_COUNTS_QUERY",
@@ -499,6 +553,7 @@ __all__ = [
     "ProjectedRunPage",
     "SelectiveReadUnavailable",
     "fetch_artifact_inventory",
+    "fetch_metric_value_steps",
     "fetch_project_counts",
     "fetch_project_fields",
     "fetch_projected_run",

--- a/tests/test_admission_control.py
+++ b/tests/test_admission_control.py
@@ -126,6 +126,18 @@ async def test_cancelled_waiter_does_not_leak_queue_or_capacity() -> None:
 def test_tool_costs_are_stable_and_unknown_is_heavy() -> None:
     assert tool_cost("list_entities_tool") == ("light", 1)
     assert tool_cost("get_run_history_tool") == ("expensive", 2)
+    assert tool_cost("get_run_history_tool", {"target_x": 100}) == ("heavy", 4)
+    assert tool_cost("get_run_history_tool", {"min_step": 0, "max_step": 100}) == ("heavy", 4)
+    assert tool_cost("query_wandb_tool", {"resource": "runs", "response_mode": "count"}) == ("light", 1)
+    assert tool_cost(
+        "query_wandb_tool",
+        {"resource": "runs", "summary_keys": ["loss"]},
+    ) == ("expensive", 2)
+    assert tool_cost(
+        "query_wandb_tool",
+        {"resource": "runs", "include": ["summary"]},
+    ) == ("heavy", 4)
+    assert tool_cost("probe_project_tool") == ("heavy", 4)
     assert tool_cost("query_wandb_graphql_tool") == ("heavy", 4)
     assert tool_cost("future_unclassified_tool") == ("heavy", 4)
 

--- a/tests/test_compare_runs.py
+++ b/tests/test_compare_runs.py
@@ -193,3 +193,45 @@ class TestCompareRuns:
         assert result["run_a"]["name"] == "alpha"
         assert result["run_b"]["id"] == "id-b"
         assert result["run_b"]["name"] == "beta"
+
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.fetch_projected_run")
+    @patch(
+        "wandb_mcp_server.mcp_tools.compare_runs._indexed_comparison_keys",
+        return_value=(["learning_rate"], ["validation/loss"], False),
+    )
+    @patch("wandb_mcp_server.mcp_tools.compare_runs.WandBApiManager")
+    def test_indexed_projection_avoids_full_sdk_runs_and_discloses_scope(
+        self,
+        mock_api_mgr,
+        _mock_keys,
+        mock_projected_run,
+    ):
+        api = mock_api_mgr.get_api.return_value
+        mock_projected_run.side_effect = [
+            {
+                "id": "a",
+                "display_name": "A",
+                "state": "finished",
+                "config": {"learning_rate": 0.01},
+                "summary": {"validation/loss": 0.4},
+            },
+            {
+                "id": "b",
+                "display_name": "B",
+                "state": "finished",
+                "config": {"learning_rate": 0.001},
+                "summary": {"validation/loss": 0.2},
+            },
+        ]
+
+        result = json.loads(compare_runs("ent", "proj", "a", "b"))
+
+        api.run.assert_not_called()
+        assert result["selection"] == {
+            "source": "project_field_index",
+            "config_keys": ["learning_rate"],
+            "summary_keys": ["validation/loss"],
+            "field_index_exhaustive": False,
+        }
+        assert result["coverage"]["full_run_fields_exhaustive"] is False
+        assert result["summary_diff"]["changed"]["validation/loss"]["delta"] == -0.2

--- a/tests/test_diagnose_run.py
+++ b/tests/test_diagnose_run.py
@@ -182,3 +182,49 @@ class TestDiagnoseRun:
 
         assert result["diagnosis"] == "diverging"
         assert any("learning rate" in r for r in result["recommendations"])
+
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.fetch_projected_run")
+    @patch(
+        "wandb_mcp_server.mcp_tools.diagnose_run._indexed_diagnosis_keys",
+        return_value=(["learning_rate"], ["train/loss", "validation/loss"], False),
+    )
+    @patch("wandb_mcp_server.mcp_tools.diagnose_run.WandBApiManager")
+    def test_uses_indexed_bounded_keys_and_discloses_sampling(
+        self,
+        mock_api_mgr,
+        _mock_keys,
+        mock_projected,
+    ):
+        rows = [
+            {
+                "epoch": float(index),
+                "train/loss": 10.0 / (index + 1),
+                "validation/loss": 11.0 / (index + 1),
+            }
+            for index in range(20)
+        ]
+        run = self._make_mock_run(history_rows=rows)
+        mock_api_mgr.get_api.return_value.run.return_value = run
+        mock_projected.return_value = {
+            "id": "r1",
+            "display_name": "test-run",
+            "state": "finished",
+            "config": {"learning_rate": 0.01},
+            "summary": {"train/loss": rows[-1]["train/loss"]},
+        }
+
+        result = json.loads(diagnose_run("ent", "proj", "r1", x_axis="epoch", samples=20))
+
+        assert result["selection"]["source"] == "project_field_index"
+        assert result["selection"]["config_keys"] == ["learning_rate"]
+        assert result["coverage"] == {
+            "sampled": True,
+            "requested_samples": 20,
+            "effective_samples": 20,
+            "returned_rows": 20,
+            "x_axis": "epoch",
+            "project_exhaustive": False,
+            "conclusions_apply_to_sample": True,
+        }
+        assert run.history.call_args.kwargs["keys"] == ["train/loss", "validation/loss"]
+        assert run.history.call_args.kwargs["x_axis"] == "epoch"

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -1,16 +1,19 @@
 """Tests for the get_run_history_tool."""
 
+import asyncio
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 import wandb
+from mcp.server.fastmcp import FastMCP
 
 from wandb_mcp_server.mcp_tools.run_history import (
     GET_RUN_HISTORY_TOOL_DESCRIPTION,
     MAX_HISTORY_ROWS,
     get_run_history,
 )
+from wandb_mcp_server.server import register_tools
 
 
 class TestRunHistoryDescription:
@@ -21,6 +24,20 @@ class TestRunHistoryDescription:
     def test_mentions_training_curves(self):
         desc_lower = GET_RUN_HISTORY_TOOL_DESCRIPTION.lower()
         assert "training curves" in desc_lower or "metric trends" in desc_lower
+
+    def test_public_schema_exposes_custom_axis_and_stream_controls(self):
+        mcp = FastMCP("history-schema")
+        register_tools(mcp)
+        tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+        properties = tools["get_run_history_tool"].inputSchema["properties"]
+
+        assert {"x_axis", "target_x", "tolerance", "stream"} <= properties.keys()
+        assert properties["stream"]["enum"] == ["default", "system"]
+        compare_properties = tools["compare_runs_tool"].inputSchema["properties"]
+        diagnose_properties = tools["diagnose_run_tool"].inputSchema["properties"]
+        assert {"config_keys", "summary_keys", "x_axis"} <= compare_properties.keys()
+        assert {"config_keys", "summary_keys", "x_axis", "samples"} <= diagnose_properties.keys()
 
 
 class TestGetRunHistory:
@@ -154,7 +171,7 @@ class TestGetRunHistory:
         mock_run.scan_history.assert_called_once()
         call_kwargs = mock_run.scan_history.call_args[1]
         assert call_kwargs["min_step"] == 50
-        assert call_kwargs["max_step"] == 200
+        assert call_kwargs["max_step"] == 201
         mock_run.history.assert_not_called()
         assert result["sampled_points"] == 3
 
@@ -290,7 +307,7 @@ class TestGetRunHistory:
 
         mock_run.scan_history.assert_called_once()
         call_kwargs = mock_run.scan_history.call_args[1]
-        assert call_kwargs["max_step"] == 200
+        assert call_kwargs["max_step"] == 201
         assert "min_step" not in call_kwargs
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
@@ -528,7 +545,7 @@ class TestTieredStepRangeFetch:
         call_kwargs = mock_run.scan_history.call_args[1]
         assert call_kwargs["keys"] == ["loss"]
         assert call_kwargs["min_step"] == 10
-        assert call_kwargs["max_step"] == 100
+        assert call_kwargs["max_step"] == 101
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
@@ -547,3 +564,140 @@ class TestTieredStepRangeFetch:
         result = json.loads(get_run_history("e", "p", "run1", min_step=5000, max_step=6000))
         mock_run.history.assert_not_called()
         assert result["sampled_points"] == 0
+
+
+class TestCustomAxisHistory:
+    @patch("wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps", return_value=[42])
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_exact_custom_axis_target_is_verified_from_history(
+        self,
+        mock_wandb_mod,
+        mock_api_mgr,
+        mock_steps,
+    ):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        run = MagicMock(name="run")
+        run.name = "custom-axis"
+        run.lastHistoryStep = 100
+        run.scan_history.return_value = [{"_step": 42, "validation/step": 1000.0, "validation/loss": 0.2}]
+        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        result = json.loads(
+            get_run_history(
+                "e",
+                "p",
+                "run1",
+                keys=["validation/loss"],
+                x_axis="validation/step",
+                target_x=1000,
+            )
+        )
+
+        assert result["exact"] is True
+        assert result["sampled"] is False
+        assert result["retrieval_method"] == "steps_for_metric_values"
+        assert result["rows"] == [{"_step": 42, "validation/step": 1000.0, "validation/loss": 0.2}]
+        assert result["rows_scanned"] == 1
+        mock_steps.assert_called_once()
+
+    @patch("wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps", return_value=[42])
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_missing_exact_custom_axis_target_is_honest(
+        self,
+        mock_wandb_mod,
+        mock_api_mgr,
+        _mock_steps,
+    ):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        run = MagicMock()
+        run.name = "custom-axis"
+        run.scan_history.return_value = [{"_step": 42, "validation/step": 999.5}]
+        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        result = json.loads(
+            get_run_history(
+                "e",
+                "p",
+                "run1",
+                keys=["validation/loss"],
+                x_axis="validation/step",
+                target_x=1000,
+            )
+        )
+
+        assert result["error"] == "target_not_logged"
+        assert result["exact"] is False
+
+    @patch("wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps", return_value=[42])
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_tolerance_permits_bounded_nearest_refinement(
+        self,
+        mock_wandb_mod,
+        mock_api_mgr,
+        _mock_steps,
+    ):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        run = MagicMock()
+        run.name = "custom-axis"
+        run.lastHistoryStep = 100
+        run.scan_history.return_value = [
+            {"_step": 40, "validation/step": 997.0},
+            {"_step": 41, "validation/step": 999.75, "validation/loss": 0.21},
+            {"_step": 42, "validation/step": 1001.0},
+        ]
+        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        result = json.loads(
+            get_run_history(
+                "e",
+                "p",
+                "run1",
+                keys=["validation/loss"],
+                x_axis="validation/step",
+                target_x=1000,
+                tolerance=0.5,
+            )
+        )
+
+        assert result["exact"] is False
+        assert result["sampled"] is False
+        assert result["rows"][0]["validation/step"] == 999.75
+        assert result["rows_scanned"] == 3
+        scan_kwargs = run.scan_history.call_args.kwargs
+        assert scan_kwargs["min_step"] == 40
+        assert scan_kwargs["max_step"] == 45
+
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_system_stream_uses_public_sdk_sampling(self, mock_wandb_mod, mock_api_mgr):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        run = MagicMock()
+        run.name = "system"
+        run.lastHistoryStep = 10
+        run.history.return_value = [{"_timestamp": 10, "system.cpu": 40.0}]
+        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        result = json.loads(
+            get_run_history(
+                "e",
+                "p",
+                "run1",
+                keys=["system.cpu"],
+                x_axis="_timestamp",
+                stream="system",
+                samples=10,
+            )
+        )
+
+        assert result["stream"] == "system"
+        assert result["retrieval_method"] == "sdk_sample"
+        assert result["sampled"] is True
+        assert run.history.call_args.kwargs["stream"] == "system"
+        assert run.history.call_args.kwargs["x_axis"] == "_timestamp"

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -7,12 +7,14 @@ import json
 from wandb_mcp_server.wandb_graphql import validate_read_only_graphql
 from wandb_mcp_server.wandb_selective_reads import (
     ARTIFACT_INVENTORY_QUERY,
+    METRIC_VALUE_STEPS_QUERY,
     PROJECTED_RUNS_QUERY,
     PROJECTED_RUN_QUERY,
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
     fetch_project_counts,
     fetch_project_fields,
+    fetch_metric_value_steps,
     fetch_projected_run,
     fetch_projected_runs,
 )
@@ -97,6 +99,8 @@ class FakeServiceApi:
                     "running": 12,
                 }
             }
+        if "MCPMetricValueSteps" in query:
+            return {"project": {"run": {"stepsForMetricValues": [42, None]}}}
         raise AssertionError("unexpected query")
 
 
@@ -112,6 +116,7 @@ def test_every_application_owned_document_is_query_only():
         PROJECT_COUNTS_QUERY,
         PROJECT_FIELDS_QUERY,
         ARTIFACT_INVENTORY_QUERY,
+        METRIC_VALUE_STEPS_QUERY,
     ):
         validate_read_only_graphql(document)
 
@@ -182,3 +187,22 @@ def test_project_field_index_and_counts_are_server_side():
         "running": 12,
     }
     assert api._service_api.calls[0][1]["pattern"] == "validation"
+
+
+def test_metric_value_lookup_returns_candidate_steps_for_caller_verification():
+    api = FakeApi()
+
+    steps = fetch_metric_value_steps(
+        api,
+        entity="entity",
+        project="project",
+        run_id="run-1",
+        metric="validation/step",
+        values=[1000.0, 2000.0],
+    )
+
+    assert steps == [42, None]
+    query, variables = api._service_api.calls[0]
+    assert "stepsForMetricValues" in query
+    assert variables["metric"] == "validation/step"
+    assert variables["values"] == [1000.0, 2000.0]


### PR DESCRIPTION
## Summary

- extends `get_run_history_tool` with custom x-axis targeting, tolerance refinement, system-history selection, and explicit retrieval/coverage metadata
- uses the W&B SDK for sampled and bounded range reads, plus one fixed query-only `stepsForMetricValues` document where public SDK parity is absent
- verifies the candidate history row before calling a custom-axis target exact; returns stable `target_not_logged` when the value was not logged
- fixes the MCP inclusive `max_step` contract over the SDK's exclusive scan bound
- makes compare/diagnose select bounded project-indexed config and summary fields instead of discovering metrics from complete wide summaries
- assigns admission weight from the requested operation: counts/metadata 1, projected/sample reads 2, scans/refinements/full analysis 4

## Stack

This cumulative draft includes #118, #119, and #120 and intentionally targets `staging/0.4.0`. Merge order remains #118 → #119 → #120 → this PR. Refresh this diff after each predecessor merges; do not bypass review.

## Validation

- Ruff check and format check
- Bandit Medium/High scan
- `uv lock --check`
- Python 3.11: 903 passed, 10 deselected
- Python 3.12: 903 passed, 10 deselected
- W&B latest compatibility: 153 passed, 1 deselected
- exact, missing, and tolerance custom-axis contract tests
- SDK sampled/range/system-history tests, including inclusive-to-exclusive step conversion
- indexed comparison and diagnosis tests proving bounded selection and disclosed coverage
- fresh wheel build and MCP schema/registration smoke

## Credentialed read-only note

The supplied fixture project was queried without exposing credentials. It validates the query/project paths but contains only single-row run histories, so it cannot demonstrate a multi-row custom-axis binary lookup live. The backend query shape and W&B 0.28 transport are exercised, and exact candidate verification is covered by the focused contract suite. Cloud Run staging should use a realistic multi-step fixture before release approval.
