### PR TITLE
perf: make collection scope and evaluation coverage explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
             tests/test_run_history.py \
             tests/test_compare_runs.py \
             tests/test_diagnose_run.py \
+            tests/test_query_artifacts.py \
+            tests/test_query_registry.py \
+            tests/test_summarize_evaluation.py \
+            tests/test_infer_schema.py \
             tests/test_tool_registration.py \
             tests/test_wandb_graphql.py \
             tests/test_wandb_graphql_read_only.py \

--- a/README.md
+++ b/README.md
@@ -555,6 +555,15 @@ When running the server locally, you can customize its behavior with command lin
 | `MCP_REQUEST_SUCCESS_SAMPLE_RATE` | Deterministic sample rate for successful HTTP request telemetry (default: `0.10`; failures and requests over two seconds are always retained). | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
 
+Workload profiles provide one deployment-level choice while preserving the
+individual `MCP_MAX_*` overrides for advanced operators:
+
+| Profile | Collection rows | History samples | Metric keys | Range scan rows | Full-detail rows | Eval detail rows | Schema sample rows | Actor/process cost |
+|---------|----------------:|----------------:|------------:|----------------:|-----------------:|-----------------:|-------------------:|-------------------:|
+| `shared` | 100 | 500 | 20 | 5,000 | 3 | 500 | 100 | 4 / 16 |
+| `dedicated` | 250 | 1,500 | 50 | 20,000 | 10 | 2,000 | 250 | 8 / 16 |
+| `local` | 1,000 | 5,000 | 100 | 100,000 | 25 | 5,000 | 500 | admission disabled |
+
 #### Usage Examples
 
 **STDIO Transport (default for desktop clients):**

--- a/src/wandb_mcp_server/admission.py
+++ b/src/wandb_mcp_server/admission.py
@@ -132,7 +132,6 @@ LIGHT_TOOLS = frozenset(
     {
         "list_entities_tool",
         "query_wandb_entity_projects",
-        "list_artifact_versions_tool",
         "get_artifact_details_tool",
         "list_registries_tool",
         "list_registry_collections_tool",
@@ -188,6 +187,10 @@ def tool_cost(name: str, arguments: Mapping[str, Any] | None = None) -> tuple[st
         return "expensive", 2
     if name == "get_artifact_details_tool" and arguments.get("include_files"):
         return "heavy", 4
+    if name == "list_artifact_versions_tool":
+        if arguments.get("created_after") or arguments.get("created_before"):
+            return "heavy", 4
+        return "expensive", 2
     if name == "count_weave_traces_tool":
         return "light", 1
     if name in LIGHT_TOOLS:

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -66,6 +66,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, int]] = {
         "project_fields": 500,
         "probe_runs": 6,
         "evaluation_rows": 500,
+        "schema_rows": 100,
         "actor_capacity": 4,
         "process_capacity": 16,
     },
@@ -78,6 +79,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, int]] = {
         "project_fields": 2_000,
         "probe_runs": 12,
         "evaluation_rows": 2_000,
+        "schema_rows": 250,
         "actor_capacity": 8,
         "process_capacity": 16,
     },
@@ -90,6 +92,7 @@ _PROFILE_DEFAULTS: dict[str, dict[str, int]] = {
         "project_fields": 5_000,
         "probe_runs": 24,
         "evaluation_rows": 5_000,
+        "schema_rows": 500,
         "actor_capacity": 16,
         "process_capacity": 16,
     },
