### PR TITLE
fix: keep v0.4 STDIO output protocol-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, "staging/**"]
   pull_request:
     branches: [main, "staging/**"]
+  schedule:
+    - cron: "17 8 * * 1"
 
 permissions:
   contents: read
@@ -12,6 +14,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -32,12 +35,14 @@ jobs:
         run: uv sync --frozen --extra test --python ${{ matrix.python-version }}
 
       - name: Smoke test package import
-        run: uv run --no-sync python -c "import wandb_mcp_server; print('ok')"
+        run: |
+          uv run --no-sync python -c "import wandb_mcp_server; print('ok')"
+          uv run --no-sync python -c "from importlib.metadata import version; assert version('mcp') == '1.29.0'; print('mcp', version('mcp'))"
 
       - name: Lint with ruff
         run: |
-          uv run --no-sync ruff check src/ tests/
-          uv run --no-sync ruff format --check src/ tests/
+          uv run --no-sync ruff check src/ tests/ scripts/mcp_stdio_smoke.py
+          uv run --no-sync ruff format --check src/ tests/ scripts/mcp_stdio_smoke.py
 
       - name: Run unit tests
         run: uv run --no-sync pytest tests/ -m "not integration" -x -v --tb=short -q
@@ -50,15 +55,22 @@ jobs:
           uv build
           SMOKE_ENV="$RUNNER_TEMP/wandb-mcp-install-smoke"
           uv venv "$SMOKE_ENV" --python ${{ matrix.python-version }}
