### PR TITLE
security: update GitPython for fixed advisories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "tiktoken>=0.9.0",
     "wandb-workspaces>=0.4.4",
     "requests>=2.34.2",
+    "gitpython>=3.1.55",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -721,14 +721,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.53"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/24/0e0c12cb6f7cb864779a9d2fefee9ca91838f6db402c8780c9d28a8d7ebe/gitpython-3.1.53.tar.gz", hash = "sha256:06ae8d9623b0ed0d67b8adeac5c7008d0a5a404b087a9e0d0c7163bdd3a6b497", size = 224597, upload-time = "2026-07-20T13:41:52.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/a6/bff12b3238885eeef7d28ef908b24e0cba91c476c31cb876a00a0986ce2c/gitpython-3.1.53-py3-none-any.whl", hash = "sha256:187885556b64ab357bd4ea84e2c4cce2861a613a7f4268b3f7f7ba05f2ce4ab0", size = 216237, upload-time = "2026-07-20T13:41:51.473Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]
@@ -2351,6 +2351,7 @@ name = "wandb-mcp-server"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "python-dotenv" },
@@ -2389,6 +2390,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'test'", specifier = ">=0.50.0" },
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.104.0" },
     { name = "fastapi", marker = "extra == 'test'", specifier = ">=0.104.0" },
+    { name = "gitpython", specifier = ">=3.1.55" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "litellm", marker = "extra == 'test'", specifier = ">=1.84.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },


### PR DESCRIPTION
## Summary

- raise the direct GitPython security floor to `>=3.1.55`
- refresh the lock from `gitpython==3.1.53` to `gitpython==3.1.57`

## Why

The refreshed v0.4.0 dependency scan detected four newly published fixable High advisories in GitPython 3.1.53. This focused integration fix prevents the release stack from shipping a version now known to be vulnerable.

## Impact

No MCP behavior or public API changes. GitPython is already a W&B runtime dependency; this PR only enforces and locks a fixed release.

## Validation

- `uv lock --check`
- Ruff check and format check
- Grype `--only-fixed --fail-on high`: no vulnerabilities found