@@ -141,6 +144,10 @@ MCP_MAX_PROBE_RUNS: int = _env_int(
 MCP_MAX_EVALUATION_ROWS: int = _env_int(
     "MCP_MAX_EVALUATION_ROWS",
     _profile_defaults["evaluation_rows"],
+)
+MCP_MAX_SCHEMA_SAMPLE_ROWS: int = _env_int(
+    "MCP_MAX_SCHEMA_SAMPLE_ROWS",
+    _profile_defaults["schema_rows"],
 )
 MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE: int = _env_int(
     "MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE",

--- a/src/wandb_mcp_server/mcp_tools/compare_runs.py
+++ b/src/wandb_mcp_server/mcp_tools/compare_runs.py
@@ -24,9 +24,10 @@ Call when the user asks "what changed between run A and B?", "which run is bette
 or wants to understand why two runs have different performance.
 
 Typical workflow:
-1. query_wandb_tool or get_run_history_tool to identify the two runs
-2. compare_runs_tool to see what differs
-3. create_wandb_report_tool to visualize the comparison
+1. probe_project_tool for indexed fields when the project is unfamiliar
+2. query_wandb_tool with projected keys to identify the two runs
+3. compare_runs_tool to see what differs
+4. get_run_history_tool for targeted custom-axis detail when needed
 </when_to_use>
 
 Parameters

--- a/src/wandb_mcp_server/mcp_tools/infer_schema.py
+++ b/src/wandb_mcp_server/mcp_tools/infer_schema.py
@@ -10,6 +10,7 @@ import json
 from collections import Counter, defaultdict
 from typing import Any, Dict
 
+from wandb_mcp_server.config import MCP_MAX_SCHEMA_SAMPLE_ROWS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 
@@ -17,9 +18,9 @@ logger = get_rich_logger(__name__)
 
 INFER_TRACE_SCHEMA_TOOL_DESCRIPTION = """Discover the schema of Weave traces in a project.
 
-Returns field names, data types, and the most common values for each field,
-plus total and root trace counts. Use this tool BEFORE querying traces to
-understand what fields are available and what values to filter on.
+Returns field names, data types, and the most common values from a bounded,
+recent sample, plus exact total and root trace counts. Sampling scope and
+exhaustiveness are explicit.
 
 <when_to_use>
 Call this tool FIRST when working with a new project's Weave traces.
@@ -34,7 +35,8 @@ entity_name : str
 project_name : str
     The Weights & Biases project name.
 sample_size : int, optional
-    Number of recent traces to sample for schema inference. Defaults to 20.
+    Number of recent traces to sample for schema inference. Defaults to 20;
+    the active workload profile applies a hard cap.
 top_n_values : int, optional
     Number of most common values to return per field. Defaults to 5.
 
@@ -45,6 +47,7 @@ JSON with:
   - total_traces: total trace count in the project
   - root_traces: root-level trace count
   - sample_size: how many traces were sampled
+  - sample_scope: requested/applied limits, coverage, and exhaustiveness
 
 Examples
 --------
@@ -104,8 +107,13 @@ def infer_trace_schema(
     from wandb_mcp_server.mcp_tools.count_traces import count_traces
     from wandb_mcp_server.mcp_tools.query_weave import get_trace_service
 
-    if sample_size > 500:
-        logger.warning(f"Large sample_size={sample_size} for schema inference; consider using a smaller value")
+    if isinstance(sample_size, bool) or not isinstance(sample_size, int) or sample_size < 1:
+        return json.dumps({"error": "invalid_input", "message": "sample_size must be a positive integer"})
+    if isinstance(top_n_values, bool) or not isinstance(top_n_values, int) or top_n_values < 1:
+        return json.dumps({"error": "invalid_input", "message": "top_n_values must be a positive integer"})
+    requested_sample_size = sample_size
+    effective_sample_size = min(sample_size, MCP_MAX_SCHEMA_SAMPLE_ROWS)
+    effective_top_n = min(top_n_values, 20)
 
     with track_tool_execution(
         "infer_trace_schema",
@@ -127,7 +135,7 @@ def infer_trace_schema(
                 filters={},
                 sort_by="started_at",
                 sort_direction="desc",
-                limit=sample_size,
+                limit=effective_sample_size,
                 include_costs=False,
                 include_feedback=False,
                 columns=[],
@@ -149,6 +157,18 @@ def infer_trace_schema(
                     "total_traces": total_traces,
                     "root_traces": root_traces,
                     "sample_size": 0,
+                    "sample_scope": {
+                        "strategy": "most_recent",
+                        "requested_count": requested_sample_size,
+                        "applied_limit": effective_sample_size,
+                        "profile": MCP_WORKLOAD_PROFILE,
+                        "profile_cap": MCP_MAX_SCHEMA_SAMPLE_ROWS,
+                        "returned_count": 0,
+                        "total_count": total_traces,
+                        "has_more": total_traces > 0,
+                        "project_exhaustive": total_traces == 0,
+                        "coverage": 1.0 if total_traces == 0 else 0.0,
+                    },
                     "note": "No traces found in this project.",
                 }
             )
@@ -180,7 +200,7 @@ def infer_trace_schema(
         for path in sorted(field_types.keys()):
             type_counts = field_types[path]
             dominant_type = type_counts.most_common(1)[0][0]
-            top_vals = [v for v, _ in field_values[path].most_common(top_n_values)]
+            top_vals = [v for v, _ in field_values[path].most_common(effective_top_n)]
             fields.append(
                 {
                     "path": path,
@@ -196,6 +216,18 @@ def infer_trace_schema(
                 "total_traces": total_traces,
                 "root_traces": root_traces,
                 "sample_size": len(traces),
+                "sample_scope": {
+                    "strategy": "most_recent",
+                    "requested_count": requested_sample_size,
+                    "applied_limit": effective_sample_size,
+                    "profile": MCP_WORKLOAD_PROFILE,
+                    "profile_cap": MCP_MAX_SCHEMA_SAMPLE_ROWS,
+                    "returned_count": len(traces),
+                    "total_count": total_traces,
+                    "has_more": total_traces > len(traces),
+                    "project_exhaustive": total_traces <= len(traces),
+                    "coverage": round(len(traces) / total_traces, 4) if total_traces else 1.0,
+                },
             }
         )
 

--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -7,17 +7,28 @@ comparison via the ``wandb.Api`` public interface.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
 from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_selective_reads import (
+    SelectiveReadUnavailable,
+    fetch_registry_artifact_versions,
+)
 
 logger = get_rich_logger(__name__)
 
 DEFAULT_MAX_ITEMS = 50
-MAX_ITEMS_CEILING = 200
 MAX_USED_BY = 20
+_ORDER_FIELDS = {
+    "created_at": "createdAt",
+    "updated_at": "updatedAt",
+    "version": "versionIndex",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +37,7 @@ MAX_USED_BY = 20
 
 LIST_ARTIFACT_VERSIONS_TOOL_DESCRIPTION = """List versions of an artifact collection from a project or registry.
 
-Returns version numbers, aliases, tags, sizes, and state for each version.
+Returns ordered, bounded version metadata with honest pagination and count scope.
 
 <when_to_use>
 Call this when the user wants to see available versions of a model, dataset, or
@@ -69,7 +80,16 @@ type_name : str, optional
 source : str, optional
     "project" (default) or "registry". Determines the API path.
 max_items : int, optional
-    Maximum versions to return. Default: 50, max: 200.
+    Maximum versions to return. Default: 50; workload-profile limits apply.
+order : str, optional
+    Sort by created_at, updated_at, or version. Prefix with "-" for descending
+    or "+" for ascending. Defaults to "-created_at".
+tags : list[str], optional
+    Require every listed artifact tag.
+created_after : str, optional
+    Include versions created at or after this ISO-8601 timestamp.
+created_before : str, optional
+    Include versions created at or before this ISO-8601 timestamp.
 
 Returns
 -------
@@ -77,8 +97,9 @@ JSON with:
   - collection: the queried collection name
   - source: "project" or "registry"
   - versions: list of version objects with version, aliases, tags, size, etc.
-  - count: number of versions returned
-  - truncated: whether more versions exist beyond max_items
+  - returned_count / total_count: returned and exact matching totals when known
+  - has_more / project_exhaustive: explicit pagination and scan scope
+  - compatibility_caveat: present only for a bounded older-backend fallback
 """
 
 
@@ -91,10 +112,12 @@ def list_artifact_versions(
     type_name: Optional[str] = None,
     source: str = "project",
     max_items: int = DEFAULT_MAX_ITEMS,
+    order: str = "-created_at",
+    tags: Optional[List[str]] = None,
+    created_after: Optional[str] = None,
+    created_before: Optional[str] = None,
 ) -> str:
     """List versions of an artifact collection."""
-
-    api = WandBApiManager.get_api()
     with track_tool_execution(
         "list_artifact_versions",
         None,
@@ -106,61 +129,123 @@ def list_artifact_versions(
             "type_name": type_name,
             "source": source,
             "max_items": max_items,
+            "order": order,
+            "tag_count": len(tags or []),
+            "has_created_after": created_after is not None,
+            "has_created_before": created_before is not None,
         },
     ) as ctx:
-        max_items = min(max_items, MAX_ITEMS_CEILING)
-
         try:
+            validation_error = _validate_version_query(
+                collection_name=collection_name,
+                registry_name=registry_name,
+                type_name=type_name,
+                source=source,
+                max_items=max_items,
+                order=order,
+                tags=tags,
+                created_after=created_after,
+                created_before=created_before,
+            )
+            if validation_error:
+                return json.dumps({"error": "invalid_input", "message": validation_error})
+
+            max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
+            order_value = _normalize_order(order)
+            after_dt = _parse_timestamp(created_after)
+            before_dt = _parse_timestamp(created_before)
+            needs_local_filter_scan = bool(created_after or created_before or (source == "registry" and tags))
+            scan_limit = MCP_MAX_WANDB_QUERY_ITEMS + 1 if needs_local_filter_scan else max_items + 1
+            api = WandBApiManager.get_api()
+            compatibility_caveat: str | None = None
+            exact_total: int | None = None
+
             if source == "registry":
-                if not registry_name:
-                    return json.dumps(
-                        {
-                            "error": "invalid_input",
-                            "message": "registry_name is required when source='registry'",
-                        }
-                    )
                 reg_kwargs: Dict[str, Any] = {}
                 if organization is not None:
                     reg_kwargs["organization"] = organization
                 registry = api.registry(registry_name, **reg_kwargs)
-                versions_iter = registry.collections(
-                    filter={"name": collection_name},
-                    per_page=min(max_items, 100),
-                ).versions()
-            else:
-                if not type_name:
-                    return json.dumps(
-                        {
-                            "error": "invalid_input",
-                            "message": "type_name is required when source='project'",
-                        }
+                resolved_organization = organization or getattr(registry, "organization", None)
+                if not isinstance(resolved_organization, str) or not resolved_organization:
+                    raise ValueError("Unable to resolve the registry organization")
+                try:
+                    page = fetch_registry_artifact_versions(
+                        api,
+                        organization=resolved_organization,
+                        registry_name=registry_name or "",
+                        collection_name=collection_name,
+                        order=order_value,
+                        scan_limit=scan_limit,
                     )
+                    raw_versions: list[Any] = page.items
+                    upstream_has_more = page.has_more
+                except SelectiveReadUnavailable:
+                    versions_iter = registry.collections(
+                        filter={"name": collection_name},
+                        per_page=min(scan_limit, 100),
+                    ).versions(per_page=min(scan_limit, 100))
+                    raw_versions, upstream_has_more = _bounded_iterable(versions_iter, scan_limit)
+                    compatibility_caveat = (
+                        "This Dedicated backend lacks ordered registry-version projection; "
+                        "a bounded SDK page was returned in backend order."
+                    )
+            else:
                 qualified_name = collection_name
                 if "/" not in collection_name and entity_name and project_name:
                     qualified_name = f"{entity_name}/{project_name}/{collection_name}"
                 versions_iter = api.artifacts(
                     type_name=type_name,
                     name=qualified_name,
-                    per_page=min(max_items, 100),
+                    order=order_value,
+                    tags=tags,
+                    per_page=min(scan_limit, 100),
                 )
+                if not tags and created_after is None and created_before is None:
+                    try:
+                        exact_total = len(versions_iter)
+                    except (TypeError, NotImplementedError):
+                        exact_total = None
+                raw_versions, upstream_has_more = _bounded_iterable(versions_iter, scan_limit)
 
-            versions: List[Dict[str, Any]] = []
-            truncated = False
-            for art in versions_iter:
-                if len(versions) >= max_items:
-                    truncated = True
-                    break
-                versions.append(_serialize_artifact_summary(art))
+            matching = [
+                _serialize_artifact_summary(artifact)
+                for artifact in raw_versions
+                if _matches_artifact_filters(
+                    artifact,
+                    tags=tags or [],
+                    created_after=after_dt,
+                    created_before=before_dt,
+                )
+            ]
+            if exact_total is None and not upstream_has_more:
+                exact_total = len(matching)
+            has_more = len(matching) > max_items or upstream_has_more
+            versions = matching[:max_items]
 
-            return json.dumps(
-                {
-                    "collection": collection_name,
-                    "source": source,
-                    "versions": versions,
-                    "count": len(versions),
-                    "truncated": truncated,
-                }
-            )
+            result: dict[str, Any] = {
+                "collection": collection_name,
+                "source": source,
+                "items": versions,
+                "versions": versions,
+                "returned_count": len(versions),
+                "total_count": exact_total,
+                "has_more": has_more,
+                "limit": max_items,
+                "project_exhaustive": not has_more,
+                "scan": {
+                    "profile": MCP_WORKLOAD_PROFILE,
+                    "rows_examined": len(raw_versions),
+                    "row_cap": scan_limit,
+                    "filter_exhaustive": not upstream_has_more,
+                    "order": order,
+                },
+                # Compatibility aliases for the existing response contract.
+                "count": len(versions),
+                "truncated": has_more,
+            }
+            if compatibility_caveat:
+                result["compatibility_caveat"] = compatibility_caveat
+            return json.dumps(result)
 
         except Exception as e:
             logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
@@ -409,6 +494,8 @@ def compare_artifact_versions(
 
 def _serialize_artifact_summary(artifact: Any) -> Dict[str, Any]:
     """Extract core properties from an Artifact into a plain dict."""
+    if isinstance(artifact, dict):
+        return dict(artifact)
     return {
         "version": getattr(artifact, "version", None),
         "name": getattr(artifact, "name", None),
@@ -421,6 +508,120 @@ def _serialize_artifact_summary(artifact: Any) -> Dict[str, Any]:
         "created_at": str(getattr(artifact, "created_at", "")),
         "digest": getattr(artifact, "digest", None),
     }
+
+
+def _validate_version_query(
+    *,
+    collection_name: str,
+    registry_name: str | None,
+    type_name: str | None,
+    source: str,
+    max_items: int,
+    order: str,
+    tags: list[str] | None,
+    created_after: str | None,
+    created_before: str | None,
+) -> str | None:
+    if not isinstance(collection_name, str) or not collection_name.strip():
+        return "collection_name must be a non-empty string"
+    if source not in {"project", "registry"}:
+        return "source must be 'project' or 'registry'"
+    if source == "registry" and not registry_name:
+        return "registry_name is required when source='registry'"
+    if source == "project" and not type_name:
+        return "type_name is required when source='project'"
+    if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+        return "max_items must be a positive integer"
+    try:
+        _normalize_order(order)
+        after_dt = _parse_timestamp(created_after)
+        before_dt = _parse_timestamp(created_before)
+    except ValueError as exc:
+        return str(exc)
+    if after_dt and before_dt and after_dt > before_dt:
+        return "created_after must not be later than created_before"
+    if tags is not None and (
+        not isinstance(tags, list) or any(not isinstance(tag, str) or not tag.strip() for tag in tags)
+    ):
+        return "tags must be a list of non-empty strings"
+    return None
+
+
+def _normalize_order(order: str) -> str:
+    if not isinstance(order, str) or not order:
+        raise ValueError("order must be a non-empty string")
+    prefix = order[0] if order[0] in "+-" else "+"
+    field = order[1:] if order[0] in "+-" else order
+    if field not in _ORDER_FIELDS:
+        raise ValueError("order must use created_at, updated_at, or version")
+    return f"{prefix}{_ORDER_FIELDS[field]}"
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("date filters must be non-empty ISO-8601 strings")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO-8601 timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _artifact_created_at(artifact: Any) -> datetime | None:
+    raw = artifact.get("created_at") if isinstance(artifact, dict) else getattr(artifact, "created_at", None)
+    if isinstance(raw, datetime):
+        parsed = raw
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    if raw:
+        try:
+            return _parse_timestamp(str(raw))
+        except ValueError:
+            return None
+    return None
+
+
+def _matches_artifact_filters(
+    artifact: Any,
+    *,
+    tags: list[str],
+    created_after: datetime | None,
+    created_before: datetime | None,
+) -> bool:
+    artifact_tags = artifact.get("tags", []) if isinstance(artifact, dict) else getattr(artifact, "tags", [])
+    if not set(tags).issubset(set(artifact_tags or [])):
+        return False
+    if created_after is None and created_before is None:
+        return True
+    created_at = _artifact_created_at(artifact)
+    if created_at is None:
+        return False
+    return not (
+        (created_after is not None and created_at < created_after)
+        or (created_before is not None and created_at > created_before)
+    )
+
+
+def _bounded_iterable(values: Any, scan_limit: int) -> tuple[list[Any], bool]:
+    iterator = iter(values)
+    rows: list[Any] = []
+    for _ in range(scan_limit):
+        raise_if_tool_deadline_exceeded()
+        try:
+            rows.append(next(iterator))
+        except StopIteration:
+            return rows, False
+    raise_if_tool_deadline_exceeded()
+    try:
+        next(iterator)
+    except StopIteration:
+        return rows, False
+    return rows, True
 
 
 def _serialize_run_info(run: Any) -> Optional[Dict[str, Any]]:

--- a/src/wandb_mcp_server/mcp_tools/query_registry.py
+++ b/src/wandb_mcp_server/mcp_tools/query_registry.py
@@ -9,14 +9,15 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, List, Optional
 
+from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
 from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
 
 DEFAULT_MAX_ITEMS = 50
-MAX_ITEMS_CEILING = 200
 
 
 # ---------------------------------------------------------------------------
@@ -54,14 +55,14 @@ organization : str, optional
 filter : dict, optional
     MongoDB-style filter dict (e.g., {"name": {"$regex": "model.*"}}).
 max_items : int, optional
-    Maximum registries to return. Default: 50, max: 200.
+    Maximum registries to return. Default: 50; workload-profile limits apply.
 
 Returns
 -------
 JSON with:
   - registries: list of registry objects with name, description, visibility, etc.
-  - count: number of registries returned
-  - truncated: whether more registries exist beyond max_items
+  - returned_count / total_count: returned and exact totals when known
+  - has_more / project_exhaustive: explicit pagination scope
 """
 
 
@@ -72,27 +73,25 @@ def list_registries(
 ) -> str:
     """List W&B registries for an organization."""
 
-    api = WandBApiManager.get_api()
     with track_tool_execution(
         "list_registries",
         None,
         {"organization": organization, "filter": filter, "max_items": max_items},
     ) as ctx:
-        max_items = min(max_items, MAX_ITEMS_CEILING)
-
         try:
-            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+                return json.dumps({"error": "invalid_input", "message": "max_items must be a positive integer"})
+            max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
+            api = WandBApiManager.get_api()
+            kwargs: Dict[str, Any] = {"per_page": min(max_items + 1, 100)}
             if organization is not None:
                 kwargs["organization"] = organization
             if filter is not None:
                 kwargs["filter"] = filter
 
+            page, has_more = _bounded_page(api.registries(**kwargs), max_items)
             registries: List[Dict[str, Any]] = []
-            truncated = False
-            for reg in api.registries(**kwargs):
-                if len(registries) >= max_items:
-                    truncated = True
-                    break
+            for reg in page:
                 registries.append(
                     {
                         "name": getattr(reg, "name", None),
@@ -107,7 +106,20 @@ def list_registries(
                     }
                 )
 
-            return json.dumps({"registries": registries, "count": len(registries), "truncated": truncated})
+            total_count = None if has_more else len(registries)
+            return json.dumps(
+                {
+                    "items": registries,
+                    "registries": registries,
+                    "returned_count": len(registries),
+                    "total_count": total_count,
+                    "has_more": has_more,
+                    "limit": max_items,
+                    "project_exhaustive": not has_more,
+                    "count": len(registries),
+                    "truncated": has_more,
+                }
+            )
 
         except Exception as e:
             logger.error(f"Error in list_registries: {e}", exc_info=True)
@@ -144,15 +156,15 @@ organization : str, optional
 filter : dict, optional
     MongoDB-style filter (e.g., {"tag": "production"}).
 max_items : int, optional
-    Maximum collections to return. Default: 50, max: 200.
+    Maximum collections to return. Default: 50; workload-profile limits apply.
 
 Returns
 -------
 JSON with:
   - registry: the queried registry name
   - collections: list of collection objects with name, type, tags, aliases, etc.
-  - count: number of collections returned
-  - truncated: whether more collections exist beyond max_items
+  - returned_count / total_count: returned and exact totals when known
+  - has_more / project_exhaustive: explicit pagination scope
 """
 
 
@@ -164,7 +176,6 @@ def list_registry_collections(
 ) -> str:
     """List collections within a W&B registry."""
 
-    api = WandBApiManager.get_api()
     with track_tool_execution(
         "list_registry_collections",
         None,
@@ -175,24 +186,29 @@ def list_registry_collections(
             "max_items": max_items,
         },
     ) as ctx:
-        max_items = min(max_items, MAX_ITEMS_CEILING)
-
         try:
+            if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+                return json.dumps({"error": "invalid_input", "message": "max_items must be a positive integer"})
+            max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
+            api = WandBApiManager.get_api()
             reg_kwargs: Dict[str, Any] = {}
             if organization is not None:
                 reg_kwargs["organization"] = organization
             registry = api.registry(registry_name, **reg_kwargs)
 
-            coll_kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
+            coll_kwargs: Dict[str, Any] = {"per_page": min(max_items + 1, 100)}
             if filter is not None:
                 coll_kwargs["filter"] = filter
 
+            collection_iter = registry.collections(**coll_kwargs)
+            exact_total: int | None = None
+            try:
+                exact_total = len(collection_iter)
+            except (TypeError, NotImplementedError):
+                pass
+            page, has_more = _bounded_page(collection_iter, max_items)
             collections: List[Dict[str, Any]] = []
-            truncated = False
-            for coll in registry.collections(**coll_kwargs):
-                if len(collections) >= max_items:
-                    truncated = True
-                    break
+            for coll in page:
                 collections.append(
                     {
                         "name": getattr(coll, "name", None),
@@ -209,9 +225,15 @@ def list_registry_collections(
             return json.dumps(
                 {
                     "registry": registry_name,
+                    "items": collections,
                     "collections": collections,
+                    "returned_count": len(collections),
+                    "total_count": exact_total if exact_total is not None else (None if has_more else len(collections)),
+                    "has_more": has_more,
+                    "limit": max_items,
+                    "project_exhaustive": not has_more,
                     "count": len(collections),
-                    "truncated": truncated,
+                    "truncated": has_more,
                 }
             )
 
@@ -219,3 +241,16 @@ def list_registry_collections(
             logger.error(f"Error in list_registry_collections: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
+
+
+def _bounded_page(values: Any, limit: int) -> tuple[list[Any], bool]:
+    """Consume at most limit-plus-one values from a lazy SDK collection."""
+    rows: list[Any] = []
+    iterator = iter(values)
+    for _ in range(limit + 1):
+        raise_if_tool_deadline_exceeded()
+        try:
+            rows.append(next(iterator))
+        except StopIteration:
+            break
+    return rows[:limit], len(rows) > limit

--- a/src/wandb_mcp_server/mcp_tools/run_history.py
+++ b/src/wandb_mcp_server/mcp_tools/run_history.py
@@ -45,9 +45,10 @@ that provides step-by-step metric history -- query_wandb_tool returns run-level
 summary metrics but not the full training history.
 
 Typical workflow:
-1. Use query_wandb_tool to find runs and their summary metrics.
-2. Use get_run_history_tool to drill into a specific run's training curves.
-3. Use create_wandb_report_tool to visualize the results.
+1. For an unfamiliar project, use probe_project_tool to discover indexed keys.
+2. Use query_wandb_tool with summary_keys/config_keys to select runs.
+3. Use get_run_history_tool with explicit keys and x_axis for targeted curves.
+4. Use create_wandb_report_tool to visualize the results.
 </when_to_use>
 
 Parameters

--- a/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
+++ b/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
@@ -3,6 +3,14 @@
 import json
 from typing import Any, Dict, List, Optional
 
+from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
+from wandb_mcp_server.config import (
+    MCP_MAX_EVALUATION_ROWS,
+    MCP_MAX_QUERY_LIMIT,
+    MCP_MAX_WANDB_QUERY_ITEMS,
+    MCP_WORKLOAD_PROFILE,
+)
+from wandb_mcp_server.mcp_tools.count_traces import count_traces
 from wandb_mcp_server.mcp_tools.query_weave import get_trace_service
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -20,7 +28,9 @@ tasks fail most?", or wants a summary of evaluation results without manually
 navigating trace hierarchies.
 
 This tool aggregates the Evaluation.evaluate -> predict_and_score trace hierarchy
-automatically. Use query_weave_traces_tool for raw trace data instead.
+automatically. Exact matching child counts are reported separately from bounded
+detail aggregates, so a capped sample is never presented as exhaustive. Use
+query_weave_traces_tool for raw trace data instead.
 </when_to_use>
 
 Parameters
@@ -39,6 +49,8 @@ include_per_task : bool, optional
 Returns
 -------
 JSON with evaluations (list of eval summaries) and optional comparison.
+Each evaluation includes exact total_predictions, detail coverage, and whether
+its error/token aggregates are exhaustive or sampled.
 """
 
 
@@ -52,16 +64,21 @@ def _extract_scores(summary: Dict[str, Any]) -> Dict[str, Any]:
     return scores
 
 
-def _aggregate_eval(eval_trace: Dict[str, Any], children: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _aggregate_eval(
+    eval_trace: Dict[str, Any],
+    children: List[Dict[str, Any]],
+    total_matching_count: int | None = None,
+) -> Dict[str, Any]:
     """Aggregate a single evaluation's results."""
     summary = eval_trace.get("summary", {})
     scores = _extract_scores(summary)
 
-    total = len(children)
+    observed = len(children)
+    total = observed if total_matching_count is None else max(0, total_matching_count)
     errors = sum(
         1 for c in children if c.get("exception") or c.get("summary", {}).get("weave", {}).get("status") == "error"
     )
-    successes = total - errors
+    successes = observed - errors
 
     usage_total = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     for child in children:
@@ -71,17 +88,75 @@ def _aggregate_eval(eval_trace: Dict[str, Any], children: List[Dict[str, Any]]) 
                 for k in usage_total:
                     usage_total[k] += model_usage.get(k, 0)
 
-    return {
+    exhaustive = observed >= total
+    result: dict[str, Any] = {
         "eval_id": eval_trace.get("id", ""),
         "op_name": eval_trace.get("op_name", ""),
         "started_at": eval_trace.get("started_at", ""),
         "total_predictions": total,
-        "successes": successes,
-        "errors": errors,
-        "error_rate": round(errors / max(total, 1), 4),
+        "observed_predictions": observed,
+        "returned_count": observed,
+        "coverage": round(observed / total, 4) if total else 1.0,
+        "details_exhaustive": exhaustive,
+        "aggregate_scope": "exhaustive" if exhaustive else "sample",
+        "observed_successes": successes,
+        "observed_errors": errors,
+        "observed_error_rate": round(errors / max(observed, 1), 4),
         "scores": scores,
         "token_usage": usage_total,
+        "token_usage_scope": "exhaustive" if exhaustive else "sample",
     }
+    if exhaustive:
+        # Compatibility aliases are safe only when the aggregate is complete.
+        result.update(
+            {
+                "successes": successes,
+                "errors": errors,
+                "error_rate": round(errors / max(total, 1), 4),
+            }
+        )
+    else:
+        result["coverage_note"] = (
+            f"Detail aggregates cover {observed} of {total} matching child traces; "
+            "scores stored on the evaluation root may still be backend-computed totals."
+        )
+    return result
+
+
+def _query_evaluation_children(
+    service: Any,
+    *,
+    entity_name: str,
+    project_name: str,
+    filters: dict[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch lightweight evaluation children in profile-bounded hosted pages."""
+    children: list[dict[str, Any]] = []
+    offset = 0
+    chunk_size = min(100, MCP_MAX_QUERY_LIMIT)
+    while len(children) < limit:
+        raise_if_tool_deadline_exceeded()
+        requested = min(chunk_size, limit - len(children))
+        result = service.query_traces(
+            entity_name=entity_name,
+            project_name=project_name,
+            filters=filters,
+            sort_by="started_at",
+            sort_direction="asc",
+            limit=requested,
+            offset=offset,
+            include_costs=False,
+            include_feedback=False,
+            columns=["id", "exception", "summary"],
+            return_full_data=False,
+        )
+        page = list(result.traces or [])
+        children.extend(page[:requested])
+        if len(page) < requested:
+            break
+        offset += requested
+    return children[:limit]
 
 
 def summarize_evaluation(
@@ -92,6 +167,9 @@ def summarize_evaluation(
     include_per_task: bool = False,
 ) -> str:
     """Summarize Weave evaluation results."""
+    if isinstance(max_evals, bool) or not isinstance(max_evals, int) or max_evals < 1:
+        return json.dumps({"error": "invalid_input", "message": "max_evals must be a positive integer"})
+    effective_max_evals = min(max_evals, MCP_MAX_WANDB_QUERY_ITEMS)
     with track_tool_execution(
         "summarize_evaluation",
         None,
@@ -103,21 +181,24 @@ def summarize_evaluation(
         },
     ) as ctx:
         try:
-            service = get_trace_service()
-
             filters: Dict[str, Any] = {"op_name_contains": "Evaluation.evaluate"}
             if eval_name:
                 filters["op_name_contains"] = eval_name
             filters["trace_roots_only"] = True
+            service = get_trace_service()
+            total_evaluations = count_traces(entity_name, project_name, filters=filters)
 
             result = service.query_traces(
                 entity_name=entity_name,
                 project_name=project_name,
                 filters=filters,
-                limit=max_evals,
+                limit=effective_max_evals,
                 sort_by="started_at",
                 sort_direction="desc",
-                return_full_data=True,
+                include_costs=False,
+                include_feedback=False,
+                columns=["id", "op_name", "started_at", "summary"],
+                return_full_data=False,
             )
 
             eval_traces = result.traces if result.traces else []
@@ -125,21 +206,38 @@ def summarize_evaluation(
                 return json.dumps(
                     {
                         "evaluations": [],
+                        "items": [],
+                        "returned_count": 0,
+                        "total_count": total_evaluations,
+                        "has_more": total_evaluations > 0,
+                        "limit": effective_max_evals,
+                        "project_exhaustive": total_evaluations == 0,
                         "message": "No Evaluation.evaluate traces found in this project.",
                     }
                 )
 
             evaluations = []
-            for eval_trace in eval_traces[:max_evals]:
-                child_result = service.query_traces(
+            for eval_trace in eval_traces[:effective_max_evals]:
+                child_filters = {"parent_ids": [eval_trace.get("id", "")]}
+                child_total = count_traces(
                     entity_name=entity_name,
                     project_name=project_name,
-                    filters={"parent_ids": [eval_trace.get("id", "")]},
-                    limit=500,
-                    return_full_data=True,
+                    filters=child_filters,
                 )
-                children = child_result.traces if child_result.traces else []
-                summary = _aggregate_eval(eval_trace, children)
+                detail_limit = min(child_total, MCP_MAX_EVALUATION_ROWS)
+                if detail_limit:
+                    children = _query_evaluation_children(
+                        service,
+                        entity_name=entity_name,
+                        project_name=project_name,
+                        filters=child_filters,
+                        limit=detail_limit,
+                    )
+                else:
+                    children = []
+                summary = _aggregate_eval(eval_trace, children, child_total)
+                summary["detail_limit"] = detail_limit
+                summary["workload_profile"] = MCP_WORKLOAD_PROFILE
 
                 if include_per_task and children:
                     per_task = []
@@ -154,12 +252,25 @@ def summarize_evaluation(
                             task_entry["scores"] = child_scores
                         per_task.append(task_entry)
                     summary["per_task"] = per_task
+                    summary["per_task_scope"] = {
+                        "returned_count": len(per_task),
+                        "total_count": child_total,
+                        "has_more": len(per_task) < child_total,
+                        "limit": 50,
+                        "project_exhaustive": len(per_task) >= child_total,
+                    }
 
                 evaluations.append(summary)
 
             return json.dumps(
                 {
+                    "items": evaluations,
                     "evaluations": evaluations,
+                    "returned_count": len(evaluations),
+                    "total_count": total_evaluations,
+                    "has_more": total_evaluations > len(evaluations),
+                    "limit": effective_max_evals,
+                    "project_exhaustive": total_evaluations <= len(evaluations),
                     "count": len(evaluations),
                     "project": f"{entity_name}/{project_name}",
                 },

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -1051,6 +1051,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
         type_name: Optional[str] = None,
         source: str = "project",
         max_items: int = 50,
+        order: str = "-created_at",
+        tags: Optional[List[str]] = None,
+        created_after: Optional[str] = None,
+        created_before: Optional[str] = None,
     ) -> str:
         """List versions of an artifact collection."""
         return list_artifact_versions(
@@ -1062,6 +1066,10 @@ def register_tools(mcp_instance: FastMCP) -> None:
             type_name=type_name,
             source=source,
             max_items=max_items,
+            order=order,
+            tags=tags,
+            created_after=created_after,
+            created_before=created_before,
         )
 
     @mcp_instance.tool(description=GET_ARTIFACT_DETAILS_TOOL_DESCRIPTION)

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -181,6 +181,59 @@ query MCPMetricValueSteps(
 }
 """
 
+REGISTRY_ARTIFACT_VERSIONS_QUERY = """
+query MCPRegistryArtifactVersions(
+  $organization: String!
+  $registryFilter: JSONString!
+  $collectionFilter: JSONString!
+  $order: String!
+  $first: Int!
+  $after: String
+) {
+  organization(name: $organization) {
+    orgEntity {
+      artifactMemberships(
+        projectFilters: $registryFilter
+        collectionFilters: $collectionFilter
+        order: $order
+        first: $first
+        after: $after
+      ) {
+        edges {
+          cursor
+          node {
+            versionIndex
+            aliases {
+              alias
+            }
+            artifactCollection {
+              name
+            }
+            artifact {
+              id
+              state
+              description
+              size
+              fileCount
+              createdAt
+              updatedAt
+              digest
+              tags {
+                name
+              }
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+}
+"""
+
 
 @dataclass(frozen=True)
 class ProjectedRunPage:
@@ -197,6 +250,15 @@ class ProjectFieldPage:
     """One bounded project-field inventory."""
 
     items: list[dict[str, str]]
+    has_more: bool
+    requests: int
+
+
+@dataclass(frozen=True)
+class ArtifactVersionPage:
+    """One bounded, ordered registry artifact-version scan."""
+
+    items: list[dict[str, Any]]
     has_more: bool
     requests: int
 
@@ -542,8 +604,104 @@ def fetch_metric_value_steps(
     return [int(step) if isinstance(step, (int, float)) else None for step in steps]
 
 
+def fetch_registry_artifact_versions(
+    api: Any,
+    *,
+    organization: str,
+    registry_name: str,
+    collection_name: str,
+    order: str,
+    scan_limit: int,
+    page_size: int = 100,
+) -> ArtifactVersionPage:
+    """Fetch an ordered, bounded registry-version page.
+
+    W&B 0.28's public Registry versions iterator does not expose its query's
+    ordering parameter. This fixed query-only adapter fills only that parity
+    gap; filtering remains bounded and explicit in the caller.
+    """
+    target = max(1, scan_limit)
+    items: list[dict[str, Any]] = []
+    cursor: str | None = None
+    requests = 0
+    has_next_page = False
+    registry_filter = json.dumps({"name": f"wandb-registry-{registry_name}"}, separators=(",", ":"))
+    collection_filter = json.dumps({"name": collection_name}, separators=(",", ":"))
+
+    while len(items) < target:
+        raise_if_tool_deadline_exceeded()
+        try:
+            data = execute_graphql(
+                api,
+                REGISTRY_ARTIFACT_VERSIONS_QUERY,
+                {
+                    "organization": organization,
+                    "registryFilter": registry_filter,
+                    "collectionFilter": collection_filter,
+                    "order": order,
+                    "first": min(max(1, page_size), target - len(items)),
+                    "after": cursor,
+                },
+            )
+        except Exception as exc:
+            raise SelectiveReadUnavailable(
+                f"ordered registry artifact query unavailable: {type(exc).__name__}"
+            ) from exc
+        requests += 1
+        organization_payload = data.get("organization")
+        org_entity = organization_payload.get("orgEntity") if isinstance(organization_payload, Mapping) else None
+        connection = org_entity.get("artifactMemberships") if isinstance(org_entity, Mapping) else None
+        if not isinstance(connection, Mapping):
+            raise SelectiveReadUnavailable("ordered registry artifact query returned no version connection")
+
+        for edge in connection.get("edges") or []:
+            membership = edge.get("node") if isinstance(edge, Mapping) else None
+            artifact = membership.get("artifact") if isinstance(membership, Mapping) else None
+            if not isinstance(membership, Mapping) or not isinstance(artifact, Mapping):
+                continue
+            version_index = membership.get("versionIndex")
+            collection = membership.get("artifactCollection") or {}
+            items.append(
+                {
+                    "version": f"v{version_index}" if version_index is not None else None,
+                    "name": collection.get("name"),
+                    "aliases": [
+                        alias.get("alias")
+                        for alias in membership.get("aliases") or []
+                        if isinstance(alias, Mapping) and alias.get("alias")
+                    ],
+                    "tags": [
+                        tag.get("name")
+                        for tag in artifact.get("tags") or []
+                        if isinstance(tag, Mapping) and tag.get("name")
+                    ],
+                    "state": artifact.get("state"),
+                    "size": artifact.get("size"),
+                    "file_count": artifact.get("fileCount"),
+                    "description": artifact.get("description"),
+                    "created_at": artifact.get("createdAt"),
+                    "updated_at": artifact.get("updatedAt"),
+                    "digest": artifact.get("digest"),
+                }
+            )
+            if len(items) >= target:
+                break
+        page_info = connection.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        cursor = page_info.get("endCursor")
+        if not has_next_page or not cursor:
+            break
+
+    return ArtifactVersionPage(
+        items=items,
+        has_more=has_next_page,
+        requests=requests,
+    )
+
+
 __all__ = [
     "ARTIFACT_INVENTORY_QUERY",
+    "REGISTRY_ARTIFACT_VERSIONS_QUERY",
     "METRIC_VALUE_STEPS_QUERY",
     "PROJECTED_RUNS_QUERY",
     "PROJECTED_RUN_QUERY",
@@ -551,9 +709,11 @@ __all__ = [
     "PROJECT_FIELDS_QUERY",
     "ProjectFieldPage",
     "ProjectedRunPage",
+    "ArtifactVersionPage",
     "SelectiveReadUnavailable",
     "fetch_artifact_inventory",
     "fetch_metric_value_steps",
+    "fetch_registry_artifact_versions",
     "fetch_project_counts",
     "fetch_project_fields",
     "fetch_projected_run",

--- a/tests/test_admission_control.py
+++ b/tests/test_admission_control.py
@@ -128,6 +128,8 @@ def test_tool_costs_are_stable_and_unknown_is_heavy() -> None:
     assert tool_cost("get_run_history_tool") == ("expensive", 2)
     assert tool_cost("get_run_history_tool", {"target_x": 100}) == ("heavy", 4)
     assert tool_cost("get_run_history_tool", {"min_step": 0, "max_step": 100}) == ("heavy", 4)
+    assert tool_cost("list_artifact_versions_tool") == ("expensive", 2)
+    assert tool_cost("list_artifact_versions_tool", {"created_after": "2026-01-01"}) == ("heavy", 4)
     assert tool_cost("query_wandb_tool", {"resource": "runs", "response_mode": "count"}) == ("light", 1)
     assert tool_cost(
         "query_wandb_tool",

--- a/tests/test_infer_schema.py
+++ b/tests/test_infer_schema.py
@@ -181,6 +181,25 @@ class TestInferTraceSchema:
         assert "id" in field_paths
         assert "op_name" in field_paths
 
+    @patch("wandb_mcp_server.mcp_tools.infer_schema.MCP_MAX_SCHEMA_SAMPLE_ROWS", 3)
+    @patch("wandb_mcp_server.mcp_tools.count_traces.count_traces")
+    def test_profile_cap_and_non_exhaustive_scope_are_explicit(self, mock_count):
+        mock_count.side_effect = [10, 4]
+        mock_service = self._make_mock_service([{"id": f"t-{index}"} for index in range(3)])
+
+        with patch("wandb_mcp_server.mcp_tools.query_weave.get_trace_service", return_value=mock_service):
+            result = json.loads(infer_trace_schema("e", "p", sample_size=50))
+
+        scope = result["sample_scope"]
+        assert scope["requested_count"] == 50
+        assert scope["applied_limit"] == 3
+        assert scope["returned_count"] == 3
+        assert scope["total_count"] == 10
+        assert scope["has_more"] is True
+        assert scope["project_exhaustive"] is False
+        assert scope["coverage"] == 0.3
+        assert mock_service.query_traces.call_args.kwargs["limit"] == 3
+
 
 class TestInferSchemaToolDescription:
     def test_has_when_to_use(self):

--- a/tests/test_oom_protection.py
+++ b/tests/test_oom_protection.py
@@ -113,6 +113,7 @@ class TestHostedLimitConfig:
             assert cfg.MCP_MAX_QUERY_LIMIT == 100
             assert cfg.MCP_MAX_FULL_TRACE_LIMIT == 25
             assert cfg.MCP_MAX_HISTORY_SAMPLES == 500
+            assert cfg.MCP_MAX_SCHEMA_SAMPLE_ROWS == 100
         importlib.reload(cfg)
 
     def test_hosted_limits_are_configurable(self):
@@ -140,6 +141,7 @@ class TestHostedLimitConfig:
             assert cfg.MCP_MAX_FULL_DETAIL_ITEMS == 10
             assert cfg.MCP_MAX_HISTORY_SAMPLES == 1_500
             assert cfg.MCP_MAX_HISTORY_KEYS == 50
+            assert cfg.MCP_MAX_SCHEMA_SAMPLE_ROWS == 250
             assert cfg.MCP_ADMISSION_ACTOR_CAPACITY == 8
             assert cfg.MCP_ADMISSION_PROCESS_CAPACITY == 16
         importlib.reload(cfg)
@@ -162,6 +164,7 @@ class TestHostedLimitConfig:
             importlib.reload(cfg)
             assert cfg.MCP_MAX_WANDB_QUERY_ITEMS == 1_000
             assert cfg.MCP_MAX_HISTORY_SAMPLES == 5_000
+            assert cfg.MCP_MAX_SCHEMA_SAMPLE_ROWS == 500
             assert cfg.MCP_ADMISSION_CONTROL_ENABLED is False
         importlib.reload(cfg)
 

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -1,7 +1,10 @@
 """Tests for artifact tools (list_artifact_versions, get_artifact_details, compare_artifact_versions)."""
 
+import asyncio
 import json
 from unittest.mock import MagicMock, PropertyMock, patch
+
+from mcp.server.fastmcp import FastMCP
 
 from wandb_mcp_server.mcp_tools.query_artifacts import (
     COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
@@ -11,6 +14,7 @@ from wandb_mcp_server.mcp_tools.query_artifacts import (
     get_artifact_details,
     list_artifact_versions,
 )
+from wandb_mcp_server.server import register_tools
 
 
 def _make_artifact(**overrides):
@@ -65,6 +69,14 @@ def _make_file(name="model.pt", size=1000000, digest="aaa111"):
 
 
 class TestListArtifactVersions:
+    def test_public_schema_exposes_order_and_filters(self):
+        mcp = FastMCP("artifact-schema")
+        register_tools(mcp)
+        tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+        properties = tools["list_artifact_versions_tool"].inputSchema["properties"]
+        assert {"order", "tags", "created_after", "created_before"} <= properties.keys()
+
     @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
     def test_project_source(self, mock_api_mgr):
         mock_api = MagicMock()
@@ -80,14 +92,18 @@ class TestListArtifactVersions:
         result = json.loads(list_artifact_versions("team/project/my-model", type_name="model", source="project"))
 
         assert result["count"] == 2
+        assert result["returned_count"] == 2
+        assert result["project_exhaustive"] is True
         assert result["source"] == "project"
         assert result["versions"][0]["version"] == "v1"
+        assert mock_api.artifacts.call_args.kwargs["order"] == "-createdAt"
 
     @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
     def test_registry_source(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
         mock_registry = MagicMock()
+        mock_registry.organization = "my-org"
         mock_collections = MagicMock()
         mock_collections.versions.return_value = iter(
             [
@@ -102,6 +118,50 @@ class TestListArtifactVersions:
 
         assert result["count"] == 1
         assert result["source"] == "registry"
+        assert "compatibility_caveat" in result
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_project_filters_order_and_limit_plus_one(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.artifacts.return_value = iter(
+            [
+                _make_artifact(version="v3", tags=["production"], created_at="2025-03-01T00:00:00Z"),
+                _make_artifact(version="v2", tags=["production"], created_at="2025-02-01T00:00:00Z"),
+                _make_artifact(version="v1", tags=["production"], created_at="2025-01-01T00:00:00Z"),
+            ]
+        )
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(
+            list_artifact_versions(
+                "team/project/my-model",
+                type_name="model",
+                max_items=1,
+                order="+version",
+                tags=["production"],
+                created_after="2025-01-15T00:00:00Z",
+            )
+        )
+
+        assert result["returned_count"] == 1
+        assert result["has_more"] is True
+        assert result["project_exhaustive"] is False
+        assert result["items"][0]["version"] == "v3"
+        assert mock_api.artifacts.call_args.kwargs["order"] == "+versionIndex"
+        assert mock_api.artifacts.call_args.kwargs["tags"] == ["production"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_invalid_filters_do_not_construct_api(self, mock_api_mgr):
+        result = json.loads(
+            list_artifact_versions(
+                "team/project/my-model",
+                type_name="model",
+                created_after="not-a-date",
+            )
+        )
+
+        assert result["error"] == "invalid_input"
+        mock_api_mgr.get_api.assert_not_called()
 
     @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
     def test_project_source_requires_type_name(self, mock_api_mgr):

--- a/tests/test_query_registry.py
+++ b/tests/test_query_registry.py
@@ -72,6 +72,7 @@ class TestListRegistries:
         assert call_kwargs["filter"] == filt
 
     @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.query_registry.MCP_MAX_WANDB_QUERY_ITEMS", 200)
     def test_max_items_ceiling(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
@@ -83,6 +84,9 @@ class TestListRegistries:
 
         assert result["count"] == 200
         assert result["truncated"] is True
+        assert result["returned_count"] == 200
+        assert result["total_count"] is None
+        assert result["has_more"] is True
 
     @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
     def test_api_error_returns_json(self, mock_api_mgr):
@@ -129,6 +133,9 @@ class TestListRegistryCollections:
 
         assert result["registry"] == "my-registry"
         assert result["count"] == 2
+        assert result["returned_count"] == 2
+        assert result["total_count"] == 2
+        assert result["project_exhaustive"] is True
         assert result["collections"][0]["name"] == "model-a"
         assert result["collections"][1]["name"] == "model-b"
 

--- a/tests/test_summarize_evaluation.py
+++ b/tests/test_summarize_evaluation.py
@@ -107,8 +107,9 @@ class TestAggregateEval:
 
 
 class TestSummarizeEvaluation:
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", return_value=0)
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
-    def test_no_evals_found(self, mock_get_svc):
+    def test_no_evals_found(self, mock_get_svc, mock_count):
         mock_service = MagicMock()
         mock_get_svc.return_value = mock_service
 
@@ -119,10 +120,13 @@ class TestSummarizeEvaluation:
         result = json.loads(summarize_evaluation("ent", "proj"))
 
         assert result["evaluations"] == []
+        assert result["total_count"] == 0
         assert "No Evaluation.evaluate" in result["message"]
+        mock_count.assert_called_once()
 
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", side_effect=[1, 2])
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
-    def test_with_eval_traces(self, mock_get_svc):
+    def test_with_eval_traces(self, mock_get_svc, mock_count):
         mock_service = MagicMock()
         mock_get_svc.return_value = mock_service
 
@@ -152,10 +156,18 @@ class TestSummarizeEvaluation:
         assert ev["total_predictions"] == 2
         assert ev["errors"] == 1
         assert ev["successes"] == 1
+        assert ev["details_exhaustive"] is True
+        assert ev["coverage"] == 1.0
         assert ev["scores"]["correctness"]["true_fraction"] == 0.9
+        assert mock_count.call_count == 2
+        child_kwargs = mock_service.query_traces.call_args_list[1].kwargs
+        assert child_kwargs["columns"] == ["id", "exception", "summary"]
+        assert child_kwargs["limit"] == 2
+        assert child_kwargs["offset"] == 0
 
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", return_value=1)
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
-    def test_query_failure_returns_error(self, mock_get_svc):
+    def test_query_failure_returns_error(self, mock_get_svc, _mock_count):
         mock_service = MagicMock()
         mock_get_svc.return_value = mock_service
         mock_service.query_traces.side_effect = Exception("Connection refused")
@@ -165,8 +177,9 @@ class TestSummarizeEvaluation:
         assert result["error"] == "evaluation_query_failed"
         assert "Connection refused" in result["message"]
 
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", side_effect=[1, 0])
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
-    def test_project_path_in_response(self, mock_get_svc):
+    def test_project_path_in_response(self, mock_get_svc, _mock_count):
         mock_service = MagicMock()
         mock_get_svc.return_value = mock_service
 
@@ -179,10 +192,38 @@ class TestSummarizeEvaluation:
         }
         eval_result = MagicMock()
         eval_result.traces = [eval_trace]
-        child_result = MagicMock()
-        child_result.traces = []
-        mock_service.query_traces.side_effect = [eval_result, child_result]
+        mock_service.query_traces.return_value = eval_result
 
         result = json.loads(summarize_evaluation("my-team", "my-project"))
 
         assert result["project"] == "my-team/my-project"
+        assert mock_service.query_traces.call_count == 1
+
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.MCP_MAX_EVALUATION_ROWS", 500)
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", side_effect=[1, 750])
+    @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")
+    def test_partial_child_aggregate_is_never_presented_as_exhaustive(
+        self,
+        mock_get_svc,
+        _mock_count,
+    ):
+        mock_service = MagicMock()
+        mock_get_svc.return_value = mock_service
+        eval_result = MagicMock()
+        eval_result.traces = [{"id": "eval-1", "op_name": "Evaluation.evaluate", "summary": {}}]
+        child_result = MagicMock()
+        child_result.traces = [{"summary": {"weave": {"status": "success"}}} for _ in range(100)]
+        mock_service.query_traces.side_effect = [eval_result, *([child_result] * 5)]
+
+        result = json.loads(summarize_evaluation("ent", "proj"))
+        summary = result["evaluations"][0]
+
+        assert summary["total_predictions"] == 750
+        assert summary["observed_predictions"] == 500
+        assert summary["details_exhaustive"] is False
+        assert summary["aggregate_scope"] == "sample"
+        assert summary["coverage"] == 0.6667
+        assert "successes" not in summary
+        assert "errors" not in summary
+        assert mock_service.query_traces.call_args_list[1].kwargs["limit"] == 100
+        assert mock_service.query_traces.call_args_list[-1].kwargs["offset"] == 400

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -12,6 +12,8 @@ from wandb_mcp_server.wandb_selective_reads import (
     PROJECTED_RUN_QUERY,
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
+    REGISTRY_ARTIFACT_VERSIONS_QUERY,
+    fetch_registry_artifact_versions,
     fetch_project_counts,
     fetch_project_fields,
     fetch_metric_value_steps,
@@ -101,6 +103,37 @@ class FakeServiceApi:
             }
         if "MCPMetricValueSteps" in query:
             return {"project": {"run": {"stepsForMetricValues": [42, None]}}}
+        if "MCPRegistryArtifactVersions" in query:
+            return {
+                "organization": {
+                    "orgEntity": {
+                        "artifactMemberships": {
+                            "edges": [
+                                {
+                                    "cursor": "version-1",
+                                    "node": {
+                                        "versionIndex": 7,
+                                        "aliases": [{"alias": "production"}],
+                                        "artifactCollection": {"name": "my-model"},
+                                        "artifact": {
+                                            "id": "artifact-7",
+                                            "state": "COMMITTED",
+                                            "description": "candidate",
+                                            "size": 123,
+                                            "fileCount": 2,
+                                            "createdAt": "2026-01-01T00:00:00Z",
+                                            "updatedAt": "2026-01-02T00:00:00Z",
+                                            "digest": "digest-7",
+                                            "tags": [{"name": "approved"}],
+                                        },
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"endCursor": "version-1", "hasNextPage": False},
+                        }
+                    }
+                }
+            }
         raise AssertionError("unexpected query")
 
 
@@ -117,6 +150,7 @@ def test_every_application_owned_document_is_query_only():
         PROJECT_FIELDS_QUERY,
         ARTIFACT_INVENTORY_QUERY,
         METRIC_VALUE_STEPS_QUERY,
+        REGISTRY_ARTIFACT_VERSIONS_QUERY,
     ):
         validate_read_only_graphql(document)
 
@@ -206,3 +240,38 @@ def test_metric_value_lookup_returns_candidate_steps_for_caller_verification():
     assert "stepsForMetricValues" in query
     assert variables["metric"] == "validation/step"
     assert variables["values"] == [1000.0, 2000.0]
+
+
+def test_registry_artifact_versions_use_fixed_ordered_query():
+    api = FakeApi()
+
+    result = fetch_registry_artifact_versions(
+        api,
+        organization="my-org",
+        registry_name="models",
+        collection_name="my-model",
+        order="-createdAt",
+        scan_limit=10,
+    )
+
+    assert result.requests == 1
+    assert result.has_more is False
+    assert result.items == [
+        {
+            "version": "v7",
+            "name": "my-model",
+            "aliases": ["production"],
+            "tags": ["approved"],
+            "state": "COMMITTED",
+            "size": 123,
+            "file_count": 2,
+            "description": "candidate",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-02T00:00:00Z",
+            "digest": "digest-7",
+        }
+    ]
+    _, variables = api._service_api.calls[0]
+    assert json.loads(variables["registryFilter"]) == {"name": "wandb-registry-models"}
+    assert json.loads(variables["collectionFilter"]) == {"name": "my-model"}
+    assert variables["order"] == "-createdAt"


### PR DESCRIPTION
## Summary

Third PR in the cumulative v0.4.0 query-quality stack. Review and merge after #120 and #121.

- normalizes registry, artifact, and evaluation collection envelopes with `returned_count`, honest `total_count`, `has_more`, `limit`, and exhaustiveness metadata
- adds artifact version ordering, tag/date filters, profile-bounded limit-plus-one pagination, and deadline checks
- uses the W&B 0.28 public artifact SDK where it has parity; registry ordering uses one isolated fixed query-only document, with a bounded SDK fallback for older Dedicated backends
- gives evaluation summaries exact matching child counts, required-column-only detail pages, and explicit coverage so partial aggregates are never presented as exhaustive
- caps trace-schema inference by workload profile and reports sampling strategy, coverage, and exhaustiveness
- documents the `probe_project_tool` → projected `query_wandb_tool` → targeted `get_run_history_tool` workflow
- expands W&B-latest CI coverage to artifact, registry, evaluation, and schema paths

## Stack

1. #120 `codex/projected-wandb-reads`
2. #121 `codex/history-and-analysis-accuracy`
3. this PR

All three intentionally target `staging/0.4.0`; merge with merge commits in that order and refresh the remaining diffs/checks after each merge.

## Validation

- `uv lock --check`
- Ruff check and format check
- Bandit Medium/High scan
- Python 3.11: 909 passed, 10 deselected
- Python 3.12: 909 passed, 10 deselected
- latest W&B SDK: 222 passed, 1 deselected
- focused collection/evaluation/security suite: 101 passed
- wheel build and fresh-install smoke on Python 3.11 and 3.12, with raw GraphQL disabled and opt-in registration checked
- credentialed read-only MCP dispatch: default raw-GraphQL absence, exact run count, project probe, targeted projected run summary, and bounded history all passed under 4 seconds per call

No write operations, `.env` values, customer identifiers, or live response bodies were logged or retained.