-          uv pip install --python "$SMOKE_ENV/bin/python" dist/*.whl
+          uv pip install --python "$SMOKE_ENV/bin/python" --refresh-package mcp dist/*.whl
           "$SMOKE_ENV/bin/python" -c "import wandb_mcp_server; print('ok')"
+          "$SMOKE_ENV/bin/python" -c "from importlib.metadata import version; from packaging.version import Version; resolved = Version(version('mcp')); assert Version('1.28.1') <= resolved < Version('2'); print('fresh-wheel mcp', resolved)"
+          "$SMOKE_ENV/bin/python" scripts/mcp_stdio_smoke.py --server-command "$SMOKE_ENV/bin/wandb_mcp_server"
           WANDB_MCP_ENABLE_RAW_GRAPHQL=true "$SMOKE_ENV/bin/python" -c "from mcp.server.fastmcp import FastMCP; from wandb_mcp_server.server import register_tools; mcp = FastMCP('smoke'); register_tools(mcp); assert 'query_wandb_graphql_tool' in mcp._tool_manager._tools; print('raw graphql ok')"
+          uv pip install --python "$SMOKE_ENV/bin/python" "mcp[cli]==1.28.1"
+          uv pip check --python "$SMOKE_ENV/bin/python"
+          "$SMOKE_ENV/bin/python" -c "from importlib.metadata import version; assert version('mcp') == '1.28.1'; print('minimum mcp', version('mcp'))"
+          "$SMOKE_ENV/bin/python" scripts/mcp_stdio_smoke.py --server-command "$SMOKE_ENV/bin/wandb_mcp_server"
         env:
           WANDB_SILENT: "True"
           WEAVE_SILENT: "True"
 
   wandb-latest-compatibility:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -55,6 +55,10 @@ the same evaluation rows.
 The Python package also constrains the MCP SDK to the compatible 1.x API. MCP
 SDK 2.x removes the `mcp.server.fastmcp` module used by this release.
 
+STDIO deployments now force analytics and startup logs to stderr, including
+when `MCP_ANALYTICS_LOG_STREAM=stdout` is set. Standard output remains reserved
+exclusively for MCP JSON-RPC messages.
+
 ### Workload protection
 
 Hosted deployments use weighted admission control at the public tool boundary:
@@ -219,5 +223,7 @@ The release candidate is validated through:
 - Source distribution and wheel builds.
 - Fresh-wheel import and server-construction smoke tests with raw GraphQL both
   disabled and enabled.
+- Installed-wheel STDIO sessions using the official MCP client with MCP 1.28.1
+  and 1.29.0, including Codex, Claude Code, and Cursor client identities.
 
 Managed staging and Helm artifact validation remain separate release gates.

--- a/scripts/mcp_stdio_smoke.py
+++ b/scripts/mcp_stdio_smoke.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Exercise an installed W&B MCP wheel through the real STDIO protocol.
+
+The harness intentionally sets ``MCP_ANALYTICS_LOG_STREAM=stdout`` for one
+session. Any non-JSON-RPC stdout line is surfaced by the official MCP client's
+parser and fails the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import anyio
+from mcp import ClientSession, StdioServerParameters, types
+from mcp.client.stdio import stdio_client
+
+
+_TEST_API_KEY = "k" * 40
+_VIEWER = {
+    "id": "stdio-smoke-user-id",
+    "name": "STDIO Smoke User",
+    "username": "stdio-smoke-user",
+    "email": "stdio-smoke@example.com",
+    "admin": False,
+    "flags": "",
+    "entity": "stdio-smoke-user",
+    "deletedAt": None,
+    "apiKeys": {"edges": []},
+    "teams": {"edges": [{"node": {"name": "stdio-smoke-team"}}]},
+}
+_CLIENTS = (
+    ("codex-mcp-client", "codex", "openai"),
+    ("claude-code", "claude_code", "anthropic"),
+    ("cursor-vscode", "cursor", "cursor"),
+)
+
+
+class _FakeWandBHandler(BaseHTTPRequestHandler):
+    """Return the public SDK viewer shape needed by read-only smoke calls."""
+
+    server_version = "WandBStdioSmoke/1.0"
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        content_length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(content_length)
+        if self.path != "/graphql":
+            self.send_error(404)
+            return
+        payload = json.dumps({"data": {"viewer": _VIEWER}}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+
+class _ProtocolParseCapture(logging.Handler):
+    """Capture malformed server stdout reported by the official MCP client."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.failures: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        message = record.getMessage()
+        if "Failed to parse JSONRPC message from server" in message:
+            self.failures.append(message)
+
+
+def _result_text(result: Any) -> str:
+    return "".join(getattr(item, "text", "") for item in result.content)
+
+
+def _analytics_events(stderr: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line in stderr.splitlines():
+        if not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("event_type"):
+            events.append(payload)
+    return events
+
+
+def _contains_none(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, dict):
+        return any(_contains_none(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_none(item) for item in value)
+    return False
+
+
+def _server_environment(base_url: str, home: str, *, unsafe_stdout_override: bool) -> dict[str, str]:
+    return {
+        "HOME": home,
+        "WANDB_API_KEY": _TEST_API_KEY,
+        "WANDB_BASE_URL": base_url,
+        "WANDB_INTERNAL_BASE_URL": "",
+        "WANDB_SILENT": "True",
+        "WEAVE_SILENT": "True",
+        "MCP_ANALYTICS_DISABLED": "false",
+        "MCP_ANALYTICS_LOG_STREAM": "stdout" if unsafe_stdout_override else "stderr",
+        "MCP_SEGMENT_DRY_RUN": "true",
+        "MCP_SEGMENT_FORWARD": "false",
+        "MCP_DATADOG_FORWARD": "false",
+        "WANDB_MCP_ENABLE_RAW_GRAPHQL": "false",
+        "WANDB_MCP_READ_ONLY": "false",
+    }
+
+
+async def _exercise_profile(
+    server_command: str,
+    base_url: str,
+    *,
+    client_name: str,
+    expected_harness: str,
+    expected_vendor: str,
+    unsafe_stdout_override: bool = False,
+) -> None:
+    parse_capture = _ProtocolParseCapture()
+    protocol_logger = logging.getLogger("mcp.client.stdio")
+    previous_level = protocol_logger.level
+    protocol_logger.addHandler(parse_capture)
+    protocol_logger.setLevel(logging.ERROR)
+
+    with tempfile.TemporaryDirectory(prefix="wandb-mcp-stdio-") as temp_dir:
+        params = StdioServerParameters(
+            command=server_command,
+            env=_server_environment(
+                base_url,
+                temp_dir,
+                unsafe_stdout_override=unsafe_stdout_override,
+            ),
+            cwd=temp_dir,
+        )
+        with tempfile.TemporaryFile(mode="w+") as server_stderr:
+            try:
+                with anyio.fail_after(60):
+                    async with stdio_client(params, errlog=server_stderr) as (read_stream, write_stream):
+                        async with ClientSession(
+                            read_stream,
+                            write_stream,
+                            client_info=types.Implementation(name=client_name, version="stdio-smoke"),
+                        ) as session:
+                            await session.initialize()
+                            await session.send_ping()
+
+                            listed = await session.list_tools()
+                            tools_by_name = {tool.name: tool for tool in listed.tools}
+                            assert "list_entities_tool" in tools_by_name
+                            assert "query_wandb_tool" in tools_by_name
+                            assert "query_wandb_graphql_tool" not in tools_by_name
+
+                            query_schema = tools_by_name["query_wandb_tool"].inputSchema
+                            query_properties = query_schema["properties"]
+                            assert "resource" in query_properties
+                            assert "query" not in query_properties
+
+                            entity_result = await session.call_tool("list_entities_tool", {})
+                            assert entity_result.isError is False
+                            entity_payload = json.loads(_result_text(entity_result))
+                            assert entity_payload == {
+                                "entities": [
+                                    {"name": "stdio-smoke-user", "type": "user"},
+                                    {"name": "stdio-smoke-team", "type": "team"},
+                                ],
+                                "count": 2,
+                            }
+
+                            invalid_result = await session.call_tool(
+                                "query_wandb_tool",
+                                {
+                                    "entity_name": "test-entity",
+                                    "project_name": "test-project",
+                                    "resource": "run",
+                                },
+                            )
+                            invalid_payload = json.loads(_result_text(invalid_result))
+                            assert invalid_payload["error"] == "invalid_request"
+
+                            unknown_result = await session.call_tool("not_a_real_tool", {})
+                            assert unknown_result.isError is True
+                            assert "Unknown tool" in _result_text(unknown_result)
+
+                            # Prove structured tool failures do not poison the session.
+                            await session.send_ping()
+            finally:
+                protocol_logger.removeHandler(parse_capture)
+                protocol_logger.setLevel(previous_level)
+
+            server_stderr.seek(0)
+            stderr = server_stderr.read()
+
+    assert parse_capture.failures == [], parse_capture.failures
+    assert stderr.count("Analytics ready:") == 1
+    assert _TEST_API_KEY not in stderr
+
+    matching_events = [
+        event
+        for event in _analytics_events(stderr)
+        if event.get("event_type") == "tool_call" and event.get("tool_name") == "list_entities_tool"
+    ]
+    assert len(matching_events) == 1
+    event = matching_events[0]
+    assert event["agent_harness"] == expected_harness
+    assert event["client_vendor"] == expected_vendor
+    assert event["call_type"] == "tools/call"
+    assert event["transport"] == "stdio"
+    assert event["success"] is True
+    assert not _contains_none(event)
+
+
+async def _exercise_missing_credentials(server_command: str, base_url: str) -> None:
+    parse_capture = _ProtocolParseCapture()
+    protocol_logger = logging.getLogger("mcp.client.stdio")
+    previous_level = protocol_logger.level
+    protocol_logger.addHandler(parse_capture)
+    protocol_logger.setLevel(logging.ERROR)
+
+    with tempfile.TemporaryDirectory(prefix="wandb-mcp-stdio-no-key-") as temp_dir:
+        environment = _server_environment(base_url, temp_dir, unsafe_stdout_override=True)
+        environment["WANDB_API_KEY"] = ""
+        params = StdioServerParameters(
+            command=server_command,
+            env=environment,
+            cwd=temp_dir,
+        )
+        failed_as_expected = False
+        with tempfile.TemporaryFile(mode="w+") as server_stderr:
+            try:
+                with anyio.fail_after(15):
+                    async with stdio_client(params, errlog=server_stderr) as (read_stream, write_stream):
+                        async with ClientSession(read_stream, write_stream) as session:
+                            await session.initialize()
+            except Exception:
+                failed_as_expected = True
+            finally:
+                protocol_logger.removeHandler(parse_capture)
+                protocol_logger.setLevel(previous_level)
+
+            server_stderr.seek(0)
+            stderr = server_stderr.read()
+
+    assert failed_as_expected, "STDIO unexpectedly started without WANDB_API_KEY"
+    assert parse_capture.failures == [], parse_capture.failures
+    assert "WANDB_API_KEY must be set for STDIO transport" in stderr
+    assert _TEST_API_KEY not in stderr
+
+
+async def _run(server_command: str) -> None:
+    fake_wandb = ThreadingHTTPServer(("127.0.0.1", 0), _FakeWandBHandler)
+    thread = threading.Thread(target=fake_wandb.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{fake_wandb.server_port}"
+    try:
+        for client_name, expected_harness, expected_vendor in _CLIENTS:
+            await _exercise_profile(
+                server_command,
+                base_url,
+                client_name=client_name,
+                expected_harness=expected_harness,
+                expected_vendor=expected_vendor,
+            )
+        await _exercise_profile(
+            server_command,
+            base_url,
+            client_name="codex-mcp-client",
+            expected_harness="codex",
+            expected_vendor="openai",
+            unsafe_stdout_override=True,
+        )
+        await _exercise_missing_credentials(server_command, base_url)
+    finally:
+        fake_wandb.shutdown()
+        fake_wandb.server_close()
+        thread.join(timeout=5)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--server-command",
+        required=True,
+        help="Path to the installed wandb_mcp_server console entrypoint.",
+    )
+    args = parser.parse_args()
+    server_command = str(Path(args.server_command).resolve())
+    if not Path(server_command).is_file():
+        parser.error(f"Server command does not exist: {server_command}")
+    anyio.run(_run, server_command)
+    print("STDIO protocol smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -48,6 +48,7 @@ _DEFAULT_REQUEST_SUCCESS_SAMPLE_RATE = 0.10
 _SLOW_REQUEST_MS = 2_000.0
 
 _configured_transport: Optional[str] = None
+_analytics_startup_logged = False
 
 _USAGE_ENUM_VALUES: Dict[str, frozenset[str]] = {
     "resource": frozenset({"project", "run", "runs", "sweep", "sweeps", "reports"}),
@@ -278,22 +279,33 @@ def configure_analytics_logging(stream: Optional[str] = None) -> str:
 
 def configure_analytics_logging_for_transport(transport: str) -> str:
     """Configure analytics output for an MCP transport."""
-    if os.environ.get("MCP_ANALYTICS_LOG_STREAM"):
-        return configure_analytics_logging()
-    if transport == "stdio":
-        return configure_analytics_logging(_ANALYTICS_STREAM_STDERR)
-    return configure_analytics_logging(_ANALYTICS_STREAM_STDOUT)
+    normalized = transport.strip().lower()
+    if normalized == "stdio":
+        # STDIO stdout is the JSON-RPC wire. An environment override must never
+        # be allowed to inject analytics records into the protocol stream.
+        stream_name = configure_analytics_logging(_ANALYTICS_STREAM_STDERR)
+    elif os.environ.get("MCP_ANALYTICS_LOG_STREAM"):
+        stream_name = configure_analytics_logging()
+    else:
+        stream_name = configure_analytics_logging(_ANALYTICS_STREAM_STDOUT)
+    _log_analytics_startup_once()
+    return stream_name
 
 
-configure_analytics_logging()
+def _log_analytics_startup_once() -> None:
+    """Log analytics/privacy configuration after the transport is known."""
+    global _analytics_startup_logged
+    if _analytics_startup_logged:
+        return
+    _analytics_startup_logged = True
+    logger.info("Analytics ready: MCP_LOG_PRIVACY_LEVEL=%s", _resolve_privacy_level())
+
+
+# Before construction selects a transport, stderr is the only protocol-safe
+# destination. HTTP construction switches analytics back to stdout below.
+configure_analytics_logging(_ANALYTICS_STREAM_STDERR)
 
 _REQUIRED_BASE_FIELDS = frozenset({"schema_version", "event_type", "timestamp"})
-
-# Surface the active privacy level once at module import so operators can
-# verify their config by grepping pod logs (instead of needing kubectl describe).
-# Triggers _resolve_privacy_level()'s WARNING for invalid values, so an env-var
-# typo also lights up here at startup.
-logger.info("Analytics ready: MCP_LOG_PRIVACY_LEVEL=%s", _resolve_privacy_level())
 
 
 def _resolve_release_version() -> str:
@@ -341,6 +353,7 @@ def configure_analytics_runtime(transport: str) -> None:
     global _configured_transport
     normalized = transport.strip().lower()
     _configured_transport = "http" if normalized == "streamable-http" else normalized
+    configure_analytics_logging_for_transport(_configured_transport)
 
 
 def _safe_wandb_base_host() -> Optional[str]:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -1330,10 +1330,6 @@ def cli():
 
     args = simple_parsing.parse(ServerMCPArgs)
 
-    from wandb_mcp_server.analytics import configure_analytics_logging_for_transport
-
-    configure_analytics_logging_for_transport(args.transport)
-
     # Configure W&B logging behavior
     configure_wandb_logging()
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
+import wandb_mcp_server.analytics as analytics_module
 from wandb_mcp_server.analytics import (
     SCHEMA_VERSION,
     AnalyticsTracker,
@@ -20,6 +21,7 @@ from wandb_mcp_server.analytics import (
     analytics_logger,
     configure_analytics_logging,
     configure_analytics_logging_for_transport,
+    configure_analytics_runtime,
     get_analytics_tracker,
     reset_analytics_tracker,
 )
@@ -29,6 +31,7 @@ from wandb_mcp_server.harness import HarnessContext, current_harness_context
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch):
     monkeypatch.setenv("MCP_REQUEST_SUCCESS_SAMPLE_RATE", "1")
+    monkeypatch.setattr(analytics_module, "_analytics_startup_logged", False)
     reset_analytics_tracker()
     configure_analytics_logging("stdout")
     yield
@@ -155,22 +158,51 @@ class TestAnalyticsLogStream:
         assert "ANALYTICS_EVENT" in stdout.getvalue()
         assert stderr.getvalue() == ""
 
-    def test_explicit_stream_env_overrides_transport(self, monkeypatch):
+    def test_stdio_ignores_unsafe_stdout_override(self, monkeypatch):
         stdout = io.StringIO()
         stderr = io.StringIO()
         monkeypatch.setattr("sys.stdout", stdout)
         monkeypatch.setattr("sys.stderr", stderr)
         monkeypatch.setenv("MCP_ANALYTICS_LOG_STREAM", "stdout")
 
-        assert configure_analytics_logging_for_transport("stdio") == "stdout"
+        assert configure_analytics_logging_for_transport("stdio") == "stderr"
         AnalyticsTracker(enabled=True).track_tool_call(
             tool_name="query_wandb_tool",
             session_id="s",
             viewer_info="viewer",
         )
 
-        assert "ANALYTICS_EVENT" in stdout.getvalue()
-        assert stderr.getvalue() == ""
+        assert stdout.getvalue() == ""
+        assert "ANALYTICS_EVENT" in stderr.getvalue()
+
+    def test_http_honors_explicit_stderr_override(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+        monkeypatch.setenv("MCP_ANALYTICS_LOG_STREAM", "stderr")
+
+        assert configure_analytics_logging_for_transport("http") == "stderr"
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="query_wandb_tool",
+            session_id="s",
+            viewer_info="viewer",
+        )
+
+        assert stdout.getvalue() == ""
+        assert "ANALYTICS_EVENT" in stderr.getvalue()
+
+    def test_runtime_selects_stream_before_startup_log_and_logs_once(self, monkeypatch):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout)
+        monkeypatch.setattr("sys.stderr", stderr)
+
+        configure_analytics_runtime("stdio")
+        configure_analytics_runtime("stdio")
+
+        assert stdout.getvalue() == ""
+        assert stderr.getvalue().count("Analytics ready") == 1
 
     def test_reconfiguration_replaces_handler_instead_of_duplicating(self, monkeypatch):
         stdout = io.StringIO()

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 
 import simple_parsing
 
-from wandb_mcp_server import analytics
 from wandb_mcp_server import server
 
 
@@ -14,8 +13,7 @@ class _DummyMCPServer:
         self.run_transport = transport
 
 
-def test_cli_configures_analytics_for_stdio_transport(monkeypatch):
-    calls = []
+def test_cli_runs_stdio_transport(monkeypatch):
     dummy_server = _DummyMCPServer()
 
     monkeypatch.setattr(
@@ -28,11 +26,6 @@ def test_cli_configures_analytics_for_stdio_transport(monkeypatch):
             wandb_api_key=None,
         ),
     )
-    monkeypatch.setattr(
-        analytics,
-        "configure_analytics_logging_for_transport",
-        lambda transport: calls.append(transport) or "stderr",
-    )
     monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
     monkeypatch.setattr(server, "validate_and_get_api_key", lambda args: None)
     monkeypatch.setattr(server, "initialize_weave_tracing", lambda: False)
@@ -40,5 +33,4 @@ def test_cli_configures_analytics_for_stdio_transport(monkeypatch):
 
     server.cli()
 
-    assert calls == ["stdio"]
     assert dummy_server.run_transport == "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -1097,7 +1097,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1115,9 +1115,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- reserve STDIO stdout exclusively for MCP JSON-RPC, including when `MCP_ANALYTICS_LOG_STREAM=stdout` is set
- select the analytics stream at the shared server-construction boundary and emit the startup/privacy record once afterward
- lock the compatible MCP v1 line at 1.29.0 while retaining the supported 1.28.1 floor
- add an installed-wheel protocol harness using the official MCP client for Codex, Claude Code, and Cursor identities

## Root cause

`analytics.py` configured its structured logger for stdout and emitted its startup record at module import, before the server knew whether it was using HTTP or STDIO. The analytics logger and module logger are the same logger, so that record could enter the STDIO JSON-RPC stream. The previous transport helper also allowed an environment override to force STDIO analytics back to stdout.

## Harness coverage

The new harness starts the installed `wandb_mcp_server` console script and exercises:

- initialize, ping, tools/list, and clean shutdown
- a successful `list_entities_tool` call through a local fake W&B GraphQL endpoint
- the structured `invalid_request` path and unknown-tool error recovery
- missing STDIO credentials
- Codex/OpenAI, Claude Code/Anthropic, and Cursor/Cursor telemetry attribution
- an adversarial `MCP_ANALYTICS_LOG_STREAM=stdout` setting
- MCP 1.28.1 and freshly resolved MCP 1.x compatibility

It fails on any `mcp.client.stdio` JSON-RPC parse error, so a client that merely recovers from malformed stdout cannot produce a false pass.

## Validation

- `915 passed, 10 deselected` — full non-integration suite
- Ruff check and format check passed
- Bandit Medium/High scan passed
- clean repository Grype scan: no fixable High/Critical vulnerabilities
- `uv lock --check` passed
- fresh Python 3.12 wheel: MCP 1.29.0 protocol harness passed
- same wheel forced to MCP 1.28.1: dependency check and protocol harness passed

This PR targets `staging/0.4.0`. It does not merge or publish v0.4.0.
