### PR TITLE
fix: harden v0.4 W&B query compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ deployment settings, and the complete customer-visible summary.
 | **query_weave_traces_tool** | Analyze LLM traces with `detail_level` control | *"Show failed traces with full data"* |
 | **count_weave_traces_tool** | Count traces and get storage metrics | *"How many traces failed?"* |
 | **resolve_trace_roots_tool** | Resolve spans to their root traces | *"Find the root traces for these calls"* |
-| **query_wandb_tool** | Query projects, runs, sweeps, and reports through the W&B SDK | *"Show me runs with loss < 0.1"* |
+| **query_wandb_tool** | Query projects, runs, sweeps, and reports through bounded W&B read APIs | *"Show me runs with loss < 0.1"* |
 | **probe_project_tool** | Discover useful project fields and bounded samples | *"What metrics and config fields are available?"* |
 | **get_run_history_tool** | Sampled time-series metric data | *"Show loss curve for run abc123"* |
 | **compare_runs_tool** | Compare selected metrics and configuration across runs | *"Compare these three training runs"* |
@@ -82,13 +82,17 @@ deployment settings, and the complete customer-visible summary.
 
 **Read-only deployment mode:** Set `WANDB_MCP_READ_ONLY=true` to omit the two write tools,
 `create_wandb_report_tool` and `log_analysis_to_wandb`, while keeping every existing read tool.
-`query_wandb_tool` uses read-only public SDK operations in every mode, regardless of this setting.
+`query_wandb_tool` is read-only in every mode. It normally uses documented W&B
+APIs and may use fixed, application-owned query-only projections to avoid
+per-result fan-out; callers cannot supply GraphQL to this tool.
 
 **Advanced raw GraphQL:** Raw GraphQL is not registered by default. Set
 `WANDB_MCP_ENABLE_RAW_GRAPHQL=true` to add the query-only `query_wandb_graphql_tool`
 for schema introspection, unmodeled fields, cross-resource nesting, aliases, or exact
-response shapes that the public SDK cannot represent. Mutations and subscriptions are
-always rejected, and this flag is independent of `WANDB_MCP_READ_ONLY`.
+response shapes that the typed tool cannot represent. It accepts exactly one bounded
+query operation; mutations and subscriptions are always rejected. This flag is
+independent of `WANDB_MCP_READ_ONLY`. See the
+[query capability matrix](docs/query-capabilities.md).
 
 **Migration from v0.3.7:** `query_wandb_tool` now accepts structured SDK parameters
 (`entity_name`, `project_name`, `resource`, filters, ordering, and identifiers) instead
@@ -588,6 +592,9 @@ When running the server locally, you can customize its behavior with command lin
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
 | `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS` | Enable Weave Agents (OTel/GenAI) tools (default: `false`) | No |
 | `WANDB_MCP_READ_ONLY` | Omit report creation and analysis logging write tools (default: `false`) | No |
+| `WANDB_MCP_ENABLE_RAW_GRAPHQL` | Register the bounded query-only GraphQL compatibility tool (default: `false`) | No |
+| `MCP_MAX_GQL_ITEMS` | Maximum items returned by the opt-in raw GraphQL tool (profile default) | No |
+| `MCP_MAX_GQL_ITEMS_PER_PAGE` | Maximum raw GraphQL connection page size (profile default) | No |
 | `MCP_HOSTED_MODE` | Marks an HTTP deployment as hosted; defaults the workload profile to `shared` | No |
 | `MCP_WORKLOAD_PROFILE` | Bounded defaults for `shared`, `dedicated`, or `local` workloads (default: `shared` when hosted, otherwise `local`) | No |
 | `MCP_ADMISSION_CONTROL_ENABLED` | Enable actor-aware weighted tool admission (default: enabled except for the `local` profile) | No |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ query operation; mutations and subscriptions are always rejected. This flag is
 independent of `WANDB_MCP_READ_ONLY`. See the
 [query capability matrix](docs/query-capabilities.md).
 
+Recommended deployment presets:
+
+| Deployment | Settings |
+|---|---|
+| Hosted production | `WANDB_MCP_READ_ONLY=false`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false`, `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=false` |
+| Strict customer read-only | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false` |
+| Trusted read-only compatibility | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=true`, `MCP_MAX_GQL_ITEMS=50`, `MCP_MAX_GQL_ITEMS_PER_PAGE=20` |
+
 **Migration from v0.3.7:** `query_wandb_tool` now accepts structured SDK parameters
 (`entity_name`, `project_name`, `resource`, filters, ordering, and identifiers) instead
 of a GraphQL document. Existing raw-query callers must explicitly enable and call

--- a/docs/query-capabilities.md
+++ b/docs/query-capabilities.md
@@ -1,0 +1,31 @@
+# W&B Query Capability Matrix
+
+W&B MCP v0.4 does not expose caller-supplied GraphQL by default. Start with the
+typed read tools below. An administrator can enable
+`WANDB_MCP_ENABLE_RAW_GRAPHQL=true` only for read shapes the typed tools cannot
+represent.
+
+| Read requirement | Preferred MCP tool | Raw GraphQL needed? |
+|---|---|---|
+| Entity and project discovery | `list_entities_tool`, `query_wandb_entity_projects` | No |
+| Project metadata | `query_wandb_tool(resource="project")` | No |
+| Run by short ID | `query_wandb_tool(resource="run", run_id=...)` | No |
+| Run by display name | `query_wandb_tool(resource="runs", filters={"displayName": ...})` | No |
+| Filtered/sorted runs | `query_wandb_tool(resource="runs", filters=..., order=...)` | No |
+| Selected or bounded full summary/config | `query_wandb_tool` with `summary_keys`, `config_keys`, or `include` | No |
+| Run count | `query_wandb_tool(resource="runs", response_mode="count")` | No |
+| Sweep lookup/list/config | `query_wandb_tool(resource="sweep"|"sweeps")` | No |
+| Report lookup/list/spec | `query_wandb_tool(resource="reports")` | No |
+| Run metric history | `get_run_history_tool` | No |
+| Artifacts and registries | Artifact and registry tools | No |
+| Automations and integrations | Automation and integration tools | No |
+| Schema introspection or unmodeled/custom fields | `query_wandb_graphql_tool` | Yes |
+| Aliases or exact GraphQL response shape | `query_wandb_graphql_tool` | Yes |
+| Cross-resource/compound nesting | `query_wandb_graphql_tool` | Yes |
+| Sweep agents, report run sets, or Launch resources | `query_wandb_graphql_tool` | Yes |
+| Backward pagination | Use a typed forward read when possible | Compatibility-only; raw tool returns one bounded `last` page |
+
+The compatibility tool accepts exactly one query operation and rejects
+mutations, subscriptions, mixed/multiple operations, nested or multiple
+paginated connections, and oversized documents. Its item, page, complexity, and
+response limits apply in every deployment.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -140,6 +140,14 @@ WANDB_MCP_READ_ONLY=true
 This omits `create_wandb_report_tool` and `log_analysis_to_wandb`. It is
 independent of the raw-GraphQL flag.
 
+Use these reviewed presets:
+
+| Deployment | Settings |
+|---|---|
+| Hosted production | `WANDB_MCP_READ_ONLY=false`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false`, `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS=false` |
+| Strict customer read-only | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false` |
+| Trusted read-only compatibility | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=true`, `MCP_MAX_GQL_ITEMS=50`, `MCP_MAX_GQL_ITEMS_PER_PAGE=20` |
+
 ### Telemetry quality and privacy
 
 Telemetry now:

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -13,20 +13,24 @@ completed staging validation.
 
 ### SDK-first W&B queries
 
-`query_wandb_tool` now reads projects, runs, sweeps, and reports through the
-public W&B SDK. The default server does not expose caller-supplied raw GraphQL.
+`query_wandb_tool` now reads projects, runs, sweeps, and reports through bounded
+W&B read APIs. The default server does not expose caller-supplied raw GraphQL.
+Fixed application-owned query-only projections are used where they avoid SDK
+fan-out or select only the requested fields.
 
 Run collections return core metadata by default. Callers can request:
 
 - `summary_keys` for specific summary metrics.
 - `config_keys` for specific configuration values.
 - Full `summary`, `config`, `system_metrics`, or related details for bounded
-  result sets.
+  result sets, subject to the response budget.
+- `cursor` continuation for collection reads that return `next_cursor`.
 - `response_mode="count"` for an exact server-side run count.
 
-Individual run lookups still support complete run details. Collection-wide full
-detail is intentionally limited because loading every field from many wide runs
-can degrade the W&B application for other users.
+Individual run lookups support the modeled run fields plus requested details.
+History, files, and artifacts remain separate bounded reads. Collection-wide
+full detail is intentionally limited because loading every field from many wide
+runs can degrade the W&B application for other users.
 
 ### Explicit scope and accuracy
 
@@ -186,7 +190,8 @@ query_wandb_tool(
   include?,
   summary_keys?,
   config_keys?,
-  response_mode?
+  response_mode?,
+  cursor?
 )
 ```
 
@@ -194,6 +199,7 @@ Use the existing specialized tools for entity/project discovery, run history,
 artifacts, registries, automations, and integrations. If a required response
 shape has no SDK equivalent, an administrator may enable the query-only raw
 GraphQL escape hatch and the caller must use `query_wandb_graphql_tool`.
+See the [query capability matrix](../query-capabilities.md) for exact routing.
 
 ## Operator settings
 

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import math
+import re
 from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
@@ -23,6 +26,7 @@ from wandb_mcp_server.config import (
     structured_error,
 )
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.trace_utils import count_tokens_conservative
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_selective_reads import (
     SelectiveReadUnavailable,
@@ -125,10 +129,125 @@ _JSON_MAX_MAPPING_KEYS = 500
 _JSON_MAX_LIST_ITEMS = 500
 _JSON_MAX_STRING_CHARS = 16_000
 _SDK_RUN_CACHE_LOCK = threading.Lock()
+_SDK_CURSOR_PREFIX = "mcp-sdk-v1:"
+_MAX_SDK_FALLBACK_REQUESTS = 10
+_MAX_TYPED_INPUT_BYTES = 64 * 1024
+_MAX_CURSOR_BYTES = 4 * 1024
+_MAX_IDENTIFIER_BYTES = 1024
+_MAX_ENUM_BYTES = 64
+_MAX_FILTER_DEPTH = 12
 
 
 class WandBQueryValidationError(ValueError):
     """Raised before any W&B client is obtained for an invalid request."""
+
+
+def _sdk_cursor_fingerprint(
+    *,
+    entity_name: str,
+    project_name: str,
+    resource: str,
+    filters: Optional[Dict[str, Any]],
+    order: str,
+    report_name: Optional[str],
+    include: frozenset[str],
+    summary_keys: Optional[List[str]],
+    config_keys: Optional[List[str]],
+) -> str:
+    """Bind compatibility offsets to the collection query that created them."""
+    canonical = json.dumps(
+        {
+            "entity": entity_name,
+            "project": project_name,
+            "resource": resource,
+            "filters": filters,
+            "order": order,
+            "report_name": report_name,
+            "include": sorted(include),
+            "summary_keys": sorted(summary_keys or ()),
+            "config_keys": sorted(config_keys or ()),
+        },
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:24]
+
+
+def _encode_sdk_cursor(resource: str, offset: int, fingerprint: str) -> str:
+    payload = json.dumps(
+        {"resource": resource, "offset": offset, "query": fingerprint},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return _SDK_CURSOR_PREFIX + base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+
+def _decode_sdk_cursor(cursor: Optional[str], resource: str, fingerprint: str) -> Optional[int]:
+    if cursor is None or not cursor.startswith(_SDK_CURSOR_PREFIX):
+        return None
+    encoded = cursor.removeprefix(_SDK_CURSOR_PREFIX)
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded + padding))
+        offset = payload["offset"]
+        cursor_resource = payload["resource"]
+        cursor_fingerprint = payload["query"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        raise WandBQueryValidationError("cursor is not a valid MCP SDK continuation") from None
+    if cursor_resource != resource or isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+        raise WandBQueryValidationError("cursor is not valid for this collection resource")
+    if cursor_fingerprint != fingerprint:
+        raise WandBQueryValidationError("cursor does not match this collection query")
+    return offset
+
+
+def _validate_text_bound(name: str, value: str, maximum_bytes: int) -> None:
+    if len(value.encode("utf-8")) > maximum_bytes:
+        raise WandBQueryValidationError(f"{name} exceeds the {maximum_bytes}-byte limit")
+
+
+def _validate_filter_shape(value: Any, *, depth: int = 0) -> None:
+    if depth > _MAX_FILTER_DEPTH:
+        raise WandBQueryValidationError(f"filters exceed the maximum depth of {_MAX_FILTER_DEPTH}")
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise WandBQueryValidationError("filters must use string keys")
+            _validate_filter_shape(child, depth=depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        for child in value:
+            _validate_filter_shape(child, depth=depth + 1)
+        return
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float) and math.isfinite(value):
+        return
+    raise WandBQueryValidationError("filters must contain finite JSON-compatible values")
+
+
+def _validate_filter_bound(filters: Optional[Dict[str, Any]]) -> None:
+    if filters is None:
+        return
+    _validate_filter_shape(filters)
+    try:
+        encoded = json.dumps(filters, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        raise WandBQueryValidationError("filters must contain finite JSON-compatible values") from None
+    if len(encoded) > _MAX_TYPED_INPUT_BYTES:
+        raise WandBQueryValidationError(f"filters exceed the {_MAX_TYPED_INPUT_BYTES}-byte limit")
+
+
+def _validate_sdk_fallback_window(offset: int, applied_limit: int) -> None:
+    page_size = min(applied_limit, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE)
+    requests = math.ceil((offset + applied_limit + 1) / max(1, page_size))
+    if requests > _MAX_SDK_FALLBACK_REQUESTS:
+        raise WandBQueryValidationError(
+            "cursor exceeds the bounded SDK compatibility window; restart the query "
+            "or use a backend that supports projected continuation"
+        )
 
 
 def _json_safe(
@@ -156,49 +275,78 @@ def _json_safe(
         return {"_truncated": "cycle"}
     seen.add(value_id)
     try:
-        scalar_item = getattr(value, "item", None)
-        if callable(scalar_item):
-            return _json_safe(scalar_item(), _depth=_depth + 1, _seen=seen)
-    except (TypeError, ValueError, OverflowError):
-        pass
-    if isinstance(value, Mapping):
-        result = {
-            str(key): _json_safe(item, _depth=_depth + 1, _seen=seen)
-            for key, item in islice(value.items(), _JSON_MAX_MAPPING_KEYS)
-        }
-        try:
-            mapping_length = len(value)
-        except TypeError:
-            mapping_length = len(result)
-        if mapping_length > _JSON_MAX_MAPPING_KEYS:
-            result["_truncated_keys"] = mapping_length - _JSON_MAX_MAPPING_KEYS
-        return result
-    if isinstance(value, (list, tuple, set, frozenset)):
-        values = list(islice(iter(value), _JSON_MAX_LIST_ITEMS + 1))
-        result = [_json_safe(item, _depth=_depth + 1, _seen=seen) for item in values[:_JSON_MAX_LIST_ITEMS]]
-        if len(values) > _JSON_MAX_LIST_ITEMS:
+        if isinstance(value, Mapping):
+            result = {
+                str(key): _json_safe(item, _depth=_depth + 1, _seen=seen)
+                for key, item in islice(value.items(), _JSON_MAX_MAPPING_KEYS)
+            }
             try:
-                omitted = len(value) - _JSON_MAX_LIST_ITEMS
+                mapping_length = len(value)
             except TypeError:
-                omitted = 1
-            result.append({"_truncated_items": omitted})
-        return result
-    try:
-        mapping = dict(value)
-    except (TypeError, ValueError):
-        rendered = str(value)
-        return rendered if len(rendered) <= _JSON_MAX_STRING_CHARS else rendered[:_JSON_MAX_STRING_CHARS] + "…"
-    return _json_safe(mapping, _depth=_depth + 1, _seen=seen)
+                mapping_length = len(result)
+            if mapping_length > _JSON_MAX_MAPPING_KEYS:
+                result["_truncated_keys"] = mapping_length - _JSON_MAX_MAPPING_KEYS
+            return result
+        # W&B 0.28 HTTPSummary is a bounded dict-like public SDK object but is
+        # not a collections.abc.Mapping. Inspect methods on the type so its
+        # __getattr__ does not turn probes such as ``value.item`` into KeyError.
+        items_method = getattr(type(value), "items", None)
+        if callable(items_method):
+            try:
+                pairs = list(islice(items_method(value), _JSON_MAX_MAPPING_KEYS + 1))
+            except (KeyError, TypeError, ValueError, OverflowError):
+                pairs = []
+            if pairs:
+                result = {
+                    str(key): _json_safe(item, _depth=_depth + 1, _seen=seen)
+                    for key, item in pairs[:_JSON_MAX_MAPPING_KEYS]
+                }
+                if len(pairs) > _JSON_MAX_MAPPING_KEYS:
+                    result["_truncated_keys"] = len(pairs) - _JSON_MAX_MAPPING_KEYS
+                return result
+        try:
+            scalar_item = getattr(type(value), "item", None)
+            if callable(scalar_item):
+                return _json_safe(scalar_item(value), _depth=_depth + 1, _seen=seen)
+        except (KeyError, TypeError, ValueError, OverflowError):
+            pass
+        if isinstance(value, (list, tuple, set, frozenset)):
+            values = list(islice(iter(value), _JSON_MAX_LIST_ITEMS + 1))
+            result = [_json_safe(item, _depth=_depth + 1, _seen=seen) for item in values[:_JSON_MAX_LIST_ITEMS]]
+            if len(values) > _JSON_MAX_LIST_ITEMS:
+                try:
+                    omitted = len(value) - _JSON_MAX_LIST_ITEMS
+                except TypeError:
+                    omitted = 1
+                result.append({"_truncated_items": omitted})
+            return result
+        try:
+            mapping = dict(value)
+        except (TypeError, ValueError):
+            rendered = str(value)
+            return rendered if len(rendered) <= _JSON_MAX_STRING_CHARS else rendered[:_JSON_MAX_STRING_CHARS] + "…"
+        return _json_safe(mapping, _depth=_depth + 1, _seen=seen)
+    finally:
+        seen.discard(value_id)
 
 
-def _serialize_user(user: Any) -> Any:
-    if user is None or isinstance(user, (str, int, float, bool, Mapping)):
+def _serialize_user(user: Any, *, include_email: bool = True) -> Any:
+    if user is None or isinstance(user, (str, int, float, bool)):
         return _json_safe(user)
+    if isinstance(user, Mapping):
+        data: dict[str, Any] = {
+            "username": user.get("username"),
+            "name": user.get("name"),
+        }
+        if include_email:
+            data["email"] = user.get("email")
+        return {key: _json_safe(value) for key, value in data.items() if value is not None}
     data = {
         "username": getattr(user, "username", None),
         "name": getattr(user, "name", None),
-        "email": getattr(user, "email", None),
     }
+    if include_email:
+        data["email"] = getattr(user, "email", None)
     return {key: _json_safe(value) for key, value in data.items() if value is not None}
 
 
@@ -229,9 +377,14 @@ def _serialize_sweep(sweep: Any, include: frozenset[str]) -> Dict[str, Any]:
         "id": _json_safe(getattr(sweep, "id", None)),
         "name": _json_safe(getattr(sweep, "name", None)),
         "state": _json_safe(getattr(sweep, "state", None)),
+        "method": _json_safe(getattr(sweep, "method", None)),
+        "description": _json_safe(getattr(sweep, "description", None)),
         "entity": _json_safe(entity),
         "project": _json_safe(project),
         "expected_run_count": _json_safe(getattr(sweep, "expected_run_count", None)),
+        "run_count": _json_safe(getattr(sweep, "run_count", None)),
+        "created_at": _json_safe(getattr(sweep, "created_at", None)),
+        "updated_at": _json_safe(getattr(sweep, "updated_at", None)),
         "url": publicize_wandb_url(
             getattr(sweep, "url", None),
             fallback_segments=(entity, project, "sweeps", sweep_id),
@@ -240,6 +393,17 @@ def _serialize_sweep(sweep: Any, include: frozenset[str]) -> Dict[str, Any]:
     if "config" in include:
         result["config"] = _json_safe(getattr(sweep, "config", {}))
     return result
+
+
+def _serialize_sweep_reference(sweep: Any, *, entity: Any, project: Any) -> Dict[str, Any]:
+    sweep_id = getattr(sweep, "id", None) or getattr(sweep, "name", None)
+    return {
+        "id": _json_safe(sweep_id),
+        "name": _json_safe(sweep_id),
+        "entity": _json_safe(entity),
+        "project": _json_safe(project),
+        "url": public_wandb_url(entity, project, "sweeps", sweep_id),
+    }
 
 
 def _select_mapping_values(value: Any, keys: Optional[List[str]]) -> Dict[str, Any]:
@@ -299,7 +463,7 @@ def _serialize_run(
     run_id = getattr(run, "id", None)
     result = {
         "id": _json_safe(run_id),
-        "display_name": _json_safe(getattr(run, "name", None)),
+        "display_name": _json_safe(getattr(run, "name", None) or run_id),
         "state": _json_safe(getattr(run, "state", None)),
         "entity": _json_safe(entity),
         "project": _json_safe(project),
@@ -310,10 +474,11 @@ def _serialize_run(
         "created_at": _json_safe(getattr(run, "created_at", None)),
         "heartbeat_at": _json_safe(getattr(run, "heartbeat_at", None)),
         "duration": _json_safe(getattr(run, "duration", None)),
+        "history_line_count": _json_safe(getattr(run, "history_line_count", None)),
         "group": _json_safe(getattr(run, "group", None)),
         "job_type": _json_safe(getattr(run, "job_type", None)),
-        "tags": _json_safe(getattr(run, "tags", [])),
-        "user": _serialize_user(getattr(run, "user", None)),
+        "tags": _json_safe(getattr(run, "tags", None) or []),
+        "user": _serialize_user(getattr(run, "user", None), include_email=False),
     }
     if include_summary:
         result["summary"] = _serialize_summary(run, summary_keys)
@@ -336,7 +501,15 @@ def _serialize_run(
         result["system_metrics"] = _json_safe(getattr(run, "system_metrics", {}))
     if "sweep" in include:
         sweep = getattr(run, "sweep", None)
-        result["sweep"] = None if sweep is None else _serialize_sweep(sweep, frozenset())
+        result["sweep"] = (
+            None
+            if sweep is None
+            else _serialize_sweep_reference(
+                sweep,
+                entity=entity,
+                project=project,
+            )
+        )
     return result
 
 
@@ -357,8 +530,9 @@ def _serialize_report(report: Any, include: frozenset[str]) -> Dict[str, Any]:
 
 
 def _estimate_tokens(payload: Dict[str, Any]) -> int:
-    """Conservative approximation suitable for enforcing the configured budget."""
-    return max(1, len(json.dumps(payload, default=str, ensure_ascii=False)) // 4)
+    """Exact token count with a conservative tokenizer-failure fallback."""
+    serialized = json.dumps(payload, default=str, ensure_ascii=False, allow_nan=False)
+    return count_tokens_conservative(serialized)
 
 
 def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -377,24 +551,17 @@ def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
             if _estimate_tokens(payload) <= MAX_RESPONSE_TOKENS:
                 break
 
-    dropped_items = 0
-    while payload["items"] and _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
-        payload["items"].pop()
-        dropped_items += 1
-
-    if omitted_fields or dropped_items:
+    if omitted_fields:
         payload["returned_count"] = len(payload["items"])
         payload["count"] = len(payload["items"])
-        payload["has_more"] = original_has_more or dropped_items > 0
-        payload["project_exhaustive"] = original_exhaustive and dropped_items == 0
-        if dropped_items:
-            payload["next_cursor"] = None
+        payload["has_more"] = original_has_more
+        payload["project_exhaustive"] = original_exhaustive
         payload["truncated"] = True
         payload["truncation"] = {
             "applied": True,
             "reason": "response_token_budget",
             "omitted_fields": sorted(omitted_fields),
-            "dropped_items": dropped_items,
+            "dropped_items": 0,
         }
     if _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
         return structured_error(
@@ -463,38 +630,67 @@ def _validate_request(
         raise WandBQueryValidationError("entity_name must be a non-empty string")
     if not isinstance(project_name, str) or not project_name.strip():
         raise WandBQueryValidationError("project_name must be a non-empty string")
-    if resource not in _INCLUDE_FIELDS:
-        raise WandBQueryValidationError(f"unsupported resource: {resource!r}")
+    _validate_text_bound("entity_name", entity_name, _MAX_IDENTIFIER_BYTES)
+    _validate_text_bound("project_name", project_name, _MAX_IDENTIFIER_BYTES)
+    if (
+        not isinstance(resource, str)
+        or len(resource.encode("utf-8")) > _MAX_ENUM_BYTES
+        or resource not in _INCLUDE_FIELDS
+    ):
+        raise WandBQueryValidationError("unsupported resource")
     if isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
         raise WandBQueryValidationError("limit must be a positive integer")
     if filters is not None and not isinstance(filters, dict):
         raise WandBQueryValidationError("filters must be a dictionary")
+    _validate_filter_bound(filters)
     if filters is not None and resource != "runs":
         raise WandBQueryValidationError("filters are supported only for resource='runs'")
     if resource != "runs" and order != "-created_at":
         raise WandBQueryValidationError("order is supported only for resource='runs'")
-    if resource == "run" and not run_id:
+    if resource == "run" and (not isinstance(run_id, str) or not run_id.strip()):
         raise WandBQueryValidationError("run_id is required for resource='run'")
     if resource != "run" and run_id is not None:
         raise WandBQueryValidationError("run_id is supported only for resource='run'")
-    if resource == "sweep" and not sweep_id:
+    if run_id is not None:
+        _validate_text_bound("run_id", run_id, _MAX_IDENTIFIER_BYTES)
+    if resource == "sweep" and (not isinstance(sweep_id, str) or not sweep_id.strip()):
         raise WandBQueryValidationError("sweep_id is required for resource='sweep'")
     if resource != "sweep" and sweep_id is not None:
         raise WandBQueryValidationError("sweep_id is supported only for resource='sweep'")
+    if sweep_id is not None:
+        _validate_text_bound("sweep_id", sweep_id, _MAX_IDENTIFIER_BYTES)
     if resource != "reports" and report_name is not None:
         raise WandBQueryValidationError("report_name is supported only for resource='reports'")
-    if response_mode not in {"items", "count"}:
+    if report_name is not None:
+        if not isinstance(report_name, str) or not report_name.strip():
+            raise WandBQueryValidationError("report_name must be a non-empty string")
+        _validate_text_bound("report_name", report_name, _MAX_IDENTIFIER_BYTES)
+    if not isinstance(order, str) or not order.strip():
+        raise WandBQueryValidationError("order must be a non-empty string")
+    _validate_text_bound("order", order, _MAX_IDENTIFIER_BYTES)
+    if not isinstance(response_mode, str) or response_mode not in {"items", "count"}:
         raise WandBQueryValidationError("response_mode must be 'items' or 'count'")
     if response_mode == "count" and resource != "runs":
         raise WandBQueryValidationError("response_mode='count' is supported only for resource='runs'")
     if cursor is not None and (not isinstance(cursor, str) or not cursor.strip()):
         raise WandBQueryValidationError("cursor must be a non-empty string")
+    if cursor is not None:
+        _validate_text_bound("cursor", cursor, _MAX_CURSOR_BYTES)
     if cursor is not None and resource not in {"runs", "sweeps", "reports"}:
         raise WandBQueryValidationError("cursor is supported only for collection resources")
     if cursor is not None and response_mode != "items":
         raise WandBQueryValidationError("cursor is not supported with response_mode='count'")
-    if include is not None and (not isinstance(include, list) or not all(isinstance(item, str) for item in include)):
-        raise WandBQueryValidationError("include must be a list of strings")
+    if include is not None and (
+        not isinstance(include, list)
+        or len(include) > 20
+        or not all(
+            isinstance(item, str) and bool(item.strip()) and len(item.encode("utf-8")) <= _MAX_ENUM_BYTES
+            for item in include
+        )
+    ):
+        raise WandBQueryValidationError(
+            f"include must contain at most 20 non-empty strings of at most {_MAX_ENUM_BYTES} bytes"
+        )
     if summary_keys is not None and (
         not isinstance(summary_keys, list)
         or not summary_keys
@@ -502,6 +698,8 @@ def _validate_request(
         or not all(isinstance(item, str) and item.strip() for item in summary_keys)
     ):
         raise WandBQueryValidationError(f"summary_keys must contain 1-{MCP_MAX_HISTORY_KEYS} non-empty strings")
+    for key in summary_keys or ():
+        _validate_text_bound("summary_keys item", key, _MAX_IDENTIFIER_BYTES)
     if summary_keys is not None and resource not in {"run", "runs"}:
         raise WandBQueryValidationError("summary_keys are supported only for resource='run' or resource='runs'")
     if config_keys is not None and (
@@ -511,6 +709,8 @@ def _validate_request(
         or not all(isinstance(item, str) and item.strip() for item in config_keys)
     ):
         raise WandBQueryValidationError(f"config_keys must contain 1-{MCP_MAX_HISTORY_KEYS} non-empty strings")
+    for key in config_keys or ():
+        _validate_text_bound("config_keys item", key, _MAX_IDENTIFIER_BYTES)
     if config_keys is not None and resource not in {"run", "runs"}:
         raise WandBQueryValidationError("config_keys are supported only for resource='run' or resource='runs'")
     if response_mode == "count" and (include or summary_keys or config_keys):
@@ -524,9 +724,7 @@ def _validate_request(
     unsupported = requested - _INCLUDE_FIELDS[resource]
     if unsupported:
         allowed = sorted(_INCLUDE_FIELDS[resource])
-        raise WandBQueryValidationError(
-            f"unsupported include value(s) for resource={resource!r}: {sorted(unsupported)}; allowed: {allowed}"
-        )
+        raise WandBQueryValidationError(f"unsupported include value for this resource; allowed values: {allowed}")
     full_detail_limit = 3 if MCP_HOSTED_MODE and MCP_WORKLOAD_PROFILE == "local" else MCP_MAX_FULL_DETAIL_ITEMS
     if resource in {"runs", "sweeps", "reports"} and limit > full_detail_limit:
         untargeted_summary = "summary" in requested and summary_keys is None
@@ -612,16 +810,6 @@ def _collection_total_count(collection: Any) -> Optional[int]:
         return None
 
 
-def _collection_cursor(collection: Any, has_more: bool) -> Optional[str]:
-    if not has_more:
-        return None
-    try:
-        cursor = collection.cursor
-    except (AttributeError, TypeError, ValueError):
-        return None
-    return str(cursor) if cursor else None
-
-
 def _decorate_projected_run(item: Dict[str, Any]) -> Dict[str, Any]:
     run_id = item.get("id")
     if run_id:
@@ -649,8 +837,11 @@ def _decorate_projected_report(
     entity_name: str,
     project_name: str,
 ) -> Dict[str, Any]:
-    report_path = item.get("name") or item.get("id")
-    if report_path:
+    display_name = item.get("display_name")
+    report_id = item.get("id")
+    if display_name and report_id:
+        slug = re.sub(r"-+", "-", re.sub(r"\W", "-", str(display_name))).strip("-")
+        report_path = f"{slug}--{str(report_id).replace('=', '')}"
         item["url"] = public_wandb_url(entity_name, project_name, "reports", report_path)
     return _json_safe(item)
 
@@ -744,11 +935,33 @@ def query_wandb(
             response_mode,
             cursor,
         )
+        sdk_cursor_fingerprint = _sdk_cursor_fingerprint(
+            entity_name=entity_name,
+            project_name=project_name,
+            resource=resource,
+            filters=filters,
+            order=order,
+            report_name=report_name,
+            include=include_fields,
+            summary_keys=summary_keys,
+            config_keys=config_keys,
+        )
+        sdk_fallback_offset = _decode_sdk_cursor(cursor, resource, sdk_cursor_fingerprint)
     except WandBQueryValidationError as exc:
-        return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=resource)
+        safe_resource = resource if isinstance(resource, str) and resource in _INCLUDE_FIELDS else "unknown"
+        return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=safe_resource)
 
     requested_limit = limit
     applied_limit = min(limit, MCP_MAX_WANDB_QUERY_ITEMS)
+    try:
+        if sdk_fallback_offset is not None:
+            if resource == "sweeps" or (resource == "reports" and "spec" not in include_fields):
+                raise WandBQueryValidationError(
+                    "this collection does not support SDK fallback cursors; restart with no cursor"
+                )
+            _validate_sdk_fallback_window(sdk_fallback_offset, applied_limit)
+    except WandBQueryValidationError as exc:
+        return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=resource)
     path = f"{entity_name}/{project_name}"
 
     with track_tool_execution(
@@ -828,14 +1041,18 @@ def query_wandb(
 
             if resource == "runs":
                 if response_mode == "count":
-                    runs = api.runs(
-                        path,
-                        filters=filters,
-                        order=order,
-                        per_page=1,
-                        include_sweeps=False,
-                        lazy=True,
-                    )
+                    with _SDK_RUN_CACHE_LOCK:
+                        flush = getattr(api, "flush", None)
+                        if callable(flush):
+                            flush()
+                        runs = api.runs(
+                            path,
+                            filters=filters,
+                            order=order,
+                            per_page=1,
+                            include_sweeps=False,
+                            lazy=True,
+                        )
                     total_count = len(runs)
                     return {
                         "source": "wandb_sdk",
@@ -847,7 +1064,7 @@ def query_wandb(
                         "project_exhaustive": True,
                     }
 
-                use_projection = bool(cursor or include_fields or summary_keys or config_keys)
+                use_projection = sdk_fallback_offset is None
                 if use_projection:
                     try:
                         projected = fetch_projected_runs(
@@ -867,7 +1084,7 @@ def query_wandb(
                             cursor=cursor,
                         )
                     except SelectiveReadUnavailable as exc:
-                        if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                        if cursor is not None:
                             return structured_error(
                                 "selective_read_unavailable",
                                 (
@@ -877,9 +1094,24 @@ def query_wandb(
                                 source="wandb_sdk",
                                 resource=resource,
                             )
-                        compatibility_caveat = (
-                            f"{exc}; used a bounded full-page SDK fallback without per-run lazy loads"
-                        )
+                        if "sweep" in include_fields:
+                            return structured_error(
+                                "selective_read_unavailable",
+                                f"{exc}; the SDK fallback would load one sweep per run",
+                                source="wandb_sdk",
+                                resource=resource,
+                            )
+                        if include_fields and applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                            return structured_error(
+                                "selective_read_unavailable",
+                                (
+                                    f"{exc}; the requested detail shape exceeds the bounded "
+                                    "public-SDK compatibility window"
+                                ),
+                                source="wandb_sdk",
+                                resource=resource,
+                            )
+                        compatibility_caveat = f"{exc}; used a bounded public-SDK compatibility page"
                     else:
                         return _collection_envelope(
                             resource,
@@ -895,8 +1127,9 @@ def query_wandb(
                             source="wandb_selective_read",
                         )
                 else:
-                    compatibility_caveat = None
+                    compatibility_caveat = "continued a bounded public-SDK compatibility page"
 
+                offset = sdk_fallback_offset or 0
                 with _SDK_RUN_CACHE_LOCK:
                     flush = getattr(api, "flush", None)
                     if callable(flush):
@@ -905,21 +1138,24 @@ def query_wandb(
                         path,
                         filters=filters,
                         order=order,
-                        per_page=min(
-                            applied_limit + (1 if compatibility_caveat else 0),
-                            MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
-                        ),
-                        include_sweeps="sweep" in include_fields,
+                        per_page=min(applied_limit, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE),
+                        include_sweeps=False,
                         lazy=not bool(include_fields & {"summary", "config", "system_metrics"}),
                     )
                 total_count = _collection_total_count(runs)
-                page = list(islice(runs, applied_limit))
-                has_more = bool(total_count is not None and total_count > len(page))
+                lookahead = 0 if total_count is not None else 1
+                page = list(islice(runs, offset, offset + applied_limit + lookahead))
+                items_page = page[:applied_limit]
+                has_more = len(page) > applied_limit or bool(
+                    total_count is not None and total_count > offset + len(items_page)
+                )
                 if total_count is None:
                     try:
-                        has_more = bool(runs.more)
+                        has_more = has_more or bool(runs.more)
                     except (AttributeError, TypeError, ValueError):
-                        has_more = len(page) == applied_limit
+                        # We requested one lookahead item from this iterator; if
+                        # none arrived, the fallback collection is exhausted.
+                        pass
                 items = [
                     _serialize_run(
                         run,
@@ -928,10 +1164,10 @@ def query_wandb(
                         config_keys=config_keys,
                         include_summary="summary" in include_fields,
                     )
-                    for run in page[:applied_limit]
+                    for run in items_page
                 ]
                 if total_count is None and not has_more:
-                    total_count = len(items)
+                    total_count = offset + len(items)
                 return _collection_envelope(
                     resource,
                     entity_name,
@@ -942,7 +1178,9 @@ def query_wandb(
                     has_more,
                     total_count,
                     cursor=cursor,
-                    next_cursor=_collection_cursor(runs, has_more),
+                    next_cursor=(
+                        _encode_sdk_cursor(resource, offset + len(items), sdk_cursor_fingerprint) if has_more else None
+                    ),
                     compatibility_caveat=compatibility_caveat,
                 )
 
@@ -962,30 +1200,11 @@ def query_wandb(
                         cursor=cursor,
                     )
                 except SelectiveReadUnavailable as exc:
-                    if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
-                        return structured_error(
-                            "selective_read_unavailable",
-                            f"{exc}; a bounded continuation cannot be reproduced safely by the public SDK",
-                            source="wandb_sdk",
-                            resource=resource,
-                        )
-                    sdk_sweeps = api.project(project_name, entity=entity_name).sweeps(
-                        per_page=min(applied_limit + 1, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE)
-                    )
-                    sweep_page = list(islice(sdk_sweeps, applied_limit + 1))
-                    has_more = len(sweep_page) > applied_limit or bool(getattr(sdk_sweeps, "more", False))
-                    items = [_serialize_sweep(sweep, include_fields) for sweep in sweep_page[:applied_limit]]
-                    return _collection_envelope(
-                        resource,
-                        entity_name,
-                        project_name,
-                        items,
-                        requested_limit,
-                        applied_limit,
-                        has_more,
-                        _collection_total_count(sdk_sweeps),
-                        next_cursor=_collection_cursor(sdk_sweeps, has_more),
-                        compatibility_caveat=f"{exc}; used a small bounded SDK fallback",
+                    return structured_error(
+                        "selective_read_unavailable",
+                        f"{exc}; the public SDK would load each sweep individually",
+                        source="wandb_sdk",
+                        resource=resource,
                     )
                 return _collection_envelope(
                     resource,
@@ -1002,6 +1221,8 @@ def query_wandb(
                 )
 
             try:
+                if sdk_fallback_offset is not None:
+                    raise SelectiveReadUnavailable("continuing bounded SDK fallback")
                 reports = fetch_projected_reports(
                     api,
                     entity=entity_name,
@@ -1013,19 +1234,34 @@ def query_wandb(
                     cursor=cursor,
                 )
             except SelectiveReadUnavailable as exc:
-                if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                if "spec" not in include_fields:
                     return structured_error(
                         "selective_read_unavailable",
-                        f"{exc}; a bounded continuation cannot be reproduced safely by the public SDK",
+                        f"{exc}; the public SDK would download every report spec",
                         source="wandb_sdk",
                         resource=resource,
                     )
+                if cursor is not None and sdk_fallback_offset is None:
+                    return structured_error(
+                        "selective_read_unavailable",
+                        f"{exc}; a native continuation cannot be reproduced safely by the public SDK",
+                        source="wandb_sdk",
+                        resource=resource,
+                    )
+                if applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                    return structured_error(
+                        "selective_read_unavailable",
+                        f"{exc}; report spec fallback is limited to {MCP_MAX_FULL_DETAIL_ITEMS} items",
+                        source="wandb_sdk",
+                        resource=resource,
+                    )
+                offset = sdk_fallback_offset or 0
                 sdk_reports = api.reports(
                     path,
                     name=report_name,
                     per_page=min(applied_limit + 1, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE),
                 )
-                report_page = list(islice(sdk_reports, applied_limit + 1))
+                report_page = list(islice(sdk_reports, offset, offset + applied_limit + 1))
                 items = [_serialize_report(report, include_fields) for report in report_page[:applied_limit]]
                 has_more = len(report_page) > applied_limit or bool(getattr(sdk_reports, "more", False))
                 return _collection_envelope(
@@ -1036,8 +1272,11 @@ def query_wandb(
                     requested_limit,
                     applied_limit,
                     has_more,
-                    None if has_more else len(items),
-                    next_cursor=_collection_cursor(sdk_reports, has_more),
+                    None if has_more else offset + len(items),
+                    cursor=cursor,
+                    next_cursor=(
+                        _encode_sdk_cursor(resource, offset + len(items), sdk_cursor_fingerprint) if has_more else None
+                    ),
                     compatibility_caveat=f"{exc}; used a small bounded SDK fallback",
                 )
             return _collection_envelope(
@@ -1054,8 +1293,8 @@ def query_wandb(
                 source="wandb_selective_read",
             )
         except Exception as exc:
-            logger.error("W&B SDK query failed: %s", exc, exc_info=True)
-            ctx.mark_error(f"sdk_query_failed: {exc}")
+            logger.error("W&B SDK query failed (%s)", type(exc).__name__)
+            ctx.mark_error(f"sdk_query_failed: {type(exc).__name__}")
             return _sdk_error_result(
                 exc,
                 resource=resource,

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
 from itertools import islice
+import threading
 from typing import Any, Dict, List, Literal, Optional
 
 from wandb_mcp_server.api_client import WandBApiManager
@@ -22,8 +26,10 @@ from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_selective_reads import (
     SelectiveReadUnavailable,
+    fetch_projected_reports,
     fetch_projected_run,
     fetch_projected_runs,
+    fetch_projected_sweeps,
 )
 from wandb_mcp_server.wandb_urls import public_wandb_url, publicize_wandb_url
 
@@ -91,6 +97,8 @@ config_keys : list[str], optional
 response_mode : "items" | "count", optional
     "items" returns bounded resources. "count" is supported for resource="runs"
     and returns only the exact server-side matching count.
+cursor : str, optional
+    Opaque continuation cursor returned by a previous collection response.
 
 Returns
 -------
@@ -112,24 +120,75 @@ _INCLUDE_FIELDS = {
     "reports": frozenset({"spec"}),
 }
 _OPTIONAL_RESPONSE_FIELDS = ("system_metrics", "config", "spec", "sweep", "summary")
+_JSON_MAX_DEPTH = 12
+_JSON_MAX_MAPPING_KEYS = 500
+_JSON_MAX_LIST_ITEMS = 500
+_JSON_MAX_STRING_CHARS = 16_000
+_SDK_RUN_CACHE_LOCK = threading.Lock()
 
 
 class WandBQueryValidationError(ValueError):
     """Raised before any W&B client is obtained for an invalid request."""
 
 
-def _json_safe(value: Any) -> Any:
+def _json_safe(
+    value: Any,
+    *,
+    _depth: int = 0,
+    _seen: Optional[set[int]] = None,
+) -> Any:
     """Convert SDK values into deterministic JSON-compatible values."""
-    if value is None or isinstance(value, (str, int, float, bool)):
+    if _depth >= _JSON_MAX_DEPTH:
+        return {"_truncated": "max_depth"}
+    if value is None or isinstance(value, (int, bool)):
         return value
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set, frozenset)):
-        return [_json_safe(item) for item in value]
-    try:
-        return {str(key): _json_safe(item) for key, item in dict(value).items()}
-    except (TypeError, ValueError):
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return value if len(value) <= _JSON_MAX_STRING_CHARS else value[:_JSON_MAX_STRING_CHARS] + "…"
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
         return str(value)
+    seen = _seen if _seen is not None else set()
+    value_id = id(value)
+    if value_id in seen:
+        return {"_truncated": "cycle"}
+    seen.add(value_id)
+    try:
+        scalar_item = getattr(value, "item", None)
+        if callable(scalar_item):
+            return _json_safe(scalar_item(), _depth=_depth + 1, _seen=seen)
+    except (TypeError, ValueError, OverflowError):
+        pass
+    if isinstance(value, Mapping):
+        result = {
+            str(key): _json_safe(item, _depth=_depth + 1, _seen=seen)
+            for key, item in islice(value.items(), _JSON_MAX_MAPPING_KEYS)
+        }
+        try:
+            mapping_length = len(value)
+        except TypeError:
+            mapping_length = len(result)
+        if mapping_length > _JSON_MAX_MAPPING_KEYS:
+            result["_truncated_keys"] = mapping_length - _JSON_MAX_MAPPING_KEYS
+        return result
+    if isinstance(value, (list, tuple, set, frozenset)):
+        values = list(islice(iter(value), _JSON_MAX_LIST_ITEMS + 1))
+        result = [_json_safe(item, _depth=_depth + 1, _seen=seen) for item in values[:_JSON_MAX_LIST_ITEMS]]
+        if len(values) > _JSON_MAX_LIST_ITEMS:
+            try:
+                omitted = len(value) - _JSON_MAX_LIST_ITEMS
+            except TypeError:
+                omitted = 1
+            result.append({"_truncated_items": omitted})
+        return result
+    try:
+        mapping = dict(value)
+    except (TypeError, ValueError):
+        rendered = str(value)
+        return rendered if len(rendered) <= _JSON_MAX_STRING_CHARS else rendered[:_JSON_MAX_STRING_CHARS] + "…"
+    return _json_safe(mapping, _depth=_depth + 1, _seen=seen)
 
 
 def _serialize_user(user: Any) -> Any:
@@ -192,12 +251,39 @@ def _select_mapping_values(value: Any, keys: Optional[List[str]]) -> Dict[str, A
         mapping = dict(value)
     except (TypeError, ValueError):
         return {}
-    return {key: _json_safe(mapping[key]) for key in keys if key in mapping and mapping[key] is not None}
+    return {key: _json_safe(mapping[key]) for key in keys if key in mapping}
 
 
 def _serialize_summary(run: Any, summary_keys: Optional[List[str]]) -> Dict[str, Any]:
     summary = getattr(run, "summary", None)
     return _select_mapping_values(summary, summary_keys)
+
+
+def _select_config_values(value: Any, keys: Optional[List[str]]) -> tuple[Dict[str, Any], list[str]]:
+    if keys is None:
+        return _json_safe(value or {}), []
+    try:
+        mapping = dict(value or {})
+    except (TypeError, ValueError):
+        return {}, list(keys)
+    selected: dict[str, Any] = {}
+    missing: list[str] = []
+    for key in keys:
+        if key in mapping:
+            selected[key] = _json_safe(mapping[key])
+            continue
+        current: Any = mapping
+        found = True
+        for part in key.split("."):
+            if not isinstance(current, Mapping) or part not in current:
+                found = False
+                break
+            current = current[part]
+        if found:
+            selected[key] = _json_safe(current)
+        else:
+            missing.append(key)
+    return selected, missing
 
 
 def _serialize_run(
@@ -231,8 +317,21 @@ def _serialize_run(
     }
     if include_summary:
         result["summary"] = _serialize_summary(run, summary_keys)
+        if summary_keys:
+            summary = getattr(run, "summary", None)
+            try:
+                summary_mapping = dict(summary or {})
+            except (TypeError, ValueError):
+                summary_mapping = {}
+            missing = [key for key in summary_keys if key not in summary_mapping]
+            if missing:
+                result["missing_summary_keys"] = missing
     if "config" in include:
-        result["config"] = _select_mapping_values(getattr(run, "config", {}), config_keys)
+        config = getattr(run, "config", {})
+        selected_config, missing = _select_config_values(config, config_keys)
+        result["config"] = selected_config
+        if missing:
+            result["missing_config_keys"] = missing
     if "system_metrics" in include:
         result["system_metrics"] = _json_safe(getattr(run, "system_metrics", {}))
     if "sweep" in include:
@@ -263,6 +362,8 @@ def _estimate_tokens(payload: Dict[str, Any]) -> int:
 
 
 def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
+    original_has_more = bool(payload["has_more"])
+    original_exhaustive = bool(payload["project_exhaustive"])
     omitted_fields: set[str] = set()
     if _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
         for field in _OPTIONAL_RESPONSE_FIELDS:
@@ -284,8 +385,10 @@ def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
     if omitted_fields or dropped_items:
         payload["returned_count"] = len(payload["items"])
         payload["count"] = len(payload["items"])
-        payload["has_more"] = True
-        payload["project_exhaustive"] = False
+        payload["has_more"] = original_has_more or dropped_items > 0
+        payload["project_exhaustive"] = original_exhaustive and dropped_items == 0
+        if dropped_items:
+            payload["next_cursor"] = None
         payload["truncated"] = True
         payload["truncation"] = {
             "applied": True,
@@ -293,6 +396,13 @@ def _fit_collection_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
             "omitted_fields": sorted(omitted_fields),
             "dropped_items": dropped_items,
         }
+    if _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
+        return structured_error(
+            "response_too_large",
+            "The W&B collection metadata exceeded the configured response budget",
+            source=payload.get("source", "wandb_sdk"),
+            resource=payload.get("resource"),
+        )
     return payload
 
 
@@ -313,6 +423,23 @@ def _fit_single_to_budget(payload: Dict[str, Any]) -> Dict[str, Any]:
             "omitted_fields": omitted_fields,
             "dropped_items": 0,
         }
+    if _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
+        identity_fields = ("id", "name", "display_name", "state", "entity", "project", "url")
+        payload["item"] = {key: payload["item"][key] for key in identity_fields if key in payload["item"]}
+        payload["truncated"] = True
+        payload["truncation"] = {
+            "applied": True,
+            "reason": "response_token_budget",
+            "omitted_fields": ["non_identity_fields"],
+            "dropped_items": 0,
+        }
+    if _estimate_tokens(payload) > MAX_RESPONSE_TOKENS:
+        return structured_error(
+            "response_too_large",
+            "The W&B resource metadata exceeded the configured response budget",
+            source=payload.get("source", "wandb_sdk"),
+            resource=payload.get("resource"),
+        )
     return payload
 
 
@@ -330,6 +457,7 @@ def _validate_request(
     summary_keys: Optional[List[str]],
     config_keys: Optional[List[str]],
     response_mode: str,
+    cursor: Optional[str],
 ) -> frozenset[str]:
     if not isinstance(entity_name, str) or not entity_name.strip():
         raise WandBQueryValidationError("entity_name must be a non-empty string")
@@ -359,6 +487,12 @@ def _validate_request(
         raise WandBQueryValidationError("response_mode must be 'items' or 'count'")
     if response_mode == "count" and resource != "runs":
         raise WandBQueryValidationError("response_mode='count' is supported only for resource='runs'")
+    if cursor is not None and (not isinstance(cursor, str) or not cursor.strip()):
+        raise WandBQueryValidationError("cursor must be a non-empty string")
+    if cursor is not None and resource not in {"runs", "sweeps", "reports"}:
+        raise WandBQueryValidationError("cursor is supported only for collection resources")
+    if cursor is not None and response_mode != "items":
+        raise WandBQueryValidationError("cursor is not supported with response_mode='count'")
     if include is not None and (not isinstance(include, list) or not all(isinstance(item, str) for item in include)):
         raise WandBQueryValidationError("include must be a list of strings")
     if summary_keys is not None and (
@@ -411,10 +545,13 @@ def _collection_envelope(
     entity_name: str,
     project_name: str,
     items: List[Dict[str, Any]],
-    limit: int,
+    requested_limit: int,
+    applied_limit: int,
     has_more: bool,
     total_count: Optional[int],
     *,
+    cursor: Optional[str] = None,
+    next_cursor: Optional[str] = None,
     source: str = "wandb_sdk",
     compatibility_caveat: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -428,10 +565,17 @@ def _collection_envelope(
         "count": len(items),
         "total_count": total_count,
         "has_more": has_more,
-        "limit": limit,
-        "project_exhaustive": not has_more,
+        "requested_limit": requested_limit,
+        "limit": applied_limit,
+        "limit_clamped": requested_limit != applied_limit,
+        "next_cursor": next_cursor if has_more else None,
+        "project_exhaustive": cursor is None and not has_more,
         "truncated": has_more,
-        "truncation": {"applied": False},
+        "truncation": (
+            {"applied": True, "reason": "collection_limit", "omitted_fields": [], "dropped_items": 0}
+            if has_more
+            else {"applied": False}
+        ),
     }
     if compatibility_caveat:
         payload["compatibility_caveat"] = compatibility_caveat
@@ -468,11 +612,102 @@ def _collection_total_count(collection: Any) -> Optional[int]:
         return None
 
 
+def _collection_cursor(collection: Any, has_more: bool) -> Optional[str]:
+    if not has_more:
+        return None
+    try:
+        cursor = collection.cursor
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return str(cursor) if cursor else None
+
+
 def _decorate_projected_run(item: Dict[str, Any]) -> Dict[str, Any]:
     run_id = item.get("id")
     if run_id:
         item["url"] = public_wandb_url(item.get("entity"), item.get("project"), "runs", run_id)
+    sweep = item.get("sweep")
+    if isinstance(sweep, dict) and sweep.get("id"):
+        sweep["url"] = public_wandb_url(
+            item.get("entity"),
+            item.get("project"),
+            "sweeps",
+            sweep["id"],
+        )
     return _json_safe(item)
+
+
+def _decorate_projected_sweep(item: Dict[str, Any]) -> Dict[str, Any]:
+    sweep_id = item.get("id")
+    if sweep_id:
+        item["url"] = public_wandb_url(item.get("entity"), item.get("project"), "sweeps", sweep_id)
+    return _json_safe(item)
+
+
+def _decorate_projected_report(
+    item: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+) -> Dict[str, Any]:
+    report_path = item.get("name") or item.get("id")
+    if report_path:
+        item["url"] = public_wandb_url(entity_name, project_name, "reports", report_path)
+    return _json_safe(item)
+
+
+def _sdk_error_result(
+    exc: Exception,
+    *,
+    resource: str,
+    entity_name: str,
+    project_name: str,
+) -> Dict[str, Any]:
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    response = getattr(exc, "response", None)
+    if status is None and response is not None:
+        status = getattr(response, "status_code", None) or getattr(response, "status", None)
+    retry_after = None
+    headers = getattr(response, "headers", None)
+    if headers:
+        retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    name = type(exc).__name__.lower()
+    message = str(exc).lower()
+    common = {
+        "source": "wandb_sdk",
+        "resource": resource,
+        "entity": entity_name,
+        "project": project_name,
+    }
+    if status == 401 or "unauth" in name or "invalid api key" in message or "no w&b api key" in message:
+        return structured_error("authentication_failed", "W&B authentication failed", **common)
+    if status == 403 or "permission" in message or "forbidden" in message:
+        return structured_error("permission_denied", "W&B denied access to this resource", **common)
+    if status == 404 or "not found" in message or "could not find" in message:
+        return structured_error("resource_not_found", "The requested W&B resource was not found", **common)
+    if status == 429 or status == 503 or "rate limit" in message or "overload" in message:
+        try:
+            retry_after_ms = max(1_000, min(60_000, int(float(retry_after or 1) * 1_000)))
+        except (TypeError, ValueError):
+            retry_after_ms = 1_000
+        return structured_error(
+            "server_busy",
+            "W&B is temporarily busy; retry this bounded request",
+            retryable=True,
+            retry_after_ms=retry_after_ms,
+            **common,
+        )
+    if "timeout" in name or "timed out" in message:
+        return structured_error(
+            "upstream_timeout",
+            "The bounded W&B request timed out",
+            retryable=True,
+            **common,
+        )
+    return structured_error(
+        "sdk_query_failed",
+        f"W&B query failed ({type(exc).__name__})",
+        **common,
+    )
 
 
 def query_wandb(
@@ -489,6 +724,7 @@ def query_wandb(
     summary_keys: Optional[List[str]] = None,
     config_keys: Optional[List[str]] = None,
     response_mode: WandBResponseMode = "items",
+    cursor: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute a structured, bounded W&B read."""
     try:
@@ -506,13 +742,13 @@ def query_wandb(
             summary_keys,
             config_keys,
             response_mode,
+            cursor,
         )
     except WandBQueryValidationError as exc:
         return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=resource)
 
     requested_limit = limit
     applied_limit = min(limit, MCP_MAX_WANDB_QUERY_ITEMS)
-    per_page = min(applied_limit + 1, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE)
     path = f"{entity_name}/{project_name}"
 
     with track_tool_execution(
@@ -526,6 +762,7 @@ def query_wandb(
             "response_mode": response_mode,
             "projected_summary_keys": len(summary_keys or []),
             "projected_config_keys": len(config_keys or []),
+            "continued": cursor is not None,
         },
         mcp_tool_name="query_wandb_tool",
     ) as ctx:
@@ -546,7 +783,7 @@ def query_wandb(
                             entity=entity_name,
                             project=project_name,
                             run_id=str(run_id),
-                            summary_keys=summary_keys or (),
+                            summary_keys=summary_keys if summary_keys is not None else None,
                             config_keys=config_keys or (),
                         )
                     except SelectiveReadUnavailable as exc:
@@ -610,11 +847,7 @@ def query_wandb(
                         "project_exhaustive": True,
                     }
 
-                use_projection = bool(summary_keys or config_keys) and not (
-                    include_fields & {"system_metrics", "sweep"}
-                    or ("summary" in include_fields and summary_keys is None)
-                    or ("config" in include_fields and config_keys is None)
-                )
+                use_projection = bool(cursor or include_fields or summary_keys or config_keys)
                 if use_projection:
                     try:
                         projected = fetch_projected_runs(
@@ -625,16 +858,21 @@ def query_wandb(
                             order=order,
                             limit=applied_limit,
                             page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
-                            summary_keys=summary_keys or (),
-                            config_keys=config_keys or (),
+                            summary_keys=summary_keys if summary_keys is not None else None,
+                            config_keys=config_keys if config_keys is not None else None,
+                            include_summary="summary" in include_fields,
+                            include_config="config" in include_fields,
+                            include_sweep="sweep" in include_fields,
+                            include_system_metrics="system_metrics" in include_fields,
+                            cursor=cursor,
                         )
                     except SelectiveReadUnavailable as exc:
-                        if applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                        if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
                             return structured_error(
                                 "selective_read_unavailable",
                                 (
                                     f"{exc}; this backend cannot project selected fields and the requested "
-                                    f"limit exceeds the safe SDK fallback of {MCP_MAX_FULL_DETAIL_ITEMS}"
+                                    "continuation or detail shape cannot be reproduced safely with the SDK fallback"
                                 ),
                                 source="wandb_sdk",
                                 resource=resource,
@@ -648,25 +886,40 @@ def query_wandb(
                             entity_name,
                             project_name,
                             [_decorate_projected_run(item) for item in projected.items],
+                            requested_limit,
                             applied_limit,
-                            projected.has_more or requested_limit > applied_limit,
+                            projected.has_more,
                             projected.total_count,
+                            cursor=cursor,
+                            next_cursor=projected.next_cursor,
                             source="wandb_selective_read",
                         )
                 else:
                     compatibility_caveat = None
 
-                runs = api.runs(
-                    path,
-                    filters=filters,
-                    order=order,
-                    per_page=per_page,
-                    include_sweeps="sweep" in include_fields,
-                    lazy=not bool(include_fields & {"summary", "config", "system_metrics"}),
-                )
+                with _SDK_RUN_CACHE_LOCK:
+                    flush = getattr(api, "flush", None)
+                    if callable(flush):
+                        flush()
+                    runs = api.runs(
+                        path,
+                        filters=filters,
+                        order=order,
+                        per_page=min(
+                            applied_limit + (1 if compatibility_caveat else 0),
+                            MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
+                        ),
+                        include_sweeps="sweep" in include_fields,
+                        lazy=not bool(include_fields & {"summary", "config", "system_metrics"}),
+                    )
                 total_count = _collection_total_count(runs)
-                page = list(islice(runs, applied_limit + 1))
-                has_more = len(page) > applied_limit or requested_limit > applied_limit
+                page = list(islice(runs, applied_limit))
+                has_more = bool(total_count is not None and total_count > len(page))
+                if total_count is None:
+                    try:
+                        has_more = bool(runs.more)
+                    except (AttributeError, TypeError, ValueError):
+                        has_more = len(page) == applied_limit
                 items = [
                     _serialize_run(
                         run,
@@ -684,9 +937,12 @@ def query_wandb(
                     entity_name,
                     project_name,
                     items,
+                    requested_limit,
                     applied_limit,
                     has_more,
                     total_count,
+                    cursor=cursor,
+                    next_cursor=_collection_cursor(runs, has_more),
                     compatibility_caveat=compatibility_caveat,
                 )
 
@@ -695,68 +951,114 @@ def query_wandb(
                 return _single_envelope(resource, entity_name, project_name, _serialize_sweep(sweep, include_fields))
 
             if resource == "sweeps":
-                sweeps = api.project(project_name, entity=entity_name).sweeps(per_page=per_page)
-                total_count = _collection_total_count(sweeps)
-                page = list(islice(sweeps, applied_limit + 1))
-                has_more = len(page) > applied_limit or requested_limit > applied_limit
-                items = [_serialize_sweep(sweep, include_fields) for sweep in page[:applied_limit]]
-                if total_count is None and not has_more:
-                    total_count = len(items)
+                try:
+                    sweeps = fetch_projected_sweeps(
+                        api,
+                        entity=entity_name,
+                        project=project_name,
+                        limit=applied_limit,
+                        page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
+                        include_config="config" in include_fields,
+                        cursor=cursor,
+                    )
+                except SelectiveReadUnavailable as exc:
+                    if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                        return structured_error(
+                            "selective_read_unavailable",
+                            f"{exc}; a bounded continuation cannot be reproduced safely by the public SDK",
+                            source="wandb_sdk",
+                            resource=resource,
+                        )
+                    sdk_sweeps = api.project(project_name, entity=entity_name).sweeps(
+                        per_page=min(applied_limit + 1, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE)
+                    )
+                    sweep_page = list(islice(sdk_sweeps, applied_limit + 1))
+                    has_more = len(sweep_page) > applied_limit or bool(getattr(sdk_sweeps, "more", False))
+                    items = [_serialize_sweep(sweep, include_fields) for sweep in sweep_page[:applied_limit]]
+                    return _collection_envelope(
+                        resource,
+                        entity_name,
+                        project_name,
+                        items,
+                        requested_limit,
+                        applied_limit,
+                        has_more,
+                        _collection_total_count(sdk_sweeps),
+                        next_cursor=_collection_cursor(sdk_sweeps, has_more),
+                        compatibility_caveat=f"{exc}; used a small bounded SDK fallback",
+                    )
+                return _collection_envelope(
+                    resource,
+                    entity_name,
+                    project_name,
+                    [_decorate_projected_sweep(item) for item in sweeps.items],
+                    requested_limit,
+                    applied_limit,
+                    sweeps.has_more,
+                    sweeps.total_count,
+                    cursor=cursor,
+                    next_cursor=sweeps.next_cursor,
+                    source="wandb_selective_read",
+                )
+
+            try:
+                reports = fetch_projected_reports(
+                    api,
+                    entity=entity_name,
+                    project=project_name,
+                    report_name=report_name,
+                    limit=applied_limit,
+                    page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
+                    include_spec="spec" in include_fields,
+                    cursor=cursor,
+                )
+            except SelectiveReadUnavailable as exc:
+                if cursor is not None or applied_limit > MCP_MAX_FULL_DETAIL_ITEMS:
+                    return structured_error(
+                        "selective_read_unavailable",
+                        f"{exc}; a bounded continuation cannot be reproduced safely by the public SDK",
+                        source="wandb_sdk",
+                        resource=resource,
+                    )
+                sdk_reports = api.reports(
+                    path,
+                    name=report_name,
+                    per_page=min(applied_limit + 1, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE),
+                )
+                report_page = list(islice(sdk_reports, applied_limit + 1))
+                items = [_serialize_report(report, include_fields) for report in report_page[:applied_limit]]
+                has_more = len(report_page) > applied_limit or bool(getattr(sdk_reports, "more", False))
                 return _collection_envelope(
                     resource,
                     entity_name,
                     project_name,
                     items,
+                    requested_limit,
                     applied_limit,
                     has_more,
-                    total_count,
+                    None if has_more else len(items),
+                    next_cursor=_collection_cursor(sdk_reports, has_more),
+                    compatibility_caveat=f"{exc}; used a small bounded SDK fallback",
                 )
-
-            reports = api.reports(path, name=report_name, per_page=per_page)
-            total_count = _collection_total_count(reports)
-            page = list(islice(reports, applied_limit + 1))
-            has_more = len(page) > applied_limit or requested_limit > applied_limit
-            items = [_serialize_report(report, include_fields) for report in page[:applied_limit]]
-            if total_count is None and not has_more:
-                total_count = len(items)
             return _collection_envelope(
                 resource,
                 entity_name,
                 project_name,
-                items,
+                [_decorate_projected_report(item, entity_name, project_name) for item in reports.items],
+                requested_limit,
                 applied_limit,
-                has_more,
-                total_count,
-            )
-        except (ValueError, KeyError, IndexError) as exc:
-            if resource in {"project", "run", "sweep"}:
-                ctx.mark_error(f"resource_not_found: {exc}")
-                return structured_error(
-                    "resource_not_found",
-                    str(exc)[:500],
-                    source="wandb_sdk",
-                    resource=resource,
-                    entity=entity_name,
-                    project=project_name,
-                )
-            logger.error("W&B SDK query failed: %s", exc, exc_info=True)
-            ctx.mark_error(f"sdk_query_failed: {exc}")
-            return structured_error(
-                "sdk_query_failed",
-                str(exc)[:500],
-                source="wandb_sdk",
-                resource=resource,
-                entity=entity_name,
-                project=project_name,
+                reports.has_more,
+                reports.total_count,
+                cursor=cursor,
+                next_cursor=reports.next_cursor,
+                source="wandb_selective_read",
             )
         except Exception as exc:
             logger.error("W&B SDK query failed: %s", exc, exc_info=True)
             ctx.mark_error(f"sdk_query_failed: {exc}")
-            return structured_error(
-                "sdk_query_failed",
-                str(exc)[:500],
-                source="wandb_sdk",
+            return _sdk_error_result(
+                exc,
                 resource=resource,
-                entity=entity_name,
-                project=project_name,
+                entity_name=entity_name,
+                project_name=project_name,
             )

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -1,15 +1,16 @@
-"""Module for querying the W&B GraphQL API."""
+"""Bounded, opt-in, query-only access to the W&B GraphQL API."""
+
+from __future__ import annotations
 
 import copy
-import logging
-import re
-import traceback
-from typing import Any, Dict, List, Optional
+import json
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
 
-from graphql import parse
 from graphql.language import ast as gql_ast
 from graphql.language import printer as gql_printer
-from graphql.language import visitor as gql_visitor
+
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_graphql import (
@@ -20,72 +21,76 @@ from wandb_mcp_server.wandb_graphql import (
 
 logger = get_rich_logger(__name__)
 
+MAX_GRAPHQL_DOCUMENT_BYTES = 64 * 1024
+MAX_GRAPHQL_DEPTH = 12
+MAX_GRAPHQL_FIELDS = 200
+MAX_GRAPHQL_FRAGMENTS = 32
 
-QUERY_WANDB_GRAPHQL_TOOL_DESCRIPTION = """Execute an advanced, query-only GraphQL document against W&B Models.
+QUERY_WANDB_GRAPHQL_TOOL_DESCRIPTION = """Execute a bounded, query-only GraphQL document against W&B Models.
 
-This opt-in escape hatch is only for reads without public W&B SDK parity:
-- schema introspection
-- unmodeled or custom fields
-- cross-resource nested selections
-- aliases or an exact GraphQL response shape
+This opt-in compatibility escape hatch is only for reads without public W&B API
+parity: schema introspection, unmodeled/custom fields, aliases, an exact GraphQL response shape,
+cross-resource nesting, sweep agents, report run sets, Launch resources, compound
+reads, and backward-pagination shapes.
 
 <when_to_use>
-Use only when the requested read cannot be represented by the public W&B SDK and
-the deployment administrator has deliberately enabled raw GraphQL access.
+Use only when the requested read cannot be represented by a typed MCP tool and
+the deployment administrator deliberately enabled raw GraphQL.
 </when_to_use>
 
 Do not use this tool for projects, run lookup/filtering/sorting, sweeps, reports,
-artifacts, registries, automations, integrations, or run history. Those operations
-have SDK-backed MCP tools and should use them instead.
+artifacts, registries, automations, integrations, or run history. Those reads
+have bounded typed MCP tools.
 
-Only GraphQL query operations are accepted. Mutations, subscriptions, and mixed
-documents are rejected before a W&B request. Collection pagination requires the
-W&B edges/node/pageInfo connection shape.
-
-Parameters
-----------
-query : str
-    A complete read-only GraphQL query document.
-variables : dict, optional
-    Variables referenced by the document.
-max_items : int, optional
-    Maximum items accumulated across pages. Default: 100.
-items_per_page : int, optional
-    Requested collection page size. Default: 20.
+The document must contain exactly one query operation. Mutations, subscriptions,
+mixed documents, multiple operations, nested/multiple paginated connections, and
+unbounded connections are rejected before any W&B request. Responses and
+pagination are bounded by deployment limits.
 """
 
 
+class GraphQLQueryValidationError(ValueError):
+    """Raised before API construction when an opt-in raw query is unsafe."""
+
+    def __init__(self, message: str, *, error: str = "invalid_request") -> None:
+        self.error = error
+        super().__init__(message)
+
+
+@dataclass
+class _ConnectionPlan:
+    path: list[str]
+    field: gql_ast.FieldNode
+    first_variable: str | None
+    after_variable: str | None
+    initial_after: str | None
+    backward: bool = False
+
+
 def find_paginated_collections(obj: Dict, current_path: Optional[List[str]] = None) -> List[List[str]]:
-    """Find collections in a response that follow the W&B connection pattern. Returns List[List[str]]."""
-    # Ensure this implementation correctly builds and returns List[List[str]]
-    if current_path is None:
-        current_path = []
-    collections = []
+    """Find W&B-style connection objects in a response."""
+    path = [] if current_path is None else current_path
+    collections: list[list[str]] = []
     if isinstance(obj, dict):
         if (
-            "edges" in obj
-            and "pageInfo" in obj
-            and isinstance(obj.get("edges"), list)
+            isinstance(obj.get("edges"), list)
             and isinstance(obj.get("pageInfo"), dict)
-            and "hasNextPage" in obj.get("pageInfo", {})
-            and "endCursor" in obj.get("pageInfo", {})
+            and "hasNextPage" in obj["pageInfo"]
+            and "endCursor" in obj["pageInfo"]
         ):
-            collections.append(list(current_path))  # Correct: append list path
-        # Recurse correctly
+            collections.append(list(path))
         for key, value in obj.items():
-            current_path.append(key)
-            collections.extend(find_paginated_collections(value, current_path))
-            current_path.pop()
+            path.append(key)
+            collections.extend(find_paginated_collections(value, path))
+            path.pop()
     elif isinstance(obj, list):
         for item in obj:
-            collections.extend(find_paginated_collections(item, current_path))
+            collections.extend(find_paginated_collections(item, path))
     return collections
 
 
 def get_nested_value(obj: Dict, path: list[str]) -> Optional[Any]:
-    """Get a value from a nested dictionary using a list of keys (path)."""
-    current = obj
-    # Iterate directly over the list path
+    current: Any = obj
     for key in path:
         if not isinstance(current, dict) or key not in current:
             return None
@@ -93,531 +98,567 @@ def get_nested_value(obj: Dict, path: list[str]) -> Optional[Any]:
     return current
 
 
-_HOSTED_LIMIT_VARIABLE_RE = re.compile(r"^(first|limit|count|max_?items|page_?size|items_per_page)$", re.I)
-
-
 def _field_name(node: gql_ast.FieldNode) -> str:
-    """Return the response field name for a GraphQL field."""
     return node.alias.value if node.alias else node.name.value
 
 
-def _is_connection_field(node: gql_ast.FieldNode) -> bool:
-    """Return True if a field selection looks like a W&B connection."""
-    if not node.selection_set:
-        return False
-    child_names = {
-        selection.name.value for selection in node.selection_set.selections if isinstance(selection, gql_ast.FieldNode)
-    }
-    return {"edges", "pageInfo"}.issubset(child_names)
-
-
-class HostedGraphQLPreflightVisitor(gql_visitor.Visitor):
-    """Clamp hosted GraphQL page sizes and reject unsafe fanout shapes."""
-
-    def __init__(self, max_first: int) -> None:
-        super().__init__()
-        self.max_first = max_first
-        self.path: list[str] = []
-        self.connection_depth = 0
-        self.connection_paths: list[tuple[str, ...]] = []
-        self.rewrites: list[str] = []
-        self.rejections: list[str] = []
-
-    def enter_variable_definition(self, node, key, parent, path, ancestors):
-        if not isinstance(node, gql_ast.VariableDefinitionNode):
-            return
-        if not _HOSTED_LIMIT_VARIABLE_RE.match(node.variable.name.value):
-            return
-        if not isinstance(node.default_value, gql_ast.IntValueNode):
-            return
-
-        requested = int(node.default_value.value)
-        if requested <= self.max_first:
-            return
-
-        node.default_value = gql_ast.IntValueNode(value=str(self.max_first))
-        self.rewrites.append(f"Clamped ${node.variable.name.value} default from {requested} to {self.max_first}")
-
-    def enter_field(self, node, key, parent, path, ancestors):
-        if not isinstance(node, gql_ast.FieldNode):
-            return
-
-        self.path.append(_field_name(node))
-        if not _is_connection_field(node):
-            return
-
-        current_path = tuple(self.path)
-        self.connection_paths.append(current_path)
-        if self.connection_depth > 0:
-            self.rejections.append(
-                f"Nested paginated collection is not allowed in hosted mode: {'/'.join(current_path)}"
-            )
-        if len(self.connection_paths) > 1:
-            self.rejections.append(
-                f"Hosted GraphQL queries may include only one paginated collection; found {len(self.connection_paths)}."
-            )
-
-        existing_args = list(node.arguments or [])
-        has_first = False
-        for idx, arg in enumerate(existing_args):
-            arg_name = arg.name.value
-            if arg_name == "last":
-                self.rejections.append(
-                    f"Hosted GraphQL does not support reverse pagination with last: {'/'.join(current_path)}"
+def _selection_field_names(
+    selection_set: gql_ast.SelectionSetNode | None,
+    fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+    stack: tuple[str, ...] = (),
+) -> set[str]:
+    names: set[str] = set()
+    if selection_set is None:
+        return names
+    for selection in selection_set.selections:
+        if isinstance(selection, gql_ast.FieldNode):
+            names.add(selection.name.value)
+        elif isinstance(selection, gql_ast.InlineFragmentNode):
+            names.update(_selection_field_names(selection.selection_set, fragments, stack))
+        elif isinstance(selection, gql_ast.FragmentSpreadNode):
+            fragment_name = selection.name.value
+            if fragment_name in stack:
+                raise GraphQLQueryValidationError("GraphQL fragment cycles are not allowed")
+            fragment = fragments.get(fragment_name)
+            if fragment is None:
+                raise GraphQLQueryValidationError(f"Unknown GraphQL fragment: {fragment_name}")
+            names.update(
+                _selection_field_names(
+                    fragment.selection_set,
+                    fragments,
+                    (*stack, fragment_name),
                 )
-            if arg_name != "first":
-                continue
-            has_first = True
-            if isinstance(arg.value, gql_ast.IntValueNode):
-                requested = int(arg.value.value)
-                if requested > self.max_first:
-                    existing_args[idx] = gql_ast.ArgumentNode(
-                        name=arg.name,
-                        value=gql_ast.IntValueNode(value=str(self.max_first)),
-                    )
-                    self.rewrites.append(f"Clamped {'/'.join(current_path)} first from {requested} to {self.max_first}")
-
-        if not has_first:
-            self.rejections.append(
-                "Hosted GraphQL paginated collections must include a first argument so the initial request "
-                f"can be bounded: {'/'.join(current_path)}"
             )
-
-        node.arguments = tuple(existing_args)
-        self.connection_depth += 1
-
-    def leave_field(self, node, key, parent, path, ancestors):
-        if isinstance(node, gql_ast.FieldNode) and _is_connection_field(node):
-            self.connection_depth = max(0, self.connection_depth - 1)
-        if self.path:
-            self.path.pop()
+    return names
 
 
-def _hosted_preprocess_graphql_query(query: str, max_first: int) -> tuple[str, list[str], list[str]]:
-    """Rewrite hosted GraphQL pagination limits before the first execution."""
-    document = parse(query.strip())
-    visitor = HostedGraphQLPreflightVisitor(max_first=max_first)
-    rewritten = gql_visitor.visit(document, visitor)
-    return gql_printer.print_ast(rewritten), visitor.rewrites, visitor.rejections
+def _is_connection_field(
+    node: gql_ast.FieldNode,
+    fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+) -> bool:
+    return {"edges", "pageInfo"}.issubset(_selection_field_names(node.selection_set, fragments))
 
 
-def _hosted_clamp_variables(variables: Dict[str, Any], max_first: int) -> Dict[str, Any]:
-    """Clamp common page-size variable names before the initial GraphQL execute."""
-    clamped = dict(variables)
-    for key, value in list(clamped.items()):
-        if not _HOSTED_LIMIT_VARIABLE_RE.match(key):
-            continue
-        if isinstance(value, int) and value > max_first:
-            clamped[key] = max_first
-    return clamped
+def _int_variable_defaults(operation: gql_ast.OperationDefinitionNode) -> dict[str, int]:
+    defaults: dict[str, int] = {}
+    for definition in operation.variable_definitions or ():
+        if isinstance(definition.default_value, gql_ast.IntValueNode):
+            defaults[definition.variable.name.value] = int(definition.default_value.value)
+    return defaults
+
+
+def _replace_argument(
+    field: gql_ast.FieldNode,
+    name: str,
+    value: gql_ast.ValueNode,
+) -> None:
+    arguments = list(field.arguments or ())
+    for index, argument in enumerate(arguments):
+        if argument.name.value == name:
+            arguments[index] = gql_ast.ArgumentNode(name=argument.name, value=value)
+            field.arguments = tuple(arguments)
+            return
+    arguments.append(gql_ast.ArgumentNode(name=gql_ast.NameNode(value=name), value=value))
+    field.arguments = tuple(arguments)
+
+
+def _ensure_variable_definition(
+    operation: gql_ast.OperationDefinitionNode,
+    variable_name: str,
+    type_name: str,
+) -> None:
+    definitions = list(operation.variable_definitions or ())
+    if any(definition.variable.name.value == variable_name for definition in definitions):
+        return
+    definitions.append(
+        gql_ast.VariableDefinitionNode(
+            variable=gql_ast.VariableNode(name=gql_ast.NameNode(value=variable_name)),
+            type=gql_ast.NamedTypeNode(name=gql_ast.NameNode(value=type_name)),
+        )
+    )
+    operation.variable_definitions = tuple(definitions)
+
+
+def _analyze_and_bound_document(
+    query: str,
+    variables: Optional[Mapping[str, Any]],
+    page_size: int,
+) -> tuple[str, dict[str, Any], _ConnectionPlan | None]:
+    if not isinstance(query, str) or not query.strip():
+        raise GraphQLQueryValidationError("query must be a non-empty string")
+    if len(query.encode("utf-8")) > MAX_GRAPHQL_DOCUMENT_BYTES:
+        raise GraphQLQueryValidationError("GraphQL document exceeds the 64 KiB limit", error="query_too_complex")
+    if variables is not None and not isinstance(variables, Mapping):
+        raise GraphQLQueryValidationError("variables must be a mapping")
+    try:
+        variables_bytes = len(json.dumps(dict(variables or {}), ensure_ascii=False, allow_nan=False).encode("utf-8"))
+    except (TypeError, ValueError):
+        raise GraphQLQueryValidationError("variables must be finite JSON-compatible values") from None
+    if variables_bytes > MAX_GRAPHQL_DOCUMENT_BYTES:
+        raise GraphQLQueryValidationError(
+            "GraphQL variables exceed the 64 KiB limit",
+            error="query_too_complex",
+        )
+
+    document = validate_read_only_graphql(query)
+    operations = [
+        definition for definition in document.definitions if isinstance(definition, gql_ast.OperationDefinitionNode)
+    ]
+    if len(operations) != 1:
+        raise GraphQLQueryValidationError(
+            "GraphQL documents must contain exactly one query operation",
+            error="query_too_complex",
+        )
+    operation = operations[0]
+    fragments = {
+        definition.name.value: definition
+        for definition in document.definitions
+        if isinstance(definition, gql_ast.FragmentDefinitionNode)
+    }
+    if len(fragments) > MAX_GRAPHQL_FRAGMENTS:
+        raise GraphQLQueryValidationError(
+            f"GraphQL documents may contain at most {MAX_GRAPHQL_FRAGMENTS} fragments",
+            error="query_too_complex",
+        )
+
+    connections: list[tuple[list[str], gql_ast.FieldNode]] = []
+    field_count = 0
+    max_depth = 0
+
+    def walk(
+        selection_set: gql_ast.SelectionSetNode | None,
+        path: list[str],
+        depth: int,
+        connection_ancestor: bool,
+        fragment_stack: tuple[str, ...] = (),
+    ) -> None:
+        nonlocal field_count, max_depth
+        if selection_set is None:
+            return
+        for selection in selection_set.selections:
+            if isinstance(selection, gql_ast.FieldNode):
+                field_count += 1
+                max_depth = max(max_depth, depth)
+                if field_count > MAX_GRAPHQL_FIELDS or max_depth > MAX_GRAPHQL_DEPTH:
+                    raise GraphQLQueryValidationError(
+                        (
+                            f"GraphQL documents are limited to {MAX_GRAPHQL_FIELDS} selected fields "
+                            f"and depth {MAX_GRAPHQL_DEPTH}"
+                        ),
+                        error="query_too_complex",
+                    )
+                field_path = [*path, _field_name(selection)]
+                is_connection = _is_connection_field(selection, fragments)
+                if is_connection:
+                    if connection_ancestor:
+                        raise GraphQLQueryValidationError(
+                            f"Nested paginated connection is not allowed: {'/'.join(field_path)}",
+                            error="query_too_complex",
+                        )
+                    connections.append((field_path, selection))
+                    if len(connections) > 1:
+                        raise GraphQLQueryValidationError(
+                            "GraphQL documents may contain only one paginated connection",
+                            error="query_too_complex",
+                        )
+                walk(
+                    selection.selection_set,
+                    field_path,
+                    depth + 1,
+                    connection_ancestor or is_connection,
+                    fragment_stack,
+                )
+            elif isinstance(selection, gql_ast.InlineFragmentNode):
+                walk(selection.selection_set, path, depth, connection_ancestor, fragment_stack)
+            elif isinstance(selection, gql_ast.FragmentSpreadNode):
+                fragment_name = selection.name.value
+                if fragment_name in fragment_stack:
+                    raise GraphQLQueryValidationError("GraphQL fragment cycles are not allowed")
+                fragment = fragments.get(fragment_name)
+                if fragment is None:
+                    raise GraphQLQueryValidationError(f"Unknown GraphQL fragment: {fragment_name}")
+                walk(
+                    fragment.selection_set,
+                    path,
+                    depth,
+                    connection_ancestor,
+                    (*fragment_stack, fragment_name),
+                )
+
+    walk(operation.selection_set, [], 1, False)
+    bounded_variables = dict(variables or {})
+    if not connections:
+        return gql_printer.print_ast(document), bounded_variables, None
+
+    connection_path, connection_field = connections[0]
+    arguments = {argument.name.value: argument for argument in connection_field.arguments or ()}
+    first = arguments.get("first")
+    last = arguments.get("last")
+    if first is not None and last is not None:
+        raise GraphQLQueryValidationError("A paginated connection cannot use both first and last")
+    if first is None and last is None:
+        raise GraphQLQueryValidationError(
+            f"Paginated connection must include first or last: {'/'.join(connection_path)}",
+            error="query_too_complex",
+        )
+
+    first_variable: str | None = None
+    pagination_argument = first or last
+    assert pagination_argument is not None
+    argument_name = "first" if first is not None else "last"
+    if isinstance(pagination_argument.value, gql_ast.IntValueNode):
+        requested_first = int(pagination_argument.value.value)
+        if requested_first < 1:
+            raise GraphQLQueryValidationError(f"GraphQL {argument_name} must be a positive integer")
+        _replace_argument(
+            connection_field,
+            argument_name,
+            gql_ast.IntValueNode(value=str(min(requested_first, page_size))),
+        )
+    elif isinstance(pagination_argument.value, gql_ast.VariableNode):
+        first_variable = pagination_argument.value.name.value
+        defaults = _int_variable_defaults(operation)
+        requested_first = bounded_variables.get(first_variable, defaults.get(first_variable, page_size))
+        if isinstance(requested_first, bool) or not isinstance(requested_first, int) or requested_first < 1:
+            raise GraphQLQueryValidationError(
+                f"GraphQL variable ${first_variable}, bound to {argument_name}, must be a positive integer"
+            )
+        bounded_variables[first_variable] = min(requested_first, page_size)
+    else:
+        raise GraphQLQueryValidationError(f"GraphQL {argument_name} must be an integer literal or variable")
+
+    if last is not None:
+        return (
+            gql_printer.print_ast(document),
+            bounded_variables,
+            _ConnectionPlan(
+                path=connection_path,
+                field=connection_field,
+                first_variable=first_variable,
+                after_variable=None,
+                initial_after=None,
+                backward=True,
+            ),
+        )
+
+    after = arguments.get("after")
+    after_variable = "__mcp_after"
+    initial_after: str | None = None
+    if after is not None and isinstance(after.value, gql_ast.VariableNode):
+        after_variable = after.value.name.value
+        supplied_after = bounded_variables.get(after_variable)
+        if supplied_after is not None and not isinstance(supplied_after, str):
+            raise GraphQLQueryValidationError(f"GraphQL variable ${after_variable} must be a string or null")
+        initial_after = supplied_after
+    else:
+        if after is not None and isinstance(after.value, gql_ast.StringValueNode):
+            initial_after = after.value.value
+        _ensure_variable_definition(operation, after_variable, "String")
+        _replace_argument(
+            connection_field,
+            "after",
+            gql_ast.VariableNode(name=gql_ast.NameNode(value=after_variable)),
+        )
+        bounded_variables[after_variable] = initial_after
+
+    return (
+        gql_printer.print_ast(document),
+        bounded_variables,
+        _ConnectionPlan(
+            path=connection_path,
+            field=connection_field,
+            first_variable=first_variable,
+            after_variable=after_variable,
+            initial_after=initial_after,
+        ),
+    )
+
+
+def _estimate_tokens(payload: Mapping[str, Any]) -> int:
+    return max(1, len(json.dumps(payload, default=str, ensure_ascii=False, allow_nan=False)) // 4)
+
+
+def _set_pagination_extension(
+    result: dict[str, Any],
+    *,
+    returned_count: int,
+    has_more: bool,
+    next_cursor: str | None,
+    truncated_by_budget: bool = False,
+) -> None:
+    extensions = result.setdefault("extensions", {})
+    if not isinstance(extensions, dict):
+        extensions = {}
+        result["extensions"] = extensions
+    extensions["wandb_mcp"] = {
+        "returned_count": returned_count,
+        "has_more": has_more,
+        "next_cursor": next_cursor if has_more else None,
+        "truncated_by_response_budget": truncated_by_budget,
+    }
+
+
+def _fit_response_budget(
+    result: dict[str, Any],
+    connection_path: list[str] | None,
+    *,
+    backward: bool = False,
+) -> dict[str, Any]:
+    from wandb_mcp_server.config import MAX_RESPONSE_TOKENS
+
+    try:
+        if _estimate_tokens(result) <= MAX_RESPONSE_TOKENS:
+            return result
+    except (TypeError, ValueError):
+        return {
+            "errors": [
+                {
+                    "error": "response_too_large",
+                    "message": "GraphQL response could not be serialized safely",
+                }
+            ]
+        }
+    connection = get_nested_value(result, connection_path or []) if connection_path else None
+    if not isinstance(connection, dict) or not isinstance(connection.get("edges"), list):
+        return {
+            "errors": [
+                {
+                    "error": "response_too_large",
+                    "message": "GraphQL response exceeded the configured response budget",
+                }
+            ]
+        }
+    edges = connection["edges"]
+    dropped = 0
+    while edges and _estimate_tokens(result) > MAX_RESPONSE_TOKENS:
+        edges.pop()
+        dropped += 1
+    page_info = connection.setdefault("pageInfo", {})
+    if backward:
+        last_cursor = edges[0].get("cursor") if edges and isinstance(edges[0], dict) else None
+        page_info["hasPreviousPage"] = True
+        page_info["startCursor"] = last_cursor
+    else:
+        last_cursor = edges[-1].get("cursor") if edges and isinstance(edges[-1], dict) else None
+        page_info["hasNextPage"] = True
+        page_info["endCursor"] = last_cursor
+    _set_pagination_extension(
+        result,
+        returned_count=len(edges),
+        has_more=True,
+        next_cursor=last_cursor,
+        truncated_by_budget=True,
+    )
+    if _estimate_tokens(result) > MAX_RESPONSE_TOKENS:
+        return {
+            "errors": [
+                {
+                    "error": "response_too_large",
+                    "message": "GraphQL response metadata exceeded the configured response budget",
+                }
+            ]
+        }
+    return result
+
+
+def _validation_error(exc: Exception) -> dict[str, Any]:
+    if isinstance(exc, GraphQLReadOnlyViolation):
+        return {
+            "errors": [
+                {
+                    "error": "read_only_violation",
+                    "message": str(exc),
+                    "operation_types": list(exc.operation_types),
+                }
+            ]
+        }
+    return {
+        "errors": [
+            {
+                "error": getattr(exc, "error", "invalid_request"),
+                "message": str(exc),
+            }
+        ]
+    }
 
 
 def query_paginated_wandb_gql(
     query: str,
     variables: Optional[Dict[str, Any]] = None,
     max_items: int = 100,
-    items_per_page: int = 50,
+    items_per_page: int = 20,
 ) -> Dict[str, Any]:
-    """
-    Execute a GraphQL query against the W&B API with pagination support using AST modification.
-    Handles a single paginated field detected via the connection pattern.
-    Modifies the result dictionary in-place.
+    """Execute one bounded read-only GraphQL operation."""
+    if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+        return _validation_error(GraphQLQueryValidationError("max_items must be a positive integer"))
+    if isinstance(items_per_page, bool) or not isinstance(items_per_page, int) or items_per_page < 1:
+        return _validation_error(GraphQLQueryValidationError("items_per_page must be a positive integer"))
 
-    Args:
-        query: The GraphQL query string. MUST include pageInfo{hasNextPage, endCursor} for paginated fields.
-        variables: Variables to pass to the GraphQL query.
-        max_items: Maximum number of items to fetch across all pages (default: 100).
-        items_per_page: Number of items to request per page (default: 20).
-        deduplicate: Whether to deduplicate nodes by ID across pages (default: True).
+    from wandb_mcp_server.config import MCP_MAX_GQL_ITEMS, MCP_MAX_GQL_ITEMS_PER_PAGE
 
-    Returns:
-        The aggregated GraphQL response dictionary.
-    """
+    applied_max_items = min(max_items, MCP_MAX_GQL_ITEMS)
+    applied_page_size = min(items_per_page, MCP_MAX_GQL_ITEMS_PER_PAGE, applied_max_items)
     try:
-        validate_read_only_graphql(query)
-    except GraphQLReadOnlyViolation as e:
-        return {
-            "errors": [
-                {
-                    "error": "read_only_violation",
-                    "message": str(e),
-                    "operation_types": list(e.operation_types),
-                }
-            ]
-        }
-    except Exception as e:
-        return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
+        bounded_query, bounded_variables, plan = _analyze_and_bound_document(
+            query,
+            variables,
+            applied_page_size,
+        )
+    except Exception as exc:
+        return _validation_error(exc)
 
     from wandb_mcp_server.api_client import get_wandb_api
 
-    api = get_wandb_api()
-    result_dict = {}
-    limit_key = None
     with track_tool_execution(
         "query_paginated_wandb_gql",
         None,
         {
-            "query": query,
-            "variables": variables,
-            "max_items": max_items,
-            "items_per_page": items_per_page,
+            "query_bytes": len(query.encode("utf-8")),
+            "has_variables": bool(variables),
+            "max_items": applied_max_items,
+            "items_per_page": applied_page_size,
         },
         mcp_tool_name="query_wandb_graphql_tool",
     ) as ctx:
         try:
-            from wandb_mcp_server.config import (
-                MCP_HOSTED_MODE,
-                MCP_MAX_GQL_ITEMS,
-                MCP_MAX_GQL_ITEMS_PER_PAGE,
-            )
+            api = get_wandb_api()
+            initial = execute_graphql(api, bounded_query, bounded_variables)
+            if not isinstance(initial, Mapping):
+                raise TypeError("W&B returned a non-mapping GraphQL response")
+            result = copy.deepcopy(dict(initial))
+            if "errors" in result or plan is None:
+                return _fit_response_budget(result, None)
 
-            if MCP_HOSTED_MODE:
-                if max_items > MCP_MAX_GQL_ITEMS:
-                    logger.warning("Clamping hosted GraphQL max_items from %s to %s", max_items, MCP_MAX_GQL_ITEMS)
-                    max_items = MCP_MAX_GQL_ITEMS
-                if items_per_page > MCP_MAX_GQL_ITEMS_PER_PAGE:
-                    logger.warning(
-                        "Clamping hosted GraphQL items_per_page from %s to %s",
-                        items_per_page,
-                        MCP_MAX_GQL_ITEMS_PER_PAGE,
+            connection = get_nested_value(result, plan.path)
+            if not isinstance(connection, dict):
+                return _fit_response_budget(result, None)
+            initial_edges = connection.get("edges")
+            page_info = connection.get("pageInfo")
+            if not isinstance(initial_edges, list) or not isinstance(page_info, dict):
+                return _fit_response_budget(result, None)
+
+            if plan.backward:
+                cut_mid_page = len(initial_edges) > applied_max_items
+                connection["edges"] = initial_edges[:applied_max_items]
+                has_more = bool(page_info.get("hasPreviousPage")) or cut_mid_page
+                next_cursor = page_info.get("startCursor")
+                if cut_mid_page and connection["edges"] and isinstance(connection["edges"][0], Mapping):
+                    next_cursor = connection["edges"][0].get("cursor") or next_cursor
+                connection["pageInfo"] = {
+                    **page_info,
+                    "hasPreviousPage": has_more,
+                    "startCursor": next_cursor,
+                }
+                _set_pagination_extension(
+                    result,
+                    returned_count=len(connection["edges"]),
+                    has_more=has_more,
+                    next_cursor=next_cursor,
+                )
+                return _fit_response_budget(result, plan.path, backward=True)
+
+            aggregated: list[Any] = []
+            seen_ids: set[Any] = set()
+
+            def append_edges(edges: list[Any]) -> bool:
+                cut_mid_page = False
+                for edge in edges:
+                    if len(aggregated) >= applied_max_items:
+                        cut_mid_page = True
+                        break
+                    node = edge.get("node") if isinstance(edge, Mapping) else None
+                    node_id = node.get("id") if isinstance(node, Mapping) else None
+                    if node_id is not None and node_id in seen_ids:
+                        continue
+                    if node_id is not None:
+                        seen_ids.add(node_id)
+                    aggregated.append(edge)
+                return cut_mid_page
+
+            cut_mid_page = append_edges(initial_edges)
+            current_page_info = dict(page_info)
+            has_next = bool(current_page_info.get("hasNextPage"))
+            cursor = current_page_info.get("endCursor")
+            max_page_requests = max(1, math.ceil(applied_max_items / applied_page_size) + 2)
+            page_requests = 1
+            partial_error = False
+
+            while has_next and cursor and len(aggregated) < applied_max_items and page_requests < max_page_requests:
+                page_variables = dict(bounded_variables)
+                assert plan.after_variable is not None
+                page_variables[plan.after_variable] = cursor
+                if plan.first_variable:
+                    page_variables[plan.first_variable] = min(
+                        applied_page_size,
+                        applied_max_items - len(aggregated),
                     )
-                    items_per_page = MCP_MAX_GQL_ITEMS_PER_PAGE
-
-            logger.info("--- Inside query_paginated_wandb_gql: Step 0: Execute Initial Query ---")
-
-            page1_vars_func = variables.copy() if variables is not None else {}
-            limit_key = None
-            for k in page1_vars_func:
-                if k.lower() in ["limit", "first", "count"]:
-                    limit_key = k
-                    break
-            if limit_key:
-                page1_vars_func[limit_key] = min(items_per_page, page1_vars_func.get(limit_key) or items_per_page)
-            else:
-                limit_key = "limit"
-                page1_vars_func[limit_key] = items_per_page
-                logger.debug(f"No limit variable found in input, adding '{limit_key}={items_per_page}'")
-
-            if MCP_HOSTED_MODE:
                 try:
-                    query, rewrites, rejections = _hosted_preprocess_graphql_query(
-                        query,
-                        MCP_MAX_GQL_ITEMS_PER_PAGE,
-                    )
-                    page1_vars_func = _hosted_clamp_variables(
-                        page1_vars_func,
-                        MCP_MAX_GQL_ITEMS_PER_PAGE,
-                    )
-                    if rejections:
-                        ctx.mark_error(f"query_too_complex: {rejections[0]}")
-                        return {
-                            "errors": [
-                                {
-                                    "message": rejections[0],
-                                    "details": rejections,
-                                    "error": "query_too_complex",
-                                }
-                            ]
+                    page = execute_graphql(api, bounded_query, page_variables)
+                except Exception as exc:
+                    result.setdefault("errors", []).append(
+                        {
+                            "error": "upstream_error",
+                            "message": f"W&B GraphQL pagination failed ({type(exc).__name__})",
                         }
-                    if rewrites:
-                        logger.warning("Hosted GraphQL preflight rewrote query: %s", rewrites)
-                except Exception as e:
-                    logger.error("Hosted GraphQL preflight failed: %s", e, exc_info=True)
-                    ctx.mark_error(f"invalid_input: {e}")
-                    return {"errors": [{"message": f"Failed to validate initial query: {e}"}]}
-
-            try:
-                parse(query.strip())
-            except Exception as e:
-                logger.error(f"Failed to parse initial query with graphql-core: {e}")
-                ctx.mark_error(f"invalid_input: {e}")
-                return {"errors": [{"message": f"Failed to parse initial query: {e}"}]}
-
-            try:
-                result1 = execute_graphql(api, query.strip(), page1_vars_func)
-                result_dict = copy.deepcopy(result1)
-                if "errors" in result_dict:
-                    logger.error(f"GraphQL errors in initial response: {result_dict['errors']}")
-                    ctx.mark_error("upstream_error: GraphQL errors in initial response")
-                    return result_dict
-            except Exception as e:
-                logger.error(f"Failed to execute initial GraphQL query: {e}", exc_info=True)
-                ctx.mark_error(f"upstream_error: {e}")
-                return {"errors": [{"message": f"Failed to execute initial query: {e}"}]}
-
-            detected_paths = find_paginated_collections(result_dict)
-            if not detected_paths:
-                logger.info("No paginated paths detected. Returning initial result.")
-                return result_dict
-
-            path_to_paginate = detected_paths[0]
-            logger.info(f"Using path for pagination: {'/'.join(path_to_paginate)}")
-
-            runs_data1 = get_nested_value(result_dict, path_to_paginate)
-            if runs_data1 is None:
-                logger.warning(
-                    f"Could not extract data for pagination path {'/'.join(path_to_paginate)}. Returning initial result."
-                )
-                return result_dict
-            page_info1 = get_nested_value(runs_data1, ["pageInfo"])
-            if page_info1 is None:
-                logger.warning(
-                    f"Could not extract pageInfo for pagination path {'/'.join(path_to_paginate)}. Returning initial result."
-                )
-                return result_dict
-
-            cursor = page_info1.get("endCursor")
-            has_next = page_info1.get("hasNextPage")
-            initial_edges = runs_data1.get("edges", [])
-            logging.info(f"Page 1 Results: {len(initial_edges)} runs.")
-            logging.info(f"Page 1 PageInfo: {page_info1}")
-
-            seen_ids = set()
-            current_edge_count = 0
-            temp_initial_edges = []
-            if initial_edges:
-                for edge in initial_edges:
-                    try:
-                        if current_edge_count >= max_items:
-                            break
-                        node_id = edge["node"]["id"]
-                        if node_id not in seen_ids:
-                            seen_ids.add(node_id)
-                            temp_initial_edges.append(edge)
-                            current_edge_count += 1
-                    except (KeyError, TypeError):
-                        if current_edge_count < max_items:
-                            temp_initial_edges.append(edge)
-                            current_edge_count += 1
-                target_collection_dict = get_nested_value(result_dict, path_to_paginate)
-                if target_collection_dict:
-                    target_collection_dict["edges"] = temp_initial_edges[:max_items]
-                    current_edge_count = len(target_collection_dict["edges"])
-                logging.info(f"Stored {current_edge_count} unique edges after page 1 (max: {max_items}).")
-
-            if not has_next or not cursor or current_edge_count >= max_items:
-                logger.info("No further pages needed based on page 1 info or max_items reached.")
-                target_pi_dict = get_nested_value(result_dict, path_to_paginate + ["pageInfo"])
-                if target_pi_dict:
-                    target_pi_dict["hasNextPage"] = False
-                return result_dict
-
-            logging.info("\n--- Generating Paginated Query String --- ")
-            generated_paginated_query_string = None
-            after_variable_name = "after"
-            try:
-                initial_ast = parse(query.strip())
-                visitor = AddPaginationArgsVisitor(
-                    field_paths=detected_paths,
-                    first_variable_name=limit_key,
-                    after_variable_name=after_variable_name,
-                )
-                modified_ast = gql_visitor.visit(copy.deepcopy(initial_ast), visitor)
-                generated_paginated_query_string = gql_printer.print_ast(modified_ast)
-                logger.info("AST modification and printing successful.")
-            except Exception as e:
-                logger.error(f"Failed to generate query string via AST: {e}", exc_info=True)
-                return result_dict
-
-            if generated_paginated_query_string is None:
-                return result_dict
-
-            logging.info("\n--- Loop: Execute, Deduplicate, Aggregate In-Place, Check Limit ---")
-            page_num = 1
-            current_cursor = cursor
-            current_has_next = has_next
-            final_page_info = page_info1
-
-            while current_has_next:
-                if current_edge_count >= max_items:
-                    logging.info(f"Reached max_items ({max_items}). Stopping loop.")
-                    final_page_info = {**final_page_info, "hasNextPage": False}
+                    )
+                    partial_error = True
+                    break
+                page_requests += 1
+                if not isinstance(page, Mapping):
+                    partial_error = True
+                    break
+                if page.get("errors"):
+                    result.setdefault("errors", []).extend(copy.deepcopy(page["errors"]))
+                    partial_error = True
+                    break
+                page_connection = get_nested_value(dict(page), plan.path)
+                if not isinstance(page_connection, Mapping):
+                    partial_error = True
+                    break
+                page_edges = page_connection.get("edges")
+                next_page_info = page_connection.get("pageInfo")
+                if not isinstance(page_edges, list) or not isinstance(next_page_info, Mapping):
+                    partial_error = True
+                    break
+                cut_mid_page = append_edges(page_edges) or cut_mid_page
+                current_page_info = dict(next_page_info)
+                has_next = bool(current_page_info.get("hasNextPage"))
+                cursor = current_page_info.get("endCursor")
+                if not page_edges:
+                    partial_error = has_next
                     break
 
-                page_num += 1
-                logging.info(f"\nFetching Page {page_num}...")
-                page_vars = variables.copy() if variables is not None else {}
-                page_vars[limit_key] = items_per_page
-                page_vars[after_variable_name] = current_cursor
-
-                try:
-                    logging.info(f"Executing generated query for page {page_num} with vars: {page_vars}")
-                    result_page = execute_graphql(api, generated_paginated_query_string, page_vars)
-
-                    if "errors" in result_page:
-                        logger.error(
-                            f"GraphQL errors on page {page_num}: {result_page['errors']}. Stopping pagination."
-                        )
-                        current_has_next = False
-                        final_page_info = {**final_page_info, "hasNextPage": False}
-                        continue
-
-                    runs_data = get_nested_value(result_page, path_to_paginate)
-                    if runs_data is None:
-                        logging.warning(
-                            f"Could not get data for path {'/'.join(path_to_paginate)} on page {page_num}. Stopping."
-                        )
-                        current_has_next = False
-                        continue
-                    else:
-                        edges_this_page = get_nested_value(runs_data, ["edges"]) or []
-                        page_info = get_nested_value(runs_data, ["pageInfo"]) or {}
-                        final_page_info = page_info
-
-                    logging.info(f"Result (Page {page_num}): {len(edges_this_page)} runs returned.")
-                    logging.info(f"Page Info (Page {page_num}): {page_info}")
-
-                    new_edges_for_aggregation = []
-                    duplicates_skipped = 0
-                    if edges_this_page:
-                        for edge in edges_this_page:
-                            if current_edge_count + len(new_edges_for_aggregation) >= max_items:
-                                logging.info(f"Max items ({max_items}) reached mid-page {page_num}.")
-                                final_page_info = {**final_page_info, "hasNextPage": False}
-                                current_has_next = False
-                                break
-
-                            try:
-                                node_id = edge["node"]["id"]
-                                if node_id not in seen_ids:
-                                    seen_ids.add(node_id)
-                                    new_edges_for_aggregation.append(edge)
-                                else:
-                                    duplicates_skipped += 1
-                            except (KeyError, TypeError):
-                                new_edges_for_aggregation.append(edge)
-
-                        if duplicates_skipped > 0:
-                            logging.info(f"Skipped {duplicates_skipped} duplicate edges on page {page_num}.")
-
-                        if new_edges_for_aggregation:
-                            target_collection_dict_inplace = get_nested_value(result_dict, path_to_paginate)
-                            if target_collection_dict_inplace and isinstance(
-                                target_collection_dict_inplace.get("edges"), list
-                            ):
-                                target_collection_dict_inplace["edges"].extend(new_edges_for_aggregation)
-                                current_edge_count = len(target_collection_dict_inplace["edges"])
-                                logging.info(
-                                    f"Appended {len(new_edges_for_aggregation)} new edges. Total unique edges: {current_edge_count}"
-                                )
-                            else:
-                                logging.error("Could not find target edges list in result_dict to append in-place.")
-                                current_has_next = False
-                        else:
-                            if len(edges_this_page) > 0:
-                                logging.info("No new unique edges found on page {page_num} after deduplication.")
-                            else:
-                                logging.info("No edges returned on page {page_num} to aggregate.")
-                    else:
-                        logging.info("No edges returned on page {page_num} to aggregate.")
-
-                    current_cursor = final_page_info.get("endCursor")
-                    if current_has_next:
-                        current_has_next = final_page_info.get("hasNextPage", False)
-
-                    if current_has_next and not current_cursor:
-                        logging.warning("hasNextPage is true but no endCursor received. Stopping loop.")
-                        current_has_next = False
-                    if not edges_this_page:
-                        logging.warning(f"No edges received for page {page_num}. Stopping loop.")
-                        current_has_next = False
-
-                except Exception as e:
-                    logging.error(f"Execution failed for page {page_num}: {e}", exc_info=True)
-                    current_has_next = False
-
-            logging.info(f"\n--- Pagination Loop Finished after page {page_num} ---")
-            logging.info(f"Final aggregated edge count: {current_edge_count}")
-
-            target_collection_dict_final = get_nested_value(result_dict, path_to_paginate)
-            if target_collection_dict_final:
-                target_collection_dict_final["pageInfo"] = final_page_info
-                logging.info(f"Updated final pageInfo: {final_page_info}")
-
-            return result_dict
-
-        except Exception as e:
-            error_message = f"Critical error in paginated GraphQL query function: {str(e)}\n{traceback.format_exc()}"
-            logger.error(error_message)
-            ctx.mark_error(f"query_failed: {e}")
-            if result_dict:
-                if "errors" not in result_dict:
-                    result_dict["errors"] = []
-                result_dict["errors"].append({"message": "Pagination failed", "details": str(e)})
-                return result_dict
-            else:
-                return {"errors": [{"message": "Pagination failed catastrophically", "details": str(e)}]}
-
-
-class AddPaginationArgsVisitor(gql_visitor.Visitor):
-    """Adds first/after args and variables"""
-
-    def __init__(self, field_paths, first_variable_name="limit", after_variable_name="after"):
-        super().__init__()
-        self.field_paths = set(tuple(p) for p in field_paths)
-        self.first_variable_name = first_variable_name
-        self.after_variable_name = after_variable_name
-        self.current_path = []
-        self.modified_operation = False
-
-    def enter_field(self, node, key, parent, path, ancestors):
-        field_name = node.alias.value if node.alias else node.name.value
-        self.current_path.append(field_name)
-        current_path_tuple = tuple(self.current_path)
-        if current_path_tuple in self.field_paths:
-            existing_args = list(node.arguments)
-            args_changed = False
-            has_first = any(arg.name.value == "first" for arg in existing_args)
-            if not has_first:
-                # Defaulting variable name to 'limit' if not found, might need refinement
-                limit_var_node = gql_ast.VariableNode(name=gql_ast.NameNode(value=self.first_variable_name))
-                existing_args.append(gql_ast.ArgumentNode(name=gql_ast.NameNode(value="first"), value=limit_var_node))
-                args_changed = True
-            has_after = any(arg.name.value == "after" for arg in existing_args)
-            if not has_after:
-                existing_args.append(
-                    gql_ast.ArgumentNode(
-                        name=gql_ast.NameNode(value="after"),
-                        value=gql_ast.VariableNode(name=gql_ast.NameNode(value=self.after_variable_name)),
-                    )
-                )
-                args_changed = True
-            if args_changed:
-                node.arguments = tuple(existing_args)
-
-    def leave_field(self, node, key, parent, path, ancestors):
-        if self.current_path:
-            self.current_path.pop()
-
-    def enter_operation_definition(self, node, key, parent, path, ancestors):
-        if self.modified_operation:
-            return
-        existing_vars = {var.variable.name.value for var in node.variable_definitions}
-        new_defs_list = list(node.variable_definitions)
-        defs_changed = False
-        # Determine limit variable name from existing vars if possible, else default
-        current_limit_var = self.first_variable_name  # Default
-        for var_name in existing_vars:
-            if var_name.lower() in ["limit", "first", "count"]:
-                current_limit_var = var_name
-                break
-
-        if current_limit_var not in existing_vars:
-            new_defs_list.append(
-                gql_ast.VariableDefinitionNode(
-                    variable=gql_ast.VariableNode(name=gql_ast.NameNode(value=current_limit_var)),
-                    type=gql_ast.NamedTypeNode(name=gql_ast.NameNode(value="Int")),
-                )
+            stopped_at_limit = len(aggregated) >= applied_max_items and (has_next or cut_mid_page)
+            stopped_at_request_bound = page_requests >= max_page_requests and has_next
+            has_more = bool(has_next or cut_mid_page or partial_error or stopped_at_request_bound)
+            connection["edges"] = aggregated
+            last_cursor = (
+                aggregated[-1].get("cursor")
+                if aggregated and isinstance(aggregated[-1], Mapping)
+                else current_page_info.get("endCursor")
             )
-            defs_changed = True
-        if self.after_variable_name not in existing_vars:
-            new_defs_list.append(
-                gql_ast.VariableDefinitionNode(
-                    variable=gql_ast.VariableNode(name=gql_ast.NameNode(value=self.after_variable_name)),
-                    type=gql_ast.NamedTypeNode(name=gql_ast.NameNode(value="String")),
-                )
+            connection["pageInfo"] = {
+                **current_page_info,
+                "hasNextPage": has_more,
+                "endCursor": last_cursor,
+            }
+            _set_pagination_extension(
+                result,
+                returned_count=len(aggregated),
+                has_more=has_more,
+                next_cursor=last_cursor,
             )
-            defs_changed = True
-        if defs_changed:
-            node.variable_definitions = tuple(new_defs_list)
-        self.modified_operation = True
+            if stopped_at_limit:
+                result["extensions"]["wandb_mcp"]["limit_applied"] = applied_max_items
+            return _fit_response_budget(result, plan.path)
+        except Exception as exc:
+            logger.error("Bounded GraphQL query failed (%s)", type(exc).__name__)
+            ctx.mark_error(f"query_failed: {type(exc).__name__}")
+            return {
+                "errors": [
+                    {
+                        "error": "upstream_error",
+                        "message": f"W&B GraphQL query failed ({type(exc).__name__})",
+                    }
+                ]
+            }

--- a/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb_gql.py
@@ -25,6 +25,9 @@ MAX_GRAPHQL_DOCUMENT_BYTES = 64 * 1024
 MAX_GRAPHQL_DEPTH = 12
 MAX_GRAPHQL_FIELDS = 200
 MAX_GRAPHQL_FRAGMENTS = 32
+MAX_GRAPHQL_VARIABLE_DEPTH = 12
+MAX_GRAPHQL_VARIABLE_NODES = 5_000
+MAX_GRAPHQL_EXPANDED_SELECTIONS = MAX_GRAPHQL_FIELDS * 4
 
 QUERY_WANDB_GRAPHQL_TOOL_DESCRIPTION = """Execute a bounded, query-only GraphQL document against W&B Models.
 
@@ -64,7 +67,28 @@ class _ConnectionPlan:
     first_variable: str | None
     after_variable: str | None
     initial_after: str | None
+    initial_before: str | None
+    edges_key: str | None
+    page_info_key: str | None
+    edge_cursor_key: str | None
+    has_next_page_key: str | None
+    end_cursor_key: str | None
+    has_previous_page_key: str | None
+    start_cursor_key: str | None
     backward: bool = False
+
+
+@dataclass
+class _SelectionExpansionBudget:
+    visited: int = 0
+
+    def consume(self) -> None:
+        self.visited += 1
+        if self.visited > MAX_GRAPHQL_EXPANDED_SELECTIONS:
+            raise GraphQLQueryValidationError(
+                f"GraphQL expanded selections are limited to {MAX_GRAPHQL_EXPANDED_SELECTIONS}",
+                error="query_too_complex",
+            )
 
 
 def find_paginated_collections(obj: Dict, current_path: Optional[List[str]] = None) -> List[List[str]]:
@@ -106,15 +130,18 @@ def _selection_field_names(
     selection_set: gql_ast.SelectionSetNode | None,
     fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
     stack: tuple[str, ...] = (),
+    budget: _SelectionExpansionBudget | None = None,
 ) -> set[str]:
     names: set[str] = set()
     if selection_set is None:
         return names
+    budget = budget or _SelectionExpansionBudget()
     for selection in selection_set.selections:
+        budget.consume()
         if isinstance(selection, gql_ast.FieldNode):
             names.add(selection.name.value)
         elif isinstance(selection, gql_ast.InlineFragmentNode):
-            names.update(_selection_field_names(selection.selection_set, fragments, stack))
+            names.update(_selection_field_names(selection.selection_set, fragments, stack, budget))
         elif isinstance(selection, gql_ast.FragmentSpreadNode):
             fragment_name = selection.name.value
             if fragment_name in stack:
@@ -127,16 +154,99 @@ def _selection_field_names(
                     fragment.selection_set,
                     fragments,
                     (*stack, fragment_name),
+                    budget,
                 )
             )
     return names
 
 
+def _selection_fields(
+    selection_set: gql_ast.SelectionSetNode | None,
+    fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+    stack: tuple[str, ...] = (),
+    budget: _SelectionExpansionBudget | None = None,
+) -> list[gql_ast.FieldNode]:
+    """Expand one selection level, retaining response aliases."""
+    fields: list[gql_ast.FieldNode] = []
+    if selection_set is None:
+        return fields
+    budget = budget or _SelectionExpansionBudget()
+    for selection in selection_set.selections:
+        budget.consume()
+        if isinstance(selection, gql_ast.FieldNode):
+            fields.append(selection)
+        elif isinstance(selection, gql_ast.InlineFragmentNode):
+            fields.extend(_selection_fields(selection.selection_set, fragments, stack, budget))
+        elif isinstance(selection, gql_ast.FragmentSpreadNode):
+            fragment_name = selection.name.value
+            if fragment_name in stack:
+                raise GraphQLQueryValidationError("GraphQL fragment cycles are not allowed")
+            fragment = fragments.get(fragment_name)
+            if fragment is None:
+                raise GraphQLQueryValidationError(f"Unknown GraphQL fragment: {fragment_name}")
+            fields.extend(
+                _selection_fields(
+                    fragment.selection_set,
+                    fragments,
+                    (*stack, fragment_name),
+                    budget,
+                )
+            )
+    return fields
+
+
+def _response_key(
+    selection_set: gql_ast.SelectionSetNode | None,
+    field_name: str,
+    fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+    budget: _SelectionExpansionBudget,
+) -> str | None:
+    """Return the unique response key selected for a schema field."""
+    keys = {
+        _field_name(field)
+        for field in _selection_fields(selection_set, fragments, budget=budget)
+        if field.name.value == field_name
+    }
+    if len(keys) > 1:
+        raise GraphQLQueryValidationError(
+            f"Paginated connection selects {field_name!r} through multiple aliases",
+            error="query_too_complex",
+        )
+    return next(iter(keys), None)
+
+
+def _nested_response_key(
+    selection_set: gql_ast.SelectionSetNode | None,
+    parent_field_name: str,
+    child_field_name: str,
+    fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+    budget: _SelectionExpansionBudget,
+) -> str | None:
+    """Return a unique response key selected below a connection metadata field."""
+    keys: set[str] = set()
+    for field in _selection_fields(selection_set, fragments, budget=budget):
+        if field.name.value != parent_field_name:
+            continue
+        key = _response_key(field.selection_set, child_field_name, fragments, budget)
+        if key is not None:
+            keys.add(key)
+    if len(keys) > 1:
+        raise GraphQLQueryValidationError(
+            (f"Paginated connection selects {parent_field_name}.{child_field_name} through multiple aliases"),
+            error="query_too_complex",
+        )
+    return next(iter(keys), None)
+
+
 def _is_connection_field(
     node: gql_ast.FieldNode,
     fragments: Mapping[str, gql_ast.FragmentDefinitionNode],
+    budget: _SelectionExpansionBudget,
 ) -> bool:
-    return {"edges", "pageInfo"}.issubset(_selection_field_names(node.selection_set, fragments))
+    argument_names = {argument.name.value for argument in node.arguments or ()}
+    if argument_names & {"first", "last"}:
+        return True
+    return {"edges", "pageInfo"}.issubset(_selection_field_names(node.selection_set, fragments, budget=budget))
 
 
 def _int_variable_defaults(operation: gql_ast.OperationDefinitionNode) -> dict[str, int]:
@@ -145,6 +255,37 @@ def _int_variable_defaults(operation: gql_ast.OperationDefinitionNode) -> dict[s
         if isinstance(definition.default_value, gql_ast.IntValueNode):
             defaults[definition.variable.name.value] = int(definition.default_value.value)
     return defaults
+
+
+def _string_variable_defaults(operation: gql_ast.OperationDefinitionNode) -> dict[str, str]:
+    defaults: dict[str, str] = {}
+    for definition in operation.variable_definitions or ():
+        if isinstance(definition.default_value, gql_ast.StringValueNode):
+            defaults[definition.variable.name.value] = definition.default_value.value
+    return defaults
+
+
+def _validate_variable_shape(value: Any) -> None:
+    """Reject deeply nested or pathologically broad JSON variables."""
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    visited = 0
+    while stack:
+        current, depth = stack.pop()
+        visited += 1
+        if visited > MAX_GRAPHQL_VARIABLE_NODES:
+            raise GraphQLQueryValidationError(
+                f"GraphQL variables may contain at most {MAX_GRAPHQL_VARIABLE_NODES} JSON values",
+                error="query_too_complex",
+            )
+        if depth > MAX_GRAPHQL_VARIABLE_DEPTH:
+            raise GraphQLQueryValidationError(
+                f"GraphQL variables are limited to depth {MAX_GRAPHQL_VARIABLE_DEPTH}",
+                error="query_too_complex",
+            )
+        if isinstance(current, Mapping):
+            stack.extend((item, depth + 1) for item in current.values())
+        elif isinstance(current, list):
+            stack.extend((item, depth + 1) for item in current)
 
 
 def _replace_argument(
@@ -191,14 +332,25 @@ def _analyze_and_bound_document(
     if variables is not None and not isinstance(variables, Mapping):
         raise GraphQLQueryValidationError("variables must be a mapping")
     try:
-        variables_bytes = len(json.dumps(dict(variables or {}), ensure_ascii=False, allow_nan=False).encode("utf-8"))
-    except (TypeError, ValueError):
+        serialized_variables = json.dumps(
+            dict(variables or {}),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+    except (RecursionError, TypeError, ValueError):
         raise GraphQLQueryValidationError("variables must be finite JSON-compatible values") from None
+    variables_bytes = len(serialized_variables.encode("utf-8"))
     if variables_bytes > MAX_GRAPHQL_DOCUMENT_BYTES:
         raise GraphQLQueryValidationError(
             "GraphQL variables exceed the 64 KiB limit",
             error="query_too_complex",
         )
+    try:
+        bounded_variables = json.loads(serialized_variables)
+    except (RecursionError, TypeError, ValueError, json.JSONDecodeError):
+        raise GraphQLQueryValidationError("variables must be finite JSON-compatible values") from None
+    _validate_variable_shape(bounded_variables)
 
     document = validate_read_only_graphql(query)
     operations = [
@@ -224,6 +376,7 @@ def _analyze_and_bound_document(
     connections: list[tuple[list[str], gql_ast.FieldNode]] = []
     field_count = 0
     max_depth = 0
+    expansion_budget = _SelectionExpansionBudget()
 
     def walk(
         selection_set: gql_ast.SelectionSetNode | None,
@@ -236,6 +389,7 @@ def _analyze_and_bound_document(
         if selection_set is None:
             return
         for selection in selection_set.selections:
+            expansion_budget.consume()
             if isinstance(selection, gql_ast.FieldNode):
                 field_count += 1
                 max_depth = max(max_depth, depth)
@@ -248,7 +402,7 @@ def _analyze_and_bound_document(
                         error="query_too_complex",
                     )
                 field_path = [*path, _field_name(selection)]
-                is_connection = _is_connection_field(selection, fragments)
+                is_connection = _is_connection_field(selection, fragments, expansion_budget)
                 if is_connection:
                     if connection_ancestor:
                         raise GraphQLQueryValidationError(
@@ -286,7 +440,6 @@ def _analyze_and_bound_document(
                 )
 
     walk(operation.selection_set, [], 1, False)
-    bounded_variables = dict(variables or {})
     if not connections:
         return gql_printer.print_ast(document), bounded_variables, None
 
@@ -327,7 +480,59 @@ def _analyze_and_bound_document(
     else:
         raise GraphQLQueryValidationError(f"GraphQL {argument_name} must be an integer literal or variable")
 
+    edges_key = _response_key(connection_field.selection_set, "edges", fragments, expansion_budget)
+    page_info_key = _response_key(connection_field.selection_set, "pageInfo", fragments, expansion_budget)
+    edge_cursor_key = _nested_response_key(
+        connection_field.selection_set,
+        "edges",
+        "cursor",
+        fragments,
+        expansion_budget,
+    )
+    has_next_page_key = _nested_response_key(
+        connection_field.selection_set,
+        "pageInfo",
+        "hasNextPage",
+        fragments,
+        expansion_budget,
+    )
+    end_cursor_key = _nested_response_key(
+        connection_field.selection_set,
+        "pageInfo",
+        "endCursor",
+        fragments,
+        expansion_budget,
+    )
+    has_previous_page_key = _nested_response_key(
+        connection_field.selection_set,
+        "pageInfo",
+        "hasPreviousPage",
+        fragments,
+        expansion_budget,
+    )
+    start_cursor_key = _nested_response_key(
+        connection_field.selection_set,
+        "pageInfo",
+        "startCursor",
+        fragments,
+        expansion_budget,
+    )
+
     if last is not None:
+        before = arguments.get("before")
+        initial_before: str | None = None
+        if before is not None and isinstance(before.value, gql_ast.VariableNode):
+            before_variable = before.value.name.value
+            initial_before = bounded_variables.get(
+                before_variable,
+                _string_variable_defaults(operation).get(before_variable),
+            )
+            if initial_before is not None and not isinstance(initial_before, str):
+                raise GraphQLQueryValidationError(f"GraphQL variable ${before_variable} must be a string or null")
+        elif before is not None and isinstance(before.value, gql_ast.StringValueNode):
+            initial_before = before.value.value
+        elif before is not None and not isinstance(before.value, gql_ast.NullValueNode):
+            raise GraphQLQueryValidationError("GraphQL before must be a string literal, variable, or null")
         return (
             gql_printer.print_ast(document),
             bounded_variables,
@@ -337,6 +542,14 @@ def _analyze_and_bound_document(
                 first_variable=first_variable,
                 after_variable=None,
                 initial_after=None,
+                initial_before=initial_before,
+                edges_key=edges_key,
+                page_info_key=page_info_key,
+                edge_cursor_key=edge_cursor_key,
+                has_next_page_key=has_next_page_key,
+                end_cursor_key=end_cursor_key,
+                has_previous_page_key=has_previous_page_key,
+                start_cursor_key=start_cursor_key,
                 backward=True,
             ),
         )
@@ -346,13 +559,19 @@ def _analyze_and_bound_document(
     initial_after: str | None = None
     if after is not None and isinstance(after.value, gql_ast.VariableNode):
         after_variable = after.value.name.value
-        supplied_after = bounded_variables.get(after_variable)
+        supplied_after = bounded_variables.get(
+            after_variable,
+            _string_variable_defaults(operation).get(after_variable),
+        )
         if supplied_after is not None and not isinstance(supplied_after, str):
             raise GraphQLQueryValidationError(f"GraphQL variable ${after_variable} must be a string or null")
         initial_after = supplied_after
     else:
-        if after is not None and isinstance(after.value, gql_ast.StringValueNode):
-            initial_after = after.value.value
+        if after is not None:
+            if isinstance(after.value, gql_ast.StringValueNode):
+                initial_after = after.value.value
+            elif not isinstance(after.value, gql_ast.NullValueNode):
+                raise GraphQLQueryValidationError("GraphQL after must be a string literal, variable, or null")
         _ensure_variable_definition(operation, after_variable, "String")
         _replace_argument(
             connection_field,
@@ -370,12 +589,23 @@ def _analyze_and_bound_document(
             first_variable=first_variable,
             after_variable=after_variable,
             initial_after=initial_after,
+            initial_before=None,
+            edges_key=edges_key,
+            page_info_key=page_info_key,
+            edge_cursor_key=edge_cursor_key,
+            has_next_page_key=has_next_page_key,
+            end_cursor_key=end_cursor_key,
+            has_previous_page_key=has_previous_page_key,
+            start_cursor_key=start_cursor_key,
         ),
     )
 
 
 def _estimate_tokens(payload: Mapping[str, Any]) -> int:
-    return max(1, len(json.dumps(payload, default=str, ensure_ascii=False, allow_nan=False)) // 4)
+    from wandb_mcp_server.trace_utils import count_tokens_conservative
+
+    serialized = json.dumps(payload, default=str, ensure_ascii=False, allow_nan=False)
+    return count_tokens_conservative(serialized)
 
 
 def _set_pagination_extension(
@@ -398,11 +628,87 @@ def _set_pagination_extension(
     }
 
 
+def _response_too_large(message: str) -> dict[str, Any]:
+    return {
+        "errors": [
+            {
+                "error": "response_too_large",
+                "message": message,
+            }
+        ]
+    }
+
+
+def _edge_cursor(edge: Any, plan: _ConnectionPlan) -> str | None:
+    if not isinstance(edge, Mapping) or plan.edge_cursor_key is None:
+        return None
+    value = edge.get(plan.edge_cursor_key)
+    return value if isinstance(value, str) and value else None
+
+
+def _pagination_error(error: str, message: str) -> dict[str, Any]:
+    return {"errors": [{"error": error, "message": message}]}
+
+
+def _is_non_advancing_cursor(cursor: str, plan: _ConnectionPlan) -> bool:
+    initial_cursor = plan.initial_before if plan.backward else plan.initial_after
+    return initial_cursor is not None and cursor == initial_cursor
+
+
+def _bound_unpageable_connection(
+    result: dict[str, Any],
+    connection: dict[str, Any],
+    edges: list[Any],
+    plan: _ConnectionPlan,
+    max_items: int,
+) -> dict[str, Any]:
+    """Enforce the local item cap when response pagination metadata is unusable."""
+    if len(edges) <= max_items:
+        return _fit_response_budget(result, plan)
+
+    retained = edges[-max_items:] if plan.backward else edges[:max_items]
+    boundary = retained[0] if plan.backward else retained[-1]
+    resume_cursor = _edge_cursor(boundary, plan)
+    if resume_cursor is None:
+        return _pagination_error(
+            "pagination_cursor_unavailable",
+            ("The bounded GraphQL page exceeded the item limit but no selected edge cursor permits safe continuation"),
+        )
+    if _is_non_advancing_cursor(resume_cursor, plan):
+        return _pagination_error(
+            "pagination_cursor_non_advancing",
+            "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+        )
+
+    connection[plan.edges_key] = retained
+    if plan.page_info_key is not None:
+        selected_page_info = connection.get(plan.page_info_key)
+        if isinstance(selected_page_info, Mapping):
+            page_info = dict(selected_page_info)
+            if plan.backward:
+                if plan.has_previous_page_key is not None:
+                    page_info[plan.has_previous_page_key] = True
+                if plan.start_cursor_key is not None:
+                    page_info[plan.start_cursor_key] = resume_cursor
+            else:
+                if plan.has_next_page_key is not None:
+                    page_info[plan.has_next_page_key] = True
+                if plan.end_cursor_key is not None:
+                    page_info[plan.end_cursor_key] = resume_cursor
+            connection[plan.page_info_key] = page_info
+    _set_pagination_extension(
+        result,
+        returned_count=len(retained),
+        has_more=True,
+        next_cursor=resume_cursor,
+    )
+    result["extensions"]["wandb_mcp"]["limit_applied"] = max_items
+    return _fit_response_budget(result, plan)
+
+
 def _fit_response_budget(
     result: dict[str, Any],
-    connection_path: list[str] | None,
-    *,
-    backward: bool = False,
+    plan: _ConnectionPlan | None,
 ) -> dict[str, Any]:
     from wandb_mcp_server.config import MAX_RESPONSE_TOKENS
 
@@ -410,55 +716,64 @@ def _fit_response_budget(
         if _estimate_tokens(result) <= MAX_RESPONSE_TOKENS:
             return result
     except (TypeError, ValueError):
-        return {
-            "errors": [
-                {
-                    "error": "response_too_large",
-                    "message": "GraphQL response could not be serialized safely",
-                }
-            ]
-        }
-    connection = get_nested_value(result, connection_path or []) if connection_path else None
-    if not isinstance(connection, dict) or not isinstance(connection.get("edges"), list):
-        return {
-            "errors": [
-                {
-                    "error": "response_too_large",
-                    "message": "GraphQL response exceeded the configured response budget",
-                }
-            ]
-        }
-    edges = connection["edges"]
-    dropped = 0
-    while edges and _estimate_tokens(result) > MAX_RESPONSE_TOKENS:
-        edges.pop()
-        dropped += 1
-    page_info = connection.setdefault("pageInfo", {})
-    if backward:
-        last_cursor = edges[0].get("cursor") if edges and isinstance(edges[0], dict) else None
-        page_info["hasPreviousPage"] = True
-        page_info["startCursor"] = last_cursor
-    else:
-        last_cursor = edges[-1].get("cursor") if edges and isinstance(edges[-1], dict) else None
-        page_info["hasNextPage"] = True
-        page_info["endCursor"] = last_cursor
-    _set_pagination_extension(
-        result,
-        returned_count=len(edges),
-        has_more=True,
-        next_cursor=last_cursor,
-        truncated_by_budget=True,
-    )
-    if _estimate_tokens(result) > MAX_RESPONSE_TOKENS:
-        return {
-            "errors": [
-                {
-                    "error": "response_too_large",
-                    "message": "GraphQL response metadata exceeded the configured response budget",
-                }
-            ]
-        }
-    return result
+        return _response_too_large("GraphQL response could not be serialized safely")
+    if plan is None or plan.edges_key is None:
+        return _response_too_large("GraphQL response exceeded the configured response budget")
+    connection = get_nested_value(result, plan.path)
+    if not isinstance(connection, dict):
+        return _response_too_large("GraphQL response exceeded the configured response budget")
+    edges = connection.get(plan.edges_key)
+    if not isinstance(edges, list):
+        return _response_too_large("GraphQL response exceeded the configured response budget")
+
+    page_info: dict[str, Any] = {}
+    if plan.page_info_key is not None:
+        selected_page_info = connection.get(plan.page_info_key)
+        if isinstance(selected_page_info, Mapping):
+            page_info = dict(selected_page_info)
+
+    while edges:
+        if plan.backward:
+            edges.pop(0)
+        else:
+            edges.pop()
+        if not edges:
+            break
+        resume_cursor = _edge_cursor(edges[0] if plan.backward else edges[-1], plan)
+        if resume_cursor is None:
+            return _response_too_large(
+                "GraphQL response exceeded the budget and no selected edge cursor permits safe continuation"
+            )
+        if _is_non_advancing_cursor(resume_cursor, plan):
+            return _pagination_error(
+                "pagination_cursor_non_advancing",
+                "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+            )
+        if plan.backward:
+            if plan.has_previous_page_key is not None:
+                page_info[plan.has_previous_page_key] = True
+            if plan.start_cursor_key is not None:
+                page_info[plan.start_cursor_key] = resume_cursor
+        else:
+            if plan.has_next_page_key is not None:
+                page_info[plan.has_next_page_key] = True
+            if plan.end_cursor_key is not None:
+                page_info[plan.end_cursor_key] = resume_cursor
+        if plan.page_info_key is not None:
+            connection[plan.page_info_key] = page_info
+        _set_pagination_extension(
+            result,
+            returned_count=len(edges),
+            has_more=True,
+            next_cursor=resume_cursor,
+            truncated_by_budget=True,
+        )
+        try:
+            if _estimate_tokens(result) <= MAX_RESPONSE_TOKENS:
+                return result
+        except (TypeError, ValueError):
+            break
+    return _response_too_large("GraphQL response exceeded the budget and could not retain one safely continuable edge")
 
 
 def _validation_error(exc: Exception) -> dict[str, Any]:
@@ -532,33 +847,72 @@ def query_paginated_wandb_gql(
             connection = get_nested_value(result, plan.path)
             if not isinstance(connection, dict):
                 return _fit_response_budget(result, None)
-            initial_edges = connection.get("edges")
-            page_info = connection.get("pageInfo")
-            if not isinstance(initial_edges, list) or not isinstance(page_info, dict):
-                return _fit_response_budget(result, None)
+            if plan.edges_key is None:
+                return _fit_response_budget(result, plan)
+            initial_edges = connection.get(plan.edges_key)
+            if not isinstance(initial_edges, list):
+                return _fit_response_budget(result, plan)
+            page_info = connection.get(plan.page_info_key) if plan.page_info_key is not None else None
+            page_flag_key = plan.has_previous_page_key if plan.backward else plan.has_next_page_key
+            if (
+                plan.page_info_key is None
+                or not isinstance(page_info, dict)
+                or page_flag_key is None
+                or not isinstance(page_info.get(page_flag_key), bool)
+            ):
+                return _bound_unpageable_connection(
+                    result,
+                    connection,
+                    initial_edges,
+                    plan,
+                    applied_max_items,
+                )
 
             if plan.backward:
                 cut_mid_page = len(initial_edges) > applied_max_items
-                connection["edges"] = initial_edges[:applied_max_items]
-                has_more = bool(page_info.get("hasPreviousPage")) or cut_mid_page
-                next_cursor = page_info.get("startCursor")
-                if cut_mid_page and connection["edges"] and isinstance(connection["edges"][0], Mapping):
-                    next_cursor = connection["edges"][0].get("cursor") or next_cursor
-                connection["pageInfo"] = {
-                    **page_info,
-                    "hasPreviousPage": has_more,
-                    "startCursor": next_cursor,
-                }
+                connection[plan.edges_key] = initial_edges[-applied_max_items:]
+                has_more = (
+                    bool(plan.has_previous_page_key is not None and page_info.get(plan.has_previous_page_key))
+                    or cut_mid_page
+                )
+                next_cursor = page_info.get(plan.start_cursor_key) if plan.start_cursor_key is not None else None
+                if cut_mid_page and connection[plan.edges_key]:
+                    next_cursor = _edge_cursor(connection[plan.edges_key][0], plan)
+                    if next_cursor is None:
+                        return _pagination_error(
+                            "pagination_cursor_unavailable",
+                            (
+                                "The bounded backward GraphQL page stopped mid-page but no selected "
+                                "edge cursor permits safe continuation"
+                            ),
+                        )
+                if next_cursor is not None and (not isinstance(next_cursor, str) or not next_cursor):
+                    next_cursor = None
+                if next_cursor is not None and _is_non_advancing_cursor(next_cursor, plan):
+                    return _pagination_error(
+                        "pagination_cursor_non_advancing",
+                        "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+                    )
+                if has_more and next_cursor is None:
+                    return _pagination_error(
+                        "pagination_cursor_unavailable",
+                        "The backward GraphQL response indicates more data but exposes no continuation cursor",
+                    )
+                updated_page_info = dict(page_info)
+                if plan.has_previous_page_key is not None:
+                    updated_page_info[plan.has_previous_page_key] = has_more
+                if plan.start_cursor_key is not None:
+                    updated_page_info[plan.start_cursor_key] = next_cursor
+                connection[plan.page_info_key] = updated_page_info
                 _set_pagination_extension(
                     result,
-                    returned_count=len(connection["edges"]),
+                    returned_count=len(connection[plan.edges_key]),
                     has_more=has_more,
                     next_cursor=next_cursor,
                 )
-                return _fit_response_budget(result, plan.path, backward=True)
+                return _fit_response_budget(result, plan)
 
             aggregated: list[Any] = []
-            seen_ids: set[Any] = set()
 
             def append_edges(edges: list[Any]) -> bool:
                 cut_mid_page = False
@@ -566,27 +920,33 @@ def query_paginated_wandb_gql(
                     if len(aggregated) >= applied_max_items:
                         cut_mid_page = True
                         break
-                    node = edge.get("node") if isinstance(edge, Mapping) else None
-                    node_id = node.get("id") if isinstance(node, Mapping) else None
-                    if node_id is not None and node_id in seen_ids:
-                        continue
-                    if node_id is not None:
-                        seen_ids.add(node_id)
                     aggregated.append(edge)
                 return cut_mid_page
 
             cut_mid_page = append_edges(initial_edges)
             current_page_info = dict(page_info)
-            has_next = bool(current_page_info.get("hasNextPage"))
-            cursor = current_page_info.get("endCursor")
+            has_next = bool(plan.has_next_page_key is not None and current_page_info.get(plan.has_next_page_key))
+            cursor = current_page_info.get(plan.end_cursor_key) if plan.end_cursor_key is not None else None
+            if cursor is not None and (not isinstance(cursor, str) or not cursor):
+                cursor = None
+            seen_page_cursors = {plan.initial_after} if plan.initial_after else set()
+            if has_next and cursor is not None:
+                if cursor in seen_page_cursors:
+                    return _pagination_error(
+                        "pagination_cursor_non_advancing",
+                        "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+                    )
+                seen_page_cursors.add(cursor)
             max_page_requests = max(1, math.ceil(applied_max_items / applied_page_size) + 2)
             page_requests = 1
             partial_error = False
+            last_page_had_edges = bool(initial_edges)
 
             while has_next and cursor and len(aggregated) < applied_max_items and page_requests < max_page_requests:
+                request_cursor = cursor
                 page_variables = dict(bounded_variables)
                 assert plan.after_variable is not None
-                page_variables[plan.after_variable] = cursor
+                page_variables[plan.after_variable] = request_cursor
                 if plan.first_variable:
                     page_variables[plan.first_variable] = min(
                         applied_page_size,
@@ -615,33 +975,76 @@ def query_paginated_wandb_gql(
                 if not isinstance(page_connection, Mapping):
                     partial_error = True
                     break
-                page_edges = page_connection.get("edges")
-                next_page_info = page_connection.get("pageInfo")
+                page_edges = page_connection.get(plan.edges_key)
+                next_page_info = page_connection.get(plan.page_info_key)
                 if not isinstance(page_edges, list) or not isinstance(next_page_info, Mapping):
                     partial_error = True
                     break
                 cut_mid_page = append_edges(page_edges) or cut_mid_page
                 current_page_info = dict(next_page_info)
-                has_next = bool(current_page_info.get("hasNextPage"))
-                cursor = current_page_info.get("endCursor")
-                if not page_edges:
-                    partial_error = has_next
+                if plan.has_next_page_key is None or not isinstance(
+                    current_page_info.get(plan.has_next_page_key), bool
+                ):
+                    partial_error = True
+                    last_page_had_edges = bool(page_edges)
+                    break
+                has_next = bool(plan.has_next_page_key is not None and current_page_info.get(plan.has_next_page_key))
+                cursor = current_page_info.get(plan.end_cursor_key) if plan.end_cursor_key is not None else None
+                if cursor is not None and (not isinstance(cursor, str) or not cursor):
+                    cursor = None
+                if has_next and cursor is not None:
+                    if cursor == request_cursor or cursor in seen_page_cursors:
+                        return _pagination_error(
+                            "pagination_cursor_non_advancing",
+                            "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+                        )
+                    seen_page_cursors.add(cursor)
+                last_page_had_edges = bool(page_edges)
+                if not page_edges and has_next and cursor is None:
+                    partial_error = True
                     break
 
             stopped_at_limit = len(aggregated) >= applied_max_items and (has_next or cut_mid_page)
             stopped_at_request_bound = page_requests >= max_page_requests and has_next
             has_more = bool(has_next or cut_mid_page or partial_error or stopped_at_request_bound)
-            connection["edges"] = aggregated
+            connection[plan.edges_key] = aggregated
+            edge_cursor = _edge_cursor(aggregated[-1], plan) if aggregated else None
+            if cut_mid_page and edge_cursor is None:
+                return {
+                    "errors": [
+                        {
+                            "error": "pagination_cursor_unavailable",
+                            "message": (
+                                "The bounded GraphQL page stopped mid-page but no selected edge cursor "
+                                "permits safe continuation"
+                            ),
+                        }
+                    ]
+                }
+            page_end_cursor = current_page_info.get(plan.end_cursor_key) if plan.end_cursor_key is not None else None
             last_cursor = (
-                aggregated[-1].get("cursor")
-                if aggregated and isinstance(aggregated[-1], Mapping)
-                else current_page_info.get("endCursor")
+                edge_cursor
+                if cut_mid_page
+                else page_end_cursor
+                if not last_page_had_edges and isinstance(page_end_cursor, str) and page_end_cursor
+                else edge_cursor or page_end_cursor
             )
-            connection["pageInfo"] = {
-                **current_page_info,
-                "hasNextPage": has_more,
-                "endCursor": last_cursor,
-            }
+            if has_more and last_cursor is None:
+                return _pagination_error(
+                    "pagination_cursor_unavailable",
+                    "The GraphQL response indicates more data but exposes no continuation cursor",
+                )
+            if has_more and isinstance(last_cursor, str) and _is_non_advancing_cursor(last_cursor, plan):
+                return _pagination_error(
+                    "pagination_cursor_non_advancing",
+                    "The GraphQL connection returned a repeated or non-advancing continuation cursor",
+                )
+            updated_page_info = dict(current_page_info)
+            if plan.has_next_page_key is not None:
+                updated_page_info[plan.has_next_page_key] = has_more
+            if plan.end_cursor_key is not None:
+                updated_page_info[plan.end_cursor_key] = last_cursor
+            connection[plan.page_info_key] = updated_page_info
             _set_pagination_extension(
                 result,
                 returned_count=len(aggregated),
@@ -650,7 +1053,7 @@ def query_paginated_wandb_gql(
             )
             if stopped_at_limit:
                 result["extensions"]["wandb_mcp"]["limit_applied"] = applied_max_items
-            return _fit_response_budget(result, plan.path)
+            return _fit_response_budget(result, plan)
         except Exception as exc:
             logger.error("Bounded GraphQL query failed (%s)", type(exc).__name__)
             ctx.mark_error(f"query_failed: {type(exc).__name__}")

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -811,6 +811,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         summary_keys: Optional[List[str]] = None,
         config_keys: Optional[List[str]] = None,
         response_mode: Literal["items", "count"] = "items",
+        cursor: Optional[str] = None,
     ) -> Dict[str, Any]:
         return query_wandb(
             entity_name=entity_name,
@@ -826,6 +827,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
             summary_keys=summary_keys,
             config_keys=config_keys,
             response_mode=response_mode,
+            cursor=cursor,
         )
 
     if WANDB_MCP_ENABLE_RAW_GRAPHQL:

--- a/src/wandb_mcp_server/trace_utils.py
+++ b/src/wandb_mcp_server/trace_utils.py
@@ -91,6 +91,16 @@ def count_tokens(text: str) -> int:
         return len(text.split())
 
 
+def count_tokens_conservative(text: str) -> int:
+    """Count tokens exactly, with a conservative no-tokenizer fallback."""
+    try:
+        return len(_get_tiktoken_encoding().encode(text))
+    except Exception:
+        # A UTF-8 byte upper bound is intentionally conservative for BPE-style
+        # tokenizers and cannot undercount dense CJK or unusual scalar data.
+        return max(1, len(text.encode("utf-8")))
+
+
 def calculate_token_counts(traces: List[Dict]) -> Dict[str, int]:
     """Calculate token counts for traces."""
     total_tokens = 0

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, NoReturn, Sequence
 
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
 from wandb_mcp_server.wandb_graphql import execute_graphql
@@ -22,6 +22,8 @@ query MCPProjectedRuns(
   $configKeys: [String!]
   $includeSummary: Boolean!
   $includeConfig: Boolean!
+  $includeSweep: Boolean!
+  $includeSystemMetrics: Boolean!
 ) {
   project(name: $project, entityName: $entity) {
     runCount(filters: $filters)
@@ -40,12 +42,14 @@ query MCPProjectedRuns(
           group
           jobType
           tags
+          sweepName @include(if: $includeSweep)
           user {
             username
             name
           }
           summaryMetrics(keys: $summaryKeys) @include(if: $includeSummary)
           config(keys: $configKeys) @include(if: $includeConfig)
+          systemMetrics @include(if: $includeSystemMetrics)
         }
       }
       pageInfo {
@@ -86,6 +90,78 @@ query MCPProjectedRun(
       }
       summaryMetrics(keys: $summaryKeys) @include(if: $includeSummary)
       config(keys: $configKeys) @include(if: $includeConfig)
+    }
+  }
+}
+"""
+
+PROJECTED_SWEEPS_QUERY = """
+query MCPProjectedSweeps(
+  $entity: String!
+  $project: String!
+  $first: Int!
+  $after: String
+  $includeConfig: Boolean!
+) {
+  project(name: $project, entityName: $entity) {
+    totalSweeps
+    sweeps(first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          displayName
+          state
+          method
+          description
+          createdAt
+          updatedAt
+          runCount
+          runCountExpected
+          config @include(if: $includeConfig)
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}
+"""
+
+PROJECTED_REPORTS_QUERY = """
+query MCPProjectedReports(
+  $entity: String!
+  $project: String!
+  $name: String
+  $first: Int!
+  $after: String
+  $includeSpec: Boolean!
+) {
+  project(name: $project, entityName: $entity) {
+    allViews(viewType: "runs", viewName: $name, first: $first, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          displayName
+          description
+          user {
+            username
+            email
+          }
+          createdAt
+          updatedAt
+          spec @include(if: $includeSpec)
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
     }
   }
 }
@@ -243,6 +319,18 @@ class ProjectedRunPage:
     total_count: int
     has_more: bool
     requests: int
+    next_cursor: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectedResourcePage:
+    """One bounded page of an application-owned resource projection."""
+
+    items: list[dict[str, Any]]
+    total_count: int | None
+    has_more: bool
+    next_cursor: str | None
+    requests: int
 
 
 @dataclass(frozen=True)
@@ -267,6 +355,19 @@ class SelectiveReadUnavailable(RuntimeError):
     """Raised when a backend cannot serve an application-owned read shape."""
 
 
+def _raise_selective_failure(context: str, exc: Exception) -> NoReturn:
+    """Preserve actionable upstream errors; wrap only projection compatibility failures."""
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    response = getattr(exc, "response", None)
+    if status is None and response is not None:
+        status = getattr(response, "status_code", None) or getattr(response, "status", None)
+    name = type(exc).__name__.lower()
+    message = str(exc).lower()
+    if status in {401, 403, 404, 429, 503} or "timeout" in name or "timed out" in message:
+        raise exc
+    raise SelectiveReadUnavailable(f"{context}: {type(exc).__name__}") from exc
+
+
 def _parse_json_mapping(value: Any) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return {str(key): item for key, item in value.items()}
@@ -285,6 +386,9 @@ def _unwrap_config_value(value: Any) -> Any:
     return value
 
 
+_MISSING = object()
+
+
 def _nested_config_value(config: Mapping[str, Any], key: str) -> Any:
     if key in config:
         return _unwrap_config_value(config[key])
@@ -292,7 +396,7 @@ def _nested_config_value(config: Mapping[str, Any], key: str) -> Any:
     for part in key.split("."):
         current = _unwrap_config_value(current)
         if not isinstance(current, Mapping) or part not in current:
-            return None
+            return _MISSING
         current = current[part]
     return _unwrap_config_value(current)
 
@@ -304,12 +408,15 @@ def _normalize_run_node(
     project: str,
     summary_keys: Sequence[str],
     config_keys: Sequence[str],
+    include_summary: bool,
+    include_config: bool,
+    include_sweep: bool = False,
+    include_system_metrics: bool = False,
 ) -> dict[str, Any]:
     summary = _parse_json_mapping(node.get("summaryMetrics"))
     config = _parse_json_mapping(node.get("config"))
     item: dict[str, Any] = {
         "id": node.get("name") or node.get("id"),
-        "graphql_id": node.get("id"),
         "display_name": node.get("displayName") or node.get("name"),
         "state": node.get("state"),
         "entity": entity,
@@ -323,10 +430,40 @@ def _normalize_run_node(
         "tags": node.get("tags") or [],
         "user": node.get("user"),
     }
-    if summary_keys:
-        item["summary"] = {key: summary.get(key) for key in summary_keys if summary.get(key) is not None}
-    if config_keys:
-        item["config"] = {key: value for key in config_keys if (value := _nested_config_value(config, key)) is not None}
+    if include_summary:
+        if summary_keys:
+            item["summary"] = {key: summary[key] for key in summary_keys if key in summary}
+            missing_summary_keys = [key for key in summary_keys if key not in summary]
+            if missing_summary_keys:
+                item["missing_summary_keys"] = missing_summary_keys
+        else:
+            item["summary"] = summary
+    if include_config:
+        selected_config: dict[str, Any] = {}
+        missing_config_keys: list[str] = []
+        for key in config_keys:
+            value = _nested_config_value(config, key)
+            if value is _MISSING:
+                missing_config_keys.append(key)
+            else:
+                selected_config[key] = value
+        item["config"] = selected_config if config_keys else config
+        if missing_config_keys:
+            item["missing_config_keys"] = missing_config_keys
+    if include_sweep:
+        sweep_name = node.get("sweepName")
+        item["sweep"] = (
+            None
+            if not sweep_name
+            else {
+                "id": sweep_name,
+                "name": sweep_name,
+                "entity": entity,
+                "project": project,
+            }
+        )
+    if include_system_metrics:
+        item["system_metrics"] = _parse_json_mapping(node.get("systemMetrics"))
     return item
 
 
@@ -346,13 +483,20 @@ def fetch_projected_runs(
     order: str,
     limit: int,
     page_size: int,
-    summary_keys: Sequence[str] = (),
-    config_keys: Sequence[str] = (),
+    summary_keys: Sequence[str] | None = (),
+    config_keys: Sequence[str] | None = (),
+    include_summary: bool = False,
+    include_config: bool = False,
+    include_sweep: bool = False,
+    include_system_metrics: bool = False,
+    cursor: str | None = None,
 ) -> ProjectedRunPage:
     """Fetch selected run fields without hydrating full SDK run objects."""
-    target = max(1, limit + 1)
+    include_summary = include_summary or bool(summary_keys)
+    include_config = include_config or bool(config_keys)
+    target = max(1, limit)
     items: list[dict[str, Any]] = []
-    cursor: str | None = None
+    page_cursor = cursor
     total_count = 0
     requests = 0
     has_next_page = False
@@ -365,16 +509,18 @@ def fetch_projected_runs(
             "filters": json.dumps(dict(filters or {}), separators=(",", ":")),
             "order": order,
             "first": min(max(1, page_size), target - len(items)),
-            "after": cursor,
-            "summaryKeys": list(summary_keys),
-            "configKeys": list(config_keys),
-            "includeSummary": bool(summary_keys),
-            "includeConfig": bool(config_keys),
+            "after": page_cursor,
+            "summaryKeys": None if summary_keys is None else list(summary_keys),
+            "configKeys": None if config_keys is None else list(config_keys),
+            "includeSummary": include_summary,
+            "includeConfig": include_config,
+            "includeSweep": include_sweep,
+            "includeSystemMetrics": include_system_metrics,
         }
         try:
             data = execute_graphql(api, PROJECTED_RUNS_QUERY, variables)
         except Exception as exc:
-            raise SelectiveReadUnavailable(f"projected run query unavailable: {type(exc).__name__}") from exc
+            _raise_selective_failure("projected run query unavailable", exc)
         requests += 1
         project_payload = _project_payload(data)
         total_count = int(project_payload.get("runCount") or 0)
@@ -389,22 +535,27 @@ def fetch_projected_runs(
                         node,
                         entity=entity,
                         project=project,
-                        summary_keys=summary_keys,
-                        config_keys=config_keys,
+                        summary_keys=summary_keys or (),
+                        config_keys=config_keys or (),
+                        include_summary=include_summary,
+                        include_config=include_config,
+                        include_sweep=include_sweep,
+                        include_system_metrics=include_system_metrics,
                     )
                 )
                 if len(items) >= target:
                     break
         page_info = connection.get("pageInfo") or {}
         has_next_page = bool(page_info.get("hasNextPage"))
-        cursor = page_info.get("endCursor")
-        if not has_next_page or not cursor:
+        page_cursor = page_info.get("endCursor")
+        if not has_next_page or not page_cursor:
             break
 
     return ProjectedRunPage(
         items=items[:limit],
         total_count=total_count,
-        has_more=len(items) > limit or has_next_page or total_count > limit,
+        has_more=has_next_page,
+        next_cursor=page_cursor if has_next_page else None,
         requests=requests,
     )
 
@@ -415,7 +566,7 @@ def fetch_projected_run(
     entity: str,
     project: str,
     run_id: str,
-    summary_keys: Sequence[str] = (),
+    summary_keys: Sequence[str] | None = (),
     config_keys: Sequence[str] = (),
 ) -> dict[str, Any] | None:
     """Fetch one run with only the requested summary and config keys."""
@@ -423,15 +574,15 @@ def fetch_projected_run(
         "entity": entity,
         "project": project,
         "run": run_id,
-        "summaryKeys": list(summary_keys),
+        "summaryKeys": None if summary_keys is None else list(summary_keys),
         "configKeys": list(config_keys),
-        "includeSummary": bool(summary_keys),
+        "includeSummary": summary_keys is None or bool(summary_keys),
         "includeConfig": bool(config_keys),
     }
     try:
         data = execute_graphql(api, PROJECTED_RUN_QUERY, variables)
     except Exception as exc:
-        raise SelectiveReadUnavailable(f"projected run query unavailable: {type(exc).__name__}") from exc
+        _raise_selective_failure("projected run query unavailable", exc)
     node = _project_payload(data).get("run")
     if not isinstance(node, Mapping):
         return None
@@ -439,8 +590,159 @@ def fetch_projected_run(
         node,
         entity=entity,
         project=project,
-        summary_keys=summary_keys,
+        summary_keys=summary_keys or (),
         config_keys=config_keys,
+        include_summary=summary_keys is None or bool(summary_keys),
+        include_config=bool(config_keys),
+    )
+
+
+def fetch_projected_sweeps(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    limit: int,
+    page_size: int,
+    include_config: bool = False,
+    cursor: str | None = None,
+) -> ProjectedResourcePage:
+    """Fetch sweep rows without hydrating one SDK Sweep per result."""
+    target = max(1, limit)
+    items: list[dict[str, Any]] = []
+    page_cursor = cursor
+    requests = 0
+    total_count: int | None = None
+    has_next_page = False
+    while len(items) < target:
+        raise_if_tool_deadline_exceeded()
+        try:
+            data = execute_graphql(
+                api,
+                PROJECTED_SWEEPS_QUERY,
+                {
+                    "entity": entity,
+                    "project": project,
+                    "first": min(max(1, page_size), target - len(items)),
+                    "after": page_cursor,
+                    "includeConfig": include_config,
+                },
+            )
+        except Exception as exc:
+            _raise_selective_failure("projected sweep query unavailable", exc)
+        requests += 1
+        project_payload = _project_payload(data)
+        total_count = int(project_payload.get("totalSweeps") or 0)
+        connection = project_payload.get("sweeps")
+        if not isinstance(connection, Mapping):
+            raise SelectiveReadUnavailable("projected sweep query returned no sweep connection")
+        for edge in connection.get("edges") or []:
+            node = edge.get("node") if isinstance(edge, Mapping) else None
+            if not isinstance(node, Mapping):
+                continue
+            sweep_id = node.get("name") or node.get("id")
+            item = {
+                "id": sweep_id,
+                "name": node.get("displayName") or node.get("name"),
+                "state": node.get("state"),
+                "method": node.get("method"),
+                "description": node.get("description"),
+                "entity": entity,
+                "project": project,
+                "expected_run_count": node.get("runCountExpected"),
+                "run_count": node.get("runCount"),
+                "created_at": node.get("createdAt"),
+                "updated_at": node.get("updatedAt"),
+            }
+            if include_config:
+                item["config"] = _parse_json_mapping(node.get("config"))
+            items.append(item)
+            if len(items) >= target:
+                break
+        page_info = connection.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        page_cursor = page_info.get("endCursor")
+        if not has_next_page or not page_cursor:
+            break
+    has_more = has_next_page
+    return ProjectedResourcePage(
+        items=items[:limit],
+        total_count=total_count,
+        has_more=has_more,
+        next_cursor=page_cursor if has_more else None,
+        requests=requests,
+    )
+
+
+def fetch_projected_reports(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    report_name: str | None,
+    limit: int,
+    page_size: int,
+    include_spec: bool = False,
+    cursor: str | None = None,
+) -> ProjectedResourcePage:
+    """Fetch report metadata without downloading report specs by default."""
+    target = max(1, limit)
+    items: list[dict[str, Any]] = []
+    page_cursor = cursor
+    requests = 0
+    has_next_page = False
+    while len(items) < target:
+        raise_if_tool_deadline_exceeded()
+        try:
+            data = execute_graphql(
+                api,
+                PROJECTED_REPORTS_QUERY,
+                {
+                    "entity": entity,
+                    "project": project,
+                    "name": report_name,
+                    "first": min(max(1, page_size), target - len(items)),
+                    "after": page_cursor,
+                    "includeSpec": include_spec,
+                },
+            )
+        except Exception as exc:
+            _raise_selective_failure("projected report query unavailable", exc)
+        requests += 1
+        connection = _project_payload(data).get("allViews")
+        if not isinstance(connection, Mapping):
+            raise SelectiveReadUnavailable("projected report query returned no report connection")
+        for edge in connection.get("edges") or []:
+            node = edge.get("node") if isinstance(edge, Mapping) else None
+            if not isinstance(node, Mapping):
+                continue
+            item = {
+                "id": node.get("id"),
+                "name": node.get("name"),
+                "display_name": node.get("displayName"),
+                "description": node.get("description"),
+                "user": node.get("user"),
+                "created_at": node.get("createdAt"),
+                "updated_at": node.get("updatedAt"),
+            }
+            if include_spec:
+                item["spec"] = _parse_json_mapping(node.get("spec"))
+            items.append(item)
+            if len(items) >= target:
+                break
+        page_info = connection.get("pageInfo") or {}
+        has_next_page = bool(page_info.get("hasNextPage"))
+        page_cursor = page_info.get("endCursor")
+        if not has_next_page or not page_cursor:
+            break
+    has_more = has_next_page
+    total_count = len(items[:limit]) if cursor is None and not has_more else None
+    return ProjectedResourcePage(
+        items=items[:limit],
+        total_count=total_count,
+        has_more=has_more,
+        next_cursor=page_cursor if has_more else None,
+        requests=requests,
     )
 
 
@@ -474,7 +776,7 @@ def fetch_project_fields(
                 },
             )
         except Exception as exc:
-            raise SelectiveReadUnavailable(f"project field index unavailable: {type(exc).__name__}") from exc
+            _raise_selective_failure("project field index unavailable", exc)
         requests += 1
         connection = _project_payload(data).get("fields")
         if not isinstance(connection, Mapping):
@@ -514,7 +816,7 @@ def fetch_project_counts(api: Any, *, entity: str, project: str) -> dict[str, in
     try:
         project_payload = _project_payload(execute_graphql(api, PROJECT_COUNTS_QUERY, variables))
     except Exception as exc:
-        raise SelectiveReadUnavailable(f"project count query unavailable: {type(exc).__name__}") from exc
+        _raise_selective_failure("project count query unavailable", exc)
     return {name: int(project_payload.get("total" if name == "all" else name) or 0) for name in filters}
 
 
@@ -535,7 +837,7 @@ def fetch_artifact_inventory(
             )
         )
     except Exception as exc:
-        raise SelectiveReadUnavailable(f"artifact inventory unavailable: {type(exc).__name__}") from exc
+        _raise_selective_failure("artifact inventory unavailable", exc)
     connection = project_payload.get("artifactTypes")
     if not isinstance(connection, Mapping):
         raise SelectiveReadUnavailable("artifact inventory returned no artifact type connection")
@@ -594,7 +896,7 @@ def fetch_metric_value_steps(
             },
         )
     except Exception as exc:
-        raise SelectiveReadUnavailable(f"metric value step lookup unavailable: {type(exc).__name__}") from exc
+        _raise_selective_failure("metric value step lookup unavailable", exc)
     node = _project_payload(data).get("run")
     if not isinstance(node, Mapping):
         raise ValueError("W&B run was not found or is not accessible")
@@ -644,9 +946,7 @@ def fetch_registry_artifact_versions(
                 },
             )
         except Exception as exc:
-            raise SelectiveReadUnavailable(
-                f"ordered registry artifact query unavailable: {type(exc).__name__}"
-            ) from exc
+            _raise_selective_failure("ordered registry artifact query unavailable", exc)
         requests += 1
         organization_payload = data.get("organization")
         org_entity = organization_payload.get("orgEntity") if isinstance(organization_payload, Mapping) else None
@@ -705,10 +1005,13 @@ __all__ = [
     "METRIC_VALUE_STEPS_QUERY",
     "PROJECTED_RUNS_QUERY",
     "PROJECTED_RUN_QUERY",
+    "PROJECTED_SWEEPS_QUERY",
+    "PROJECTED_REPORTS_QUERY",
     "PROJECT_COUNTS_QUERY",
     "PROJECT_FIELDS_QUERY",
     "ProjectFieldPage",
     "ProjectedRunPage",
+    "ProjectedResourcePage",
     "ArtifactVersionPage",
     "SelectiveReadUnavailable",
     "fetch_artifact_inventory",
@@ -718,4 +1021,6 @@ __all__ = [
     "fetch_project_fields",
     "fetch_projected_run",
     "fetch_projected_runs",
+    "fetch_projected_sweeps",
+    "fetch_projected_reports",
 ]

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import math
 from typing import Any, Mapping, NoReturn, Sequence
 
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
@@ -355,6 +356,62 @@ class SelectiveReadUnavailable(RuntimeError):
     """Raised when a backend cannot serve an application-owned read shape."""
 
 
+_MAX_PROJECTED_PAGE_REQUESTS = 10
+
+
+def _projected_page_request_limit(target: int, page_size: int) -> int:
+    """Bound requests even when a backend returns short or empty pages."""
+    expected_requests = math.ceil(max(1, target) / max(1, page_size))
+    return min(_MAX_PROJECTED_PAGE_REQUESTS, expected_requests + 1)
+
+
+def _next_projected_cursor(
+    *,
+    context: str,
+    current: str | None,
+    candidate: Any,
+    seen: set[str],
+) -> str:
+    """Return a usable continuation cursor or reject a broken connection."""
+    if not isinstance(candidate, str) or not candidate:
+        raise SelectiveReadUnavailable(f"{context} reported another page without a continuation cursor")
+    if candidate == current or candidate in seen:
+        raise SelectiveReadUnavailable(f"{context} repeated a continuation cursor")
+    seen.add(candidate)
+    return candidate
+
+
+def _projected_connection_page(
+    connection: Mapping[str, Any],
+    *,
+    context: str,
+) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], bool]:
+    """Validate one fixed-projection connection page before consuming it."""
+    edges = connection.get("edges")
+    if not isinstance(edges, list) or not all(isinstance(edge, Mapping) for edge in edges):
+        raise SelectiveReadUnavailable(f"{context} returned invalid edges")
+    page_info = connection.get("pageInfo")
+    if not isinstance(page_info, Mapping) or not isinstance(page_info.get("hasNextPage"), bool):
+        raise SelectiveReadUnavailable(f"{context} returned invalid pagination metadata")
+    return edges, page_info, page_info["hasNextPage"]
+
+
+def _retained_projected_cursor(
+    edge: Mapping[str, Any],
+    *,
+    context: str,
+    current: str | None,
+    seen: set[str],
+) -> str:
+    """Resume immediately after the last edge retained from an oversized page."""
+    return _next_projected_cursor(
+        context=context,
+        current=current,
+        candidate=edge.get("cursor"),
+        seen=seen,
+    )
+
+
 def _raise_selective_failure(context: str, exc: Exception) -> NoReturn:
     """Preserve actionable upstream errors; wrap only projection compatibility failures."""
     status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
@@ -500,8 +557,10 @@ def fetch_projected_runs(
     total_count = 0
     requests = 0
     has_next_page = False
+    seen_cursors = {cursor} if cursor else set()
+    max_requests = _projected_page_request_limit(target, page_size)
 
-    while len(items) < target:
+    while len(items) < target and requests < max_requests:
         raise_if_tool_deadline_exceeded()
         variables = {
             "entity": entity,
@@ -527,29 +586,52 @@ def fetch_projected_runs(
         connection = project_payload.get("runs")
         if not isinstance(connection, Mapping):
             raise SelectiveReadUnavailable("projected run query returned no run connection")
-        for edge in connection.get("edges") or []:
-            node = edge.get("node") if isinstance(edge, Mapping) else None
-            if isinstance(node, Mapping):
-                items.append(
-                    _normalize_run_node(
-                        node,
-                        entity=entity,
-                        project=project,
-                        summary_keys=summary_keys or (),
-                        config_keys=config_keys or (),
-                        include_summary=include_summary,
-                        include_config=include_config,
-                        include_sweep=include_sweep,
-                        include_system_metrics=include_system_metrics,
-                    )
+        edges, page_info, backend_has_next = _projected_connection_page(
+            connection,
+            context="projected run query",
+        )
+        retained_edge: Mapping[str, Any] | None = None
+        consumed_edges = 0
+        for edge in edges:
+            if len(items) >= target:
+                break
+            node = edge.get("node")
+            if not isinstance(node, Mapping):
+                raise SelectiveReadUnavailable("projected run query returned an invalid run edge")
+            items.append(
+                _normalize_run_node(
+                    node,
+                    entity=entity,
+                    project=project,
+                    summary_keys=summary_keys or (),
+                    config_keys=config_keys or (),
+                    include_summary=include_summary,
+                    include_config=include_config,
+                    include_sweep=include_sweep,
+                    include_system_metrics=include_system_metrics,
                 )
-                if len(items) >= target:
-                    break
-        page_info = connection.get("pageInfo") or {}
-        has_next_page = bool(page_info.get("hasNextPage"))
-        page_cursor = page_info.get("endCursor")
-        if not has_next_page or not page_cursor:
+            )
+            retained_edge = edge
+            consumed_edges += 1
+        cut_mid_page = consumed_edges < len(edges)
+        has_next_page = backend_has_next or cut_mid_page
+        if not has_next_page:
             break
+        if cut_mid_page:
+            assert retained_edge is not None
+            page_cursor = _retained_projected_cursor(
+                retained_edge,
+                context="projected run query",
+                current=page_cursor,
+                seen=seen_cursors,
+            )
+        else:
+            page_cursor = _next_projected_cursor(
+                context="projected run query",
+                current=page_cursor,
+                candidate=page_info.get("endCursor"),
+                seen=seen_cursors,
+            )
 
     return ProjectedRunPage(
         items=items[:limit],
@@ -614,7 +696,9 @@ def fetch_projected_sweeps(
     requests = 0
     total_count: int | None = None
     has_next_page = False
-    while len(items) < target:
+    seen_cursors = {cursor} if cursor else set()
+    max_requests = _projected_page_request_limit(target, page_size)
+    while len(items) < target and requests < max_requests:
         raise_if_tool_deadline_exceeded()
         try:
             data = execute_graphql(
@@ -636,10 +720,18 @@ def fetch_projected_sweeps(
         connection = project_payload.get("sweeps")
         if not isinstance(connection, Mapping):
             raise SelectiveReadUnavailable("projected sweep query returned no sweep connection")
-        for edge in connection.get("edges") or []:
-            node = edge.get("node") if isinstance(edge, Mapping) else None
+        edges, page_info, backend_has_next = _projected_connection_page(
+            connection,
+            context="projected sweep query",
+        )
+        retained_edge: Mapping[str, Any] | None = None
+        consumed_edges = 0
+        for edge in edges:
+            if len(items) >= target:
+                break
+            node = edge.get("node")
             if not isinstance(node, Mapping):
-                continue
+                raise SelectiveReadUnavailable("projected sweep query returned an invalid sweep edge")
             sweep_id = node.get("name") or node.get("id")
             item = {
                 "id": sweep_id,
@@ -657,13 +749,27 @@ def fetch_projected_sweeps(
             if include_config:
                 item["config"] = _parse_json_mapping(node.get("config"))
             items.append(item)
-            if len(items) >= target:
-                break
-        page_info = connection.get("pageInfo") or {}
-        has_next_page = bool(page_info.get("hasNextPage"))
-        page_cursor = page_info.get("endCursor")
-        if not has_next_page or not page_cursor:
+            retained_edge = edge
+            consumed_edges += 1
+        cut_mid_page = consumed_edges < len(edges)
+        has_next_page = backend_has_next or cut_mid_page
+        if not has_next_page:
             break
+        if cut_mid_page:
+            assert retained_edge is not None
+            page_cursor = _retained_projected_cursor(
+                retained_edge,
+                context="projected sweep query",
+                current=page_cursor,
+                seen=seen_cursors,
+            )
+        else:
+            page_cursor = _next_projected_cursor(
+                context="projected sweep query",
+                current=page_cursor,
+                candidate=page_info.get("endCursor"),
+                seen=seen_cursors,
+            )
     has_more = has_next_page
     return ProjectedResourcePage(
         items=items[:limit],
@@ -691,7 +797,9 @@ def fetch_projected_reports(
     page_cursor = cursor
     requests = 0
     has_next_page = False
-    while len(items) < target:
+    seen_cursors = {cursor} if cursor else set()
+    max_requests = _projected_page_request_limit(target, page_size)
+    while len(items) < target and requests < max_requests:
         raise_if_tool_deadline_exceeded()
         try:
             data = execute_graphql(
@@ -712,10 +820,18 @@ def fetch_projected_reports(
         connection = _project_payload(data).get("allViews")
         if not isinstance(connection, Mapping):
             raise SelectiveReadUnavailable("projected report query returned no report connection")
-        for edge in connection.get("edges") or []:
-            node = edge.get("node") if isinstance(edge, Mapping) else None
+        edges, page_info, backend_has_next = _projected_connection_page(
+            connection,
+            context="projected report query",
+        )
+        retained_edge: Mapping[str, Any] | None = None
+        consumed_edges = 0
+        for edge in edges:
+            if len(items) >= target:
+                break
+            node = edge.get("node")
             if not isinstance(node, Mapping):
-                continue
+                raise SelectiveReadUnavailable("projected report query returned an invalid report edge")
             item = {
                 "id": node.get("id"),
                 "name": node.get("name"),
@@ -728,13 +844,27 @@ def fetch_projected_reports(
             if include_spec:
                 item["spec"] = _parse_json_mapping(node.get("spec"))
             items.append(item)
-            if len(items) >= target:
-                break
-        page_info = connection.get("pageInfo") or {}
-        has_next_page = bool(page_info.get("hasNextPage"))
-        page_cursor = page_info.get("endCursor")
-        if not has_next_page or not page_cursor:
+            retained_edge = edge
+            consumed_edges += 1
+        cut_mid_page = consumed_edges < len(edges)
+        has_next_page = backend_has_next or cut_mid_page
+        if not has_next_page:
             break
+        if cut_mid_page:
+            assert retained_edge is not None
+            page_cursor = _retained_projected_cursor(
+                retained_edge,
+                context="projected report query",
+                current=page_cursor,
+                seen=seen_cursors,
+            )
+        else:
+            page_cursor = _next_projected_cursor(
+                context="projected report query",
+                current=page_cursor,
+                candidate=page_info.get("endCursor"),
+                seen=seen_cursors,
+            )
     has_more = has_next_page
     total_count = len(items[:limit]) if cursor is None and not has_more else None
     return ProjectedResourcePage(

--- a/tests/test_hosted_gql_guardrails.py
+++ b/tests/test_hosted_gql_guardrails.py
@@ -113,7 +113,7 @@ def test_hosted_literal_first_is_rewritten_before_execute(monkeypatch):
     executed_query, variables = client.executions[0]
     assert "first: 50" in executed_query
     assert "100000" not in executed_query
-    assert variables["limit"] == 50
+    assert variables["__mcp_after"] is None
     assert "errors" not in result
 
 
@@ -130,8 +130,8 @@ def test_query_executes_with_service_api_without_client(monkeypatch):
     )
 
     executed_query, variables = service_api.executions[0]
-    assert "first: 100000" in executed_query
-    assert variables["limit"] == 100
+    assert "first: 100" in executed_query
+    assert variables["__mcp_after"] is None
     assert "errors" not in result
 
 
@@ -218,18 +218,18 @@ def test_hosted_nested_connection_query_is_rejected_before_execute(monkeypatch):
     )
 
     assert result["errors"][0]["error"] == "query_too_complex"
-    assert "Nested paginated collection" in result["errors"][0]["details"][0]
+    assert "Nested paginated connection" in result["errors"][0]["message"]
     assert client.executions == []
 
 
-def test_hosted_last_pagination_is_rejected_before_execute(monkeypatch):
+def test_hosted_last_pagination_is_bounded_to_one_page(monkeypatch):
     monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", True)
     client = FakeClient()
     _install_fake_api(monkeypatch, client)
     query = """
     query Runs($entity: String!, $project: String!) {
       project(name: $project, entityName: $entity) {
-        runs(last: 10) {
+        runs(last: 10000) {
           edges { node { id } }
           pageInfo { hasNextPage endCursor }
         }
@@ -242,11 +242,11 @@ def test_hosted_last_pagination_is_rejected_before_execute(monkeypatch):
         variables={"entity": "e", "project": "p"},
     )
 
-    assert result["errors"][0]["error"] == "query_too_complex"
-    assert client.executions == []
+    assert "last: 20" in client.executions[0][0]
+    assert "errors" not in result
 
 
-def test_non_hosted_query_passes_literal_first_unchanged(monkeypatch):
+def test_non_hosted_query_is_bounded_too(monkeypatch):
     monkeypatch.setattr(cfg, "MCP_HOSTED_MODE", False)
     client = FakeClient()
     _install_fake_api(monkeypatch, client)
@@ -259,5 +259,5 @@ def test_non_hosted_query_passes_literal_first_unchanged(monkeypatch):
     )
 
     executed_query, variables = client.executions[0]
-    assert "first: 100000" in executed_query
-    assert variables["limit"] == 100
+    assert "first: 100" in executed_query
+    assert variables["__mcp_after"] is None

--- a/tests/test_hosted_gql_production_errors.py
+++ b/tests/test_hosted_gql_production_errors.py
@@ -63,7 +63,7 @@ def test_malformed_natural_language_query_fails_before_execute(monkeypatch):
         variables={"entity": "entity", "project": "project"},
     )
 
-    assert "Failed to validate initial query" in result["errors"][0]["message"]
+    assert "Syntax Error" in result["errors"][0]["message"]
     assert client.executions == []
 
 
@@ -166,7 +166,7 @@ def test_ambiguous_connection_without_first_is_rejected_before_execute(
     )
 
     assert result["errors"][0]["error"] == "query_too_complex"
-    assert "must include a first argument" in result["errors"][0]["message"]
+    assert "must include first" in result["errors"][0]["message"]
     assert client.executions == []
 
 
@@ -198,7 +198,7 @@ def test_existing_first_on_ambiguous_connection_is_not_changed(monkeypatch):
     )
 
     executed_query, _ = client.executions[0]
-    assert "views(first: 10)" in executed_query
+    assert "views(first: 10, after: $__mcp_after)" in executed_query
     assert result == upstream_error
 
 
@@ -225,9 +225,9 @@ def test_valid_run_query_still_clamps_literal_first(monkeypatch):
     )
 
     executed_query, variables = client.executions[0]
-    assert "runs(first: 50)" in executed_query
+    assert "runs(first: 50, after: $__mcp_after)" in executed_query
     assert "100000" not in executed_query
-    assert variables["limit"] == 50
+    assert variables["__mcp_after"] is None
     assert "errors" not in result
 
 
@@ -254,6 +254,6 @@ def test_variable_default_first_is_clamped_before_execute(monkeypatch):
     )
 
     executed_query, variables = client.executions[0]
-    assert "$first: Int = 50" in executed_query
-    assert variables["limit"] == 50
+    assert "$first: Int = 100000" in executed_query
+    assert variables["first"] == 50
     assert "errors" not in result

--- a/tests/test_query_wandb_hardening.py
+++ b/tests/test_query_wandb_hardening.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 from contextlib import contextmanager
 import math
 from types import SimpleNamespace
+from urllib.parse import urlsplit
 
 import pytest
-from wandb.apis.public import Runs
+from wandb.apis.public import Run, Runs
+from wandb.apis.public.reports import BetaReport
 
 from wandb_mcp_server.mcp_tools import query_wandb as query_module
 from wandb_mcp_server.wandb_selective_reads import (
     PROJECTED_REPORTS_QUERY,
     PROJECTED_RUNS_QUERY,
     PROJECTED_SWEEPS_QUERY,
+    SelectiveReadUnavailable,
 )
 
 
@@ -327,6 +330,154 @@ def test_json_normalization_handles_cycles_and_non_finite_numbers():
     assert result["self"] == {"_truncated": "cycle"}
 
 
+def test_json_normalization_does_not_treat_shared_values_as_cycles():
+    shared = {"metric": 1}
+
+    result = query_module._json_safe({"left": shared, "right": shared})
+
+    assert result == {"left": {"metric": 1}, "right": {"metric": 1}}
+
+
+def test_real_wandb_028_run_summary_serializes_without_attribute_probe():
+    service = FakeServiceApi(lambda query, variables: {})
+    run = Run(
+        service,
+        "entity",
+        "project",
+        "run-1",
+        attrs={
+            "name": "run-1",
+            "displayName": "Real SDK run",
+            "state": "finished",
+            "summaryMetrics": '{"accuracy": 0.9, "nullable": null}',
+            "config": "{}",
+        },
+        lazy=False,
+    )
+
+    result = query_module._serialize_run(
+        run,
+        frozenset(),
+        include_summary=True,
+    )
+
+    assert result["summary"] == {"accuracy": 0.9, "nullable": None}
+
+
+def test_dense_unicode_uses_real_token_budget(monkeypatch):
+    monkeypatch.setattr(query_module, "MAX_RESPONSE_TOKENS", 100)
+    payload = {
+        "source": "wandb_sdk",
+        "resource": "project",
+        "entity": "entity",
+        "project": "project",
+        "item": {
+            "id": "project",
+            "display_name": "界" * 200,
+        },
+        "truncated": False,
+        "truncation": {"applied": False},
+    }
+
+    result = query_module._fit_single_to_budget(payload)
+
+    assert query_module._estimate_tokens(result) <= 100
+    assert "界" * 200 not in str(result)
+
+
+def test_projected_report_url_matches_wandb_028_beta_report():
+    service = FakeServiceApi(lambda query, variables: {})
+    attrs = {
+        "id": "VmlldzoxMjM=",
+        "name": "quarterly-results",
+        "displayName": "Quarterly Results / Café",
+        "spec": "{}",
+    }
+    sdk_report = BetaReport(
+        service,
+        attrs,
+        entity="entity",
+        project="project",
+    )
+    projected = query_module._decorate_projected_report(
+        {
+            "id": attrs["id"],
+            "name": attrs["name"],
+            "display_name": attrs["displayName"],
+        },
+        "entity",
+        "project",
+    )
+
+    assert urlsplit(projected["url"]).path == urlsplit(sdk_report.url).path
+    assert projected["url"].endswith("/reports/Quarterly-Results-Caf%C3%A9--VmlldzoxMjM")
+
+
+def test_partial_sdk_projection_fallback_cursor_continues_without_skipping(monkeypatch):
+    class Api:
+        def flush(self):
+            pass
+
+        def runs(self, *args, **kwargs):
+            return [_sdk_run("run-1"), _sdk_run("run-2")]
+
+    _install_api(monkeypatch, Api())
+    monkeypatch.setattr(
+        query_module,
+        "fetch_projected_runs",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+
+    first = query_module.query_wandb(
+        "entity",
+        "project",
+        "runs",
+        limit=1,
+        include=["summary"],
+        summary_keys=["accuracy"],
+    )
+    second = query_module.query_wandb(
+        "entity",
+        "project",
+        "runs",
+        limit=1,
+        include=["summary"],
+        summary_keys=["accuracy"],
+        cursor=first["next_cursor"],
+    )
+
+    assert first["items"][0]["id"] == "run-1"
+    assert first["next_cursor"].startswith("mcp-sdk-v1:")
+    assert second["items"][0]["id"] == "run-2"
+    assert second["has_more"] is False
+    assert second["next_cursor"] is None
+
+
+def test_count_mode_flushes_cached_runs_before_construction(monkeypatch):
+    class Api:
+        def __init__(self):
+            self.flushed = False
+
+        def flush(self):
+            self.flushed = True
+
+        def runs(self, *args, **kwargs):
+            assert self.flushed
+            return [_sdk_run("run-1")]
+
+    api = Api()
+    _install_api(monkeypatch, api)
+
+    result = query_module.query_wandb(
+        "entity",
+        "project",
+        "runs",
+        response_mode="count",
+    )
+
+    assert result["total_count"] == 1
+
+
 @pytest.mark.parametrize(
     ("status", "expected"),
     [(401, "authentication_failed"), (403, "permission_denied"), (404, "resource_not_found"), (429, "server_busy")],
@@ -342,3 +493,137 @@ def test_sdk_errors_map_to_stable_categories(monkeypatch, status, expected):
 
     assert result["error"] == expected
     assert "secret" not in result["message"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"resource": "runs", "cursor": "x" * 5000},
+        {"resource": "runs", "filters": {"name": "x" * (64 * 1024)}},
+        {"resource": "runs", "filters": {"metric": float("nan")}},
+        {"resource": "run", "run_id": "x" * 1025},
+        {"resource": "run", "run_id": "run-1", "summary_keys": ["x" * 1025]},
+        {"resource": "reports", "report_name": "x" * 1025},
+        {"resource": "runs", "include": ["x" * 65]},
+    ],
+)
+def test_oversized_or_nonfinite_typed_inputs_fail_before_api(monkeypatch, kwargs):
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for invalid typed input"),
+    )
+
+    result = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        **kwargs,
+    )
+
+    assert result["error"] == "invalid_request"
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [["runs"], "x" * (64 * 1024)],
+    ids=["unhashable", "oversized"],
+)
+def test_invalid_resource_errors_are_bounded_and_do_not_echo_input(monkeypatch, resource):
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for an invalid resource"),
+    )
+
+    result = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource=resource,
+    )
+
+    assert result["error"] == "invalid_request"
+    assert result["resource"] == "unknown"
+    assert len(str(result)) < 512
+
+
+def test_deep_mongo_filter_fails_before_api(monkeypatch):
+    nested: dict[str, object] = {"state": "finished"}
+    for _ in range(13):
+        nested = {"$and": [nested]}
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for an over-deep filter"),
+    )
+
+    result = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        filters=nested,
+    )
+
+    assert result["error"] == "invalid_request"
+    assert "depth" in result["message"]
+
+
+def test_sdk_fallback_cursor_request_ceiling_is_checked_before_api(monkeypatch):
+    fingerprint = query_module._sdk_cursor_fingerprint(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        filters=None,
+        order="-created_at",
+        report_name=None,
+        include=frozenset(),
+        summary_keys=None,
+        config_keys=None,
+    )
+    cursor = query_module._encode_sdk_cursor("runs", 500, fingerprint)
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created beyond the fallback request ceiling"),
+    )
+
+    result = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        limit=50,
+        cursor=cursor,
+    )
+
+    assert result["error"] == "invalid_request"
+    assert "compatibility window" in result["message"]
+
+
+def test_sdk_fallback_cursor_is_bound_to_original_query(monkeypatch):
+    fingerprint = query_module._sdk_cursor_fingerprint(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        filters=None,
+        order="-created_at",
+        report_name=None,
+        include=frozenset(),
+        summary_keys=None,
+        config_keys=None,
+    )
+    cursor = query_module._encode_sdk_cursor("runs", 1, fingerprint)
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for a mismatched continuation"),
+    )
+
+    result = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        filters={"state": "finished"},
+        cursor=cursor,
+    )
+
+    assert result["error"] == "invalid_request"
+    assert "does not match" in result["message"]

--- a/tests/test_query_wandb_hardening.py
+++ b/tests/test_query_wandb_hardening.py
@@ -1,0 +1,344 @@
+"""Regression tests for bounded v0.4 W&B query behavior."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import math
+from types import SimpleNamespace
+
+import pytest
+from wandb.apis.public import Runs
+
+from wandb_mcp_server.mcp_tools import query_wandb as query_module
+from wandb_mcp_server.wandb_selective_reads import (
+    PROJECTED_REPORTS_QUERY,
+    PROJECTED_RUNS_QUERY,
+    PROJECTED_SWEEPS_QUERY,
+)
+
+
+@contextmanager
+def _tracking(*args, **kwargs):
+    yield SimpleNamespace(mark_error=lambda error: None)
+
+
+class FakeServiceApi:
+    app_url = "https://wandb.ai/"
+
+    def __init__(self, handler):
+        self.handler = handler
+        self.executions: list[tuple[str, dict]] = []
+
+    def execute_graphql(self, query, variables=None):
+        variables = dict(variables or {})
+        self.executions.append((query, variables))
+        return self.handler(query, variables)
+
+
+class SelectiveApi:
+    def __init__(self, handler):
+        self._service_api = FakeServiceApi(handler)
+
+
+def _run_node(run_id: str, *, summary=None, config=None, sweep_name=None):
+    node = {
+        "id": f"storage-{run_id}",
+        "name": run_id,
+        "displayName": f"Display {run_id}",
+        "state": "finished",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "heartbeatAt": "2026-01-01T01:00:00Z",
+        "computeSeconds": 60,
+        "historyLineCount": 10,
+        "group": "g",
+        "jobType": "train",
+        "tags": ["release"],
+        "user": {"username": "alice", "name": "Alice"},
+    }
+    if summary is not None:
+        node["summaryMetrics"] = summary
+    if config is not None:
+        node["config"] = config
+    if sweep_name is not None:
+        node["sweepName"] = sweep_name
+    return node
+
+
+def _install_api(monkeypatch, api):
+    monkeypatch.setattr(query_module.WandBApiManager, "get_api", lambda: api)
+    monkeypatch.setattr(query_module, "track_tool_execution", _tracking)
+
+
+def test_real_wandb_028_runs_paginator_is_bounded_to_one_page(monkeypatch):
+    def handler(query, variables):
+        assert variables["perPage"] == 50
+        return {
+            "project": {
+                "runCount": 50,
+                "runs": {
+                    "edges": [{"cursor": f"c-{index}", "node": _run_node(f"run-{index}")} for index in range(50)],
+                    "pageInfo": {"hasNextPage": False, "endCursor": "c-49"},
+                },
+            }
+        }
+
+    service = FakeServiceApi(handler)
+
+    class Api:
+        def __init__(self):
+            self.flush_calls = 0
+
+        def flush(self):
+            self.flush_calls += 1
+
+        def runs(self, path, **kwargs):
+            entity, project = path.split("/", 1)
+            return Runs(
+                service,
+                entity,
+                project,
+                filters=kwargs["filters"],
+                order=kwargs["order"],
+                per_page=kwargs["per_page"],
+                include_sweeps=kwargs["include_sweeps"],
+                lazy=kwargs["lazy"],
+            )
+
+    api = Api()
+    _install_api(monkeypatch, api)
+
+    result = query_module.query_wandb("entity", "project", "runs", limit=50)
+
+    assert result["returned_count"] == 50
+    assert result["has_more"] is False
+    assert len(service.executions) == 1
+    assert api.flush_calls == 1
+
+
+def test_config_only_single_projection_preserves_default_summary_and_nulls(monkeypatch):
+    def handler(query, variables):
+        assert variables["includeSummary"] is True
+        assert variables["summaryKeys"] is None
+        return {
+            "project": {
+                "run": _run_node(
+                    "run-1",
+                    summary={"accuracy": None, "loss": 0.1},
+                    config={"learning_rate": {"value": None}},
+                )
+            }
+        }
+
+    api = SelectiveApi(handler)
+    _install_api(monkeypatch, api)
+
+    result = query_module.query_wandb(
+        "entity",
+        "project",
+        "run",
+        run_id="run-1",
+        config_keys=["learning_rate", "missing"],
+    )
+
+    assert result["item"]["summary"] == {"accuracy": None, "loss": 0.1}
+    assert result["item"]["config"] == {"learning_rate": None}
+    assert result["item"]["missing_config_keys"] == ["missing"]
+    assert "graphql_id" not in result["item"]
+
+
+def test_projected_run_cursor_and_lightweight_sweep_have_no_n_plus_one(monkeypatch):
+    def handler(query, variables):
+        assert query == PROJECTED_RUNS_QUERY
+        assert variables["includeSweep"] is True
+        after = variables["after"]
+        if after is None:
+            nodes = [("cursor-1", "run-1"), ("cursor-2", "run-2")]
+            has_more = True
+            end_cursor = "cursor-2"
+        else:
+            assert after == "cursor-2"
+            nodes = [("cursor-3", "run-3")]
+            has_more = False
+            end_cursor = "cursor-3"
+        return {
+            "project": {
+                "runCount": 3,
+                "runs": {
+                    "edges": [
+                        {"cursor": item_cursor, "node": _run_node(run_id, sweep_name="sweep-1")}
+                        for item_cursor, run_id in nodes
+                    ],
+                    "pageInfo": {"hasNextPage": has_more, "endCursor": end_cursor},
+                },
+            }
+        }
+
+    api = SelectiveApi(handler)
+    _install_api(monkeypatch, api)
+
+    first = query_module.query_wandb("entity", "project", "runs", limit=2, include=["sweep"])
+    second = query_module.query_wandb(
+        "entity",
+        "project",
+        "runs",
+        limit=2,
+        include=["sweep"],
+        cursor=first["next_cursor"],
+    )
+
+    assert first["next_cursor"] == "cursor-2"
+    assert first["truncation"]["applied"] is True
+    assert second["has_more"] is False
+    assert second["next_cursor"] is None
+    assert second["project_exhaustive"] is False
+    assert first["items"][0]["sweep"]["id"] == "sweep-1"
+    assert first["items"][0]["sweep"]["url"].endswith("/sweeps/sweep-1")
+    assert len(api._service_api.executions) == 2
+
+
+def test_fifty_sweeps_and_reports_each_require_one_bounded_request(monkeypatch):
+    def handler(query, variables):
+        if query == PROJECTED_SWEEPS_QUERY:
+            assert variables["first"] == 50
+            assert variables["includeConfig"] is False
+            return {
+                "project": {
+                    "totalSweeps": 50,
+                    "sweeps": {
+                        "edges": [
+                            {
+                                "cursor": f"s-{index}",
+                                "node": {
+                                    "id": f"storage-s-{index}",
+                                    "name": f"sweep-{index}",
+                                    "displayName": f"Sweep {index}",
+                                    "state": "FINISHED",
+                                    "runCountExpected": 2,
+                                    "runCount": 2,
+                                },
+                            }
+                            for index in range(50)
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": "s-49"},
+                    },
+                }
+            }
+        assert query == PROJECTED_REPORTS_QUERY
+        assert variables["first"] == 50
+        assert variables["includeSpec"] is False
+        return {
+            "project": {
+                "allViews": {
+                    "edges": [
+                        {
+                            "cursor": f"r-{index}",
+                            "node": {
+                                "id": f"report-{index}",
+                                "name": f"report-{index}",
+                                "displayName": f"Report {index}",
+                            },
+                        }
+                        for index in range(50)
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": "r-49"},
+                }
+            }
+        }
+
+    api = SelectiveApi(handler)
+    _install_api(monkeypatch, api)
+
+    sweeps = query_module.query_wandb("entity", "project", "sweeps", limit=50)
+    reports = query_module.query_wandb("entity", "project", "reports", limit=50)
+
+    assert len(sweeps["items"]) == 50
+    assert len(reports["items"]) == 50
+    assert all("config" not in item for item in sweeps["items"])
+    assert all("spec" not in item for item in reports["items"])
+    assert len(api._service_api.executions) == 2
+
+
+def test_report_total_count_is_unknown_when_more_pages_exist(monkeypatch):
+    def handler(query, variables):
+        return {
+            "project": {
+                "allViews": {
+                    "edges": [{"cursor": "r-1", "node": {"id": "report-1", "name": "report-1"}}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "r-1"},
+                }
+            }
+        }
+
+    api = SelectiveApi(handler)
+    _install_api(monkeypatch, api)
+
+    result = query_module.query_wandb("entity", "project", "reports", limit=1)
+
+    assert result["total_count"] is None
+    assert result["next_cursor"] == "r-1"
+
+
+def test_clamped_limit_does_not_claim_more_when_backend_is_exhausted(monkeypatch):
+    monkeypatch.setattr(query_module, "MCP_MAX_WANDB_QUERY_ITEMS", 1)
+
+    class Api:
+        def flush(self):
+            pass
+
+        def runs(self, *args, **kwargs):
+            return [_sdk_run("run-1")]
+
+    _install_api(monkeypatch, Api())
+    result = query_module.query_wandb("entity", "project", "runs", limit=50)
+
+    assert result["requested_limit"] == 50
+    assert result["limit"] == 1
+    assert result["limit_clamped"] is True
+    assert result["has_more"] is False
+    assert result["truncated"] is False
+
+
+def _sdk_run(run_id):
+    return SimpleNamespace(
+        id=run_id,
+        name=run_id,
+        state="finished",
+        entity="entity",
+        project="project",
+        url=f"https://wandb.ai/entity/project/runs/{run_id}",
+        created_at=None,
+        heartbeat_at=None,
+        duration=None,
+        group=None,
+        job_type=None,
+        tags=[],
+        user=None,
+    )
+
+
+def test_json_normalization_handles_cycles_and_non_finite_numbers():
+    cyclic: dict[str, object] = {"nan": math.nan, "infinity": math.inf}
+    cyclic["self"] = cyclic
+
+    result = query_module._json_safe(cyclic)
+
+    assert result["nan"] is None
+    assert result["infinity"] is None
+    assert result["self"] == {"_truncated": "cycle"}
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [(401, "authentication_failed"), (403, "permission_denied"), (404, "resource_not_found"), (429, "server_busy")],
+)
+def test_sdk_errors_map_to_stable_categories(monkeypatch, status, expected):
+    class Error(RuntimeError):
+        status_code = status
+
+    monkeypatch.setattr(query_module.WandBApiManager, "get_api", lambda: (_ for _ in ()).throw(Error("secret")))
+    monkeypatch.setattr(query_module, "track_tool_execution", _tracking)
+
+    result = query_module.query_wandb("entity", "project", "project")
+
+    assert result["error"] == expected
+    assert "secret" not in result["message"]

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -12,7 +12,7 @@ from wandb.apis.public import Api, Project
 
 from wandb_mcp_server.mcp_tools import query_wandb as sdk_query
 from wandb_mcp_server.server import create_mcp_server
-from wandb_mcp_server.wandb_selective_reads import ProjectedRunPage
+from wandb_mcp_server.wandb_selective_reads import ProjectedResourcePage, ProjectedRunPage, SelectiveReadUnavailable
 
 
 @contextmanager
@@ -121,6 +121,7 @@ def fake_api(monkeypatch):
         ({"entity_name": "", "project_name": "project", "resource": "runs"}, "entity_name"),
         ({"entity_name": "entity", "project_name": "", "resource": "runs"}, "project_name"),
         ({"entity_name": "entity", "project_name": "project", "resource": "unknown"}, "unsupported resource"),
+        ({"entity_name": "entity", "project_name": "project", "resource": []}, "unsupported resource"),
         ({"entity_name": "entity", "project_name": "project", "resource": "run"}, "run_id is required"),
         (
             {"entity_name": "entity", "project_name": "project", "resource": "sweep"},
@@ -135,6 +136,10 @@ def fake_api(monkeypatch):
             "unsupported include",
         ),
         ({"entity_name": "entity", "project_name": "project", "resource": "runs", "limit": 0}, "limit"),
+        (
+            {"entity_name": "entity", "project_name": "project", "resource": "runs", "response_mode": []},
+            "response_mode",
+        ),
         (
             {"entity_name": "entity", "project_name": "project", "resource": "project", "cursor": "cursor-1"},
             "cursor is supported only",
@@ -190,7 +195,12 @@ def test_run_includes_summary_by_default_and_requested_details(fake_api):
     assert result["item"]["sweep"]["id"] == "sweep-1"
 
 
-def test_runs_pass_sdk_filters_order_and_bound_collection(fake_api):
+def test_runs_sdk_fallback_passes_filters_order_and_bounds_collection(fake_api, monkeypatch):
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_runs",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
     result = sdk_query.query_wandb(
         "entity",
         "project",
@@ -198,7 +208,6 @@ def test_runs_pass_sdk_filters_order_and_bound_collection(fake_api):
         filters={"summary_metrics.accuracy": {"$gt": 0.8}},
         order="-summary_metrics.accuracy",
         limit=2,
-        include=["sweep"],
     )
 
     call = fake_api.calls[0]
@@ -206,8 +215,8 @@ def test_runs_pass_sdk_filters_order_and_bound_collection(fake_api):
     assert call[2] == {
         "filters": {"summary_metrics.accuracy": {"$gt": 0.8}},
         "order": "-summary_metrics.accuracy",
-        "per_page": 3,
-        "include_sweeps": True,
+        "per_page": 2,
+        "include_sweeps": False,
         "lazy": True,
     }
     assert result["count"] == 2
@@ -239,10 +248,18 @@ def test_run_collection_can_select_fields_without_full_summary(fake_api, monkeyp
 
     monkeypatch.setattr(sdk_query, "fetch_projected_runs", projected)
 
+    filters = {
+        "$and": [
+            {"displayName": {"$regex": "cruise"}},
+            {"$or": [{"sweep": "sweep-1"}, {"name": "arbitrary-run-id"}]},
+        ]
+    }
     result = sdk_query.query_wandb(
         "entity",
         "project",
         "runs",
+        filters=filters,
+        order="-summary_metrics.accuracy",
         limit=50,
         summary_keys=["accuracy", "loss"],
         config_keys=["learning_rate"],
@@ -253,6 +270,8 @@ def test_run_collection_can_select_fields_without_full_summary(fake_api, monkeyp
     assert result["total_count"] == 24_000
     assert result["returned_count"] == 1
     assert result["source"] == "wandb_selective_read"
+    assert projected_calls[0]["filters"] == filters
+    assert projected_calls[0]["order"] == "-summary_metrics.accuracy"
     assert projected_calls[0]["summary_keys"] == ["accuracy", "loss"]
     assert projected_calls[0]["config_keys"] == ["learning_rate"]
 
@@ -377,7 +396,7 @@ def test_collection_limit_is_clamped_to_deployment_ceiling(fake_api, monkeypatch
 
 
 def test_response_budget_drops_optional_fields_before_items(fake_api, monkeypatch):
-    monkeypatch.setattr(sdk_query, "MAX_RESPONSE_TOKENS", 250)
+    monkeypatch.setattr(sdk_query, "MAX_RESPONSE_TOKENS", 500)
     runs = [_run("run-1"), _run("run-2")]
     for run in runs:
         run.config = {"large": "x" * 4000}
@@ -390,17 +409,86 @@ def test_response_budget_drops_optional_fields_before_items(fake_api, monkeypatc
     assert all("config" not in item for item in result["items"])
 
 
-def test_single_and_collection_sweeps_use_public_sdk(fake_api):
+def test_single_sweep_uses_sdk_and_collection_uses_projection_without_fanout(fake_api, monkeypatch):
     single = sdk_query.query_wandb("entity", "project", "sweep", sweep_id="sweep-1", include=["config"])
-
-    fake_api.project_result.sweeps = lambda per_page: iter([_sweep("sweep-1"), _sweep("sweep-2")])
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_sweeps",
+        lambda *args, **kwargs: ProjectedResourcePage(
+            items=[
+                {
+                    "id": "sweep-1",
+                    "name": "display-sweep-1",
+                    "entity": "entity",
+                    "project": "project",
+                    "config": {"method": "bayes"},
+                }
+            ],
+            total_count=2,
+            has_more=True,
+            next_cursor="sweep-cursor",
+            requests=1,
+        ),
+    )
     collection = sdk_query.query_wandb("entity", "project", "sweeps", limit=1, include=["config"])
 
     assert single["item"]["config"] == {"method": "bayes"}
     assert ("sweep", "entity/project/sweep-1") in fake_api.calls
-    assert ("project", "project", "entity") in fake_api.calls
+    assert ("project", "project", "entity") not in fake_api.calls
     assert collection["items"][0]["id"] == "sweep-1"
     assert collection["truncated"] is True
+
+
+def test_collection_fallbacks_never_reintroduce_n_plus_one_or_spec_overfetch(fake_api, monkeypatch):
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_runs",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_sweeps",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_reports",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+
+    run_sweeps = sdk_query.query_wandb("entity", "project", "runs", limit=1, include=["sweep"])
+    sweeps = sdk_query.query_wandb("entity", "project", "sweeps", limit=1)
+    reports = sdk_query.query_wandb("entity", "project", "reports", limit=1)
+
+    assert run_sweeps["error"] == "selective_read_unavailable"
+    assert sweeps["error"] == "selective_read_unavailable"
+    assert reports["error"] == "selective_read_unavailable"
+    assert fake_api.calls == []
+
+
+def test_explicit_report_spec_sdk_fallback_cursor_continues(fake_api, monkeypatch):
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_projected_reports",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+
+    first = sdk_query.query_wandb("entity", "project", "reports", limit=1, include=["spec"])
+    second = sdk_query.query_wandb(
+        "entity",
+        "project",
+        "reports",
+        limit=1,
+        include=["spec"],
+        cursor=first["next_cursor"],
+    )
+
+    assert first["items"][0]["id"] == "report-1"
+    assert first["next_cursor"].startswith("mcp-sdk-v1:")
+    assert second["items"][0]["id"] == "report-2"
+    assert second["total_count"] == 2
+    assert second["has_more"] is False
+    assert second["next_cursor"] is None
 
 
 def test_reports_use_sdk_name_filter_and_optional_spec(fake_api):

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -135,6 +135,20 @@ def fake_api(monkeypatch):
             "unsupported include",
         ),
         ({"entity_name": "entity", "project_name": "project", "resource": "runs", "limit": 0}, "limit"),
+        (
+            {"entity_name": "entity", "project_name": "project", "resource": "project", "cursor": "cursor-1"},
+            "cursor is supported only",
+        ),
+        (
+            {
+                "entity_name": "entity",
+                "project_name": "project",
+                "resource": "runs",
+                "cursor": "cursor-1",
+                "response_mode": "count",
+            },
+            "cursor is not supported",
+        ),
     ],
 )
 def test_invalid_requests_do_not_create_api(monkeypatch, kwargs, message):
@@ -253,6 +267,7 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
         "summary_keys",
         "config_keys",
         "response_mode",
+        "cursor",
     } <= query_tool.inputSchema["properties"].keys()
 
     await server.call_tool(
@@ -422,7 +437,7 @@ def test_malformed_collection_filter_returns_sdk_query_error(fake_api):
     result = sdk_query.query_wandb("entity", "project", "runs", filters={"$bad": True})
 
     assert result["error"] == "sdk_query_failed"
-    assert result["message"] == "invalid filters"
+    assert result["message"] == "W&B query failed (ValueError)"
 
 
 def test_sdk_client_initialization_failure_returns_structured_error(monkeypatch):
@@ -439,7 +454,7 @@ def test_sdk_client_initialization_failure_returns_structured_error(monkeypatch)
     result = sdk_query.query_wandb("entity", "project", "project")
 
     assert result["error"] == "sdk_query_failed"
-    assert result["message"] == "temporary initialization failure"
+    assert result["message"] == "W&B query failed (RuntimeError)"
 
 
 def test_supported_sdk_exposes_every_public_query_operation():

--- a/tests/test_raw_graphql_hardening.py
+++ b/tests/test_raw_graphql_hardening.py
@@ -1,0 +1,207 @@
+"""Security and pagination tests for the opt-in raw GraphQL compatibility tool."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import wandb_mcp_server.api_client as api_client
+from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+
+
+@contextmanager
+def _tracking(*args, **kwargs):
+    yield SimpleNamespace(mark_error=lambda error: None)
+
+
+class Service:
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.calls = []
+
+    def execute_graphql(self, query, variables=None):
+        self.calls.append((query, dict(variables or {})))
+        if self.responses:
+            return self.responses.pop(0)
+        return {"viewer": {"id": "viewer"}}
+
+
+def _install(monkeypatch, service):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: SimpleNamespace(_service_api=service))
+    monkeypatch.setattr(gql_tool, "track_tool_execution", _tracking)
+
+
+def test_connection_hidden_in_fragment_is_bounded_by_actual_variable(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"cursor": "c1", "node": {"id": "r1"}}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c1"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+    query = """
+    query Runs($weirdBatch: Int!, $entity: String!, $project: String!) {
+      project(name: $project, entityName: $entity) { ...RunConnection }
+    }
+    fragment RunConnection on Project {
+      runs(first: $weirdBatch) { ...ConnectionFields }
+    }
+    fragment ConnectionFields on RunConnection {
+      edges { node { id } cursor }
+      pageInfo { hasNextPage endCursor }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        {"entity": "e", "project": "p", "weirdBatch": 100_000},
+        max_items=10,
+        items_per_page=7,
+    )
+
+    assert service.calls[0][1]["weirdBatch"] == 7
+    assert result["extensions"]["wandb_mcp"]["returned_count"] == 1
+
+
+def test_inline_fragment_second_connection_is_rejected_before_api(monkeypatch):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+    query = """
+    query Multi {
+      viewer {
+        ... on User {
+          projects(first: 2) {
+            edges { node { id } }
+            pageInfo { hasNextPage endCursor }
+          }
+          teams(first: 2) {
+            edges { node { id } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(query)
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "query One { viewer { id } } query Two { viewer { name } }",
+        "fragment Only on User { id }",
+    ],
+)
+def test_exactly_one_query_operation_is_required_before_api(monkeypatch, query):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+
+    result = gql_tool.query_paginated_wandb_gql(query)
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+
+
+@pytest.mark.parametrize(
+    ("max_items", "items_per_page"),
+    [(0, 20), (-1, 20), (10, 0), (10, -1), (True, 20)],
+)
+def test_positive_integer_limits_are_required_before_api(monkeypatch, max_items, items_per_page):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+
+    result = gql_tool.query_paginated_wandb_gql(
+        "query Viewer { viewer { id } }",
+        max_items=max_items,
+        items_per_page=items_per_page,
+    )
+
+    assert result["errors"][0]["error"] == "invalid_request"
+
+
+def test_document_size_depth_field_and_fragment_limits_reject_before_api(monkeypatch):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+    oversized = "query Q { viewer { id } }" + (" " * gql_tool.MAX_GRAPHQL_DOCUMENT_BYTES)
+    too_deep = "query Q { " + "a { " * 13 + "id" + " }" * 13 + " }"
+    too_many_fields = "query Q { viewer { " + " ".join(f"f{i}" for i in range(201)) + " } }"
+    fragments = "\n".join(f"fragment F{i} on User {{ id }}" for i in range(33))
+    too_many_fragments = f"query Q {{ viewer {{ ...F0 }} }}\n{fragments}"
+
+    for document in (oversized, too_deep, too_many_fields, too_many_fragments):
+        result = gql_tool.query_paginated_wandb_gql(document)
+        assert result["errors"][0]["error"] == "query_too_complex"
+
+
+def test_limit_stop_preserves_truthful_page_info_and_cursor(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [
+                            {"cursor": "c1", "node": {"id": "r1"}},
+                            {"cursor": "c2", "node": {"id": "r2"}},
+                        ],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c2"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+    query = """
+    query Runs($first: Int!) {
+      project(name: "p", entityName: "e") {
+        runs(first: $first) {
+          edges { cursor node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(query, {"first": 100}, max_items=1, items_per_page=20)
+    connection = result["project"]["runs"]
+
+    assert len(connection["edges"]) == 1
+    assert connection["pageInfo"] == {"hasNextPage": True, "endCursor": "c1"}
+    assert result["extensions"]["wandb_mcp"]["next_cursor"] == "c1"
+
+
+def test_raw_query_and_variables_are_not_forwarded_to_analytics(monkeypatch):
+    captured = {}
+
+    @contextmanager
+    def capture(*args, **kwargs):
+        captured["parameters"] = args[2]
+        yield SimpleNamespace(mark_error=lambda error: None)
+
+    service = Service()
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: SimpleNamespace(_service_api=service))
+    monkeypatch.setattr(gql_tool, "track_tool_execution", capture)
+
+    gql_tool.query_paginated_wandb_gql(
+        "query Secret($token: String!) { viewer { id } }",
+        {"token": "secret-canary"},
+    )
+
+    assert "query" not in captured["parameters"]
+    assert "variables" not in captured["parameters"]
+    assert "secret-canary" not in str(captured)
+
+
+def test_oversized_non_connection_response_returns_bounded_error(monkeypatch):
+    service = Service([{"viewer": {"custom": "x" * 20_000}}])
+    _install(monkeypatch, service)
+    monkeypatch.setattr("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 100)
+
+    result = gql_tool.query_paginated_wandb_gql("query Viewer { viewer { custom } }")
+
+    assert result["errors"][0]["error"] == "response_too_large"

--- a/tests/test_raw_graphql_hardening.py
+++ b/tests/test_raw_graphql_hardening.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import json
 from types import SimpleNamespace
 
 import pytest
 
 import wandb_mcp_server.api_client as api_client
 from wandb_mcp_server.mcp_tools import query_wandb_gql as gql_tool
+from wandb_mcp_server.trace_utils import count_tokens
 
 
 @contextmanager
@@ -69,6 +71,97 @@ def test_connection_hidden_in_fragment_is_bounded_by_actual_variable(monkeypatch
 
     assert service.calls[0][1]["weirdBatch"] == 7
     assert result["extensions"]["wandb_mcp"]["returned_count"] == 1
+
+
+def test_first_argument_is_bounded_even_without_page_info_selection(monkeypatch):
+    service = Service([{"project": {"runs": {"edges": [{"node": {"id": "r1"}}]}}}])
+    _install(monkeypatch, service)
+    query = """
+    query Runs($unusualLimit: Int!) {
+      project(name: "p", entityName: "e") {
+        runs(first: $unusualLimit) {
+          edges { node { id } }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        {"unusualLimit": 1_000_000},
+        max_items=10,
+        items_per_page=7,
+    )
+
+    assert service.calls[0][1]["unusualLimit"] == 7
+    assert result["project"]["runs"]["edges"] == [{"node": {"id": "r1"}}]
+
+
+@pytest.mark.parametrize("page_info", [None, "not-a-page-info-object"])
+def test_local_item_limit_is_enforced_without_usable_page_info(monkeypatch, page_info):
+    connection = {
+        "edges": [{"cursor": f"c{index}", "node": {"id": f"r{index}"}} for index in range(1, 6)],
+    }
+    if page_info is not None:
+        connection["pageInfo"] = page_info
+    service = Service([{"project": {"runs": connection}}])
+    _install(monkeypatch, service)
+    query = """
+    query Runs($batch: Int!) {
+      project(name: "p", entityName: "e") {
+        runs(first: $batch) {
+          edges { cursor node { id } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        {"batch": 100},
+        max_items=2,
+        items_per_page=2,
+    )
+
+    assert [edge["cursor"] for edge in result["project"]["runs"]["edges"]] == ["c1", "c2"]
+    assert result["extensions"]["wandb_mcp"] == {
+        "returned_count": 2,
+        "has_more": True,
+        "next_cursor": "c2",
+        "truncated_by_response_budget": False,
+        "limit_applied": 2,
+    }
+
+
+def test_local_item_limit_without_page_info_fails_when_cursor_was_not_selected(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"node": {"id": f"r{index}"}} for index in range(3)],
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!) {
+          project(name: "p", entityName: "e") {
+            runs(first: $batch) { edges { node { id } } }
+          }
+        }
+        """,
+        {"batch": 100},
+        max_items=1,
+        items_per_page=1,
+    )
+
+    assert result["errors"][0]["error"] == "pagination_cursor_unavailable"
 
 
 def test_inline_fragment_second_connection_is_rejected_before_api(monkeypatch):
@@ -139,6 +232,59 @@ def test_document_size_depth_field_and_fragment_limits_reject_before_api(monkeyp
         assert result["errors"][0]["error"] == "query_too_complex"
 
 
+def test_fragment_fanout_hits_expansion_budget_before_api(monkeypatch):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+    fragments = []
+    for index in range(20):
+        body = "id" if index == 19 else f"...F{index + 1} ...F{index + 1}"
+        fragments.append(f"fragment F{index} on User {{ {body} }}")
+    query = "query Q { viewer { ...F0 } }\n" + "\n".join(fragments)
+
+    result = gql_tool.query_paginated_wandb_gql(query)
+
+    assert result["errors"][0]["error"] == "query_too_complex"
+    assert "expanded selections" in result["errors"][0]["message"]
+
+
+def test_malformed_forward_cursor_is_rejected_before_api(monkeypatch):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs {
+          project(name: "p", entityName: "e") {
+            runs(first: 1, after: 123) {
+              edges { cursor node { id } }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+        """
+    )
+
+    assert result["errors"][0]["error"] == "invalid_request"
+    assert "after must be a string literal, variable, or null" in result["errors"][0]["message"]
+
+
+def test_variable_size_depth_and_node_limits_reject_before_api(monkeypatch):
+    monkeypatch.setattr(api_client, "get_wandb_api", lambda: pytest.fail("must reject before API construction"))
+    deeply_nested = "leaf"
+    for _ in range(gql_tool.MAX_GRAPHQL_VARIABLE_DEPTH + 2):
+        deeply_nested = {"nested": deeply_nested}
+    cases = [
+        {"value": "x" * gql_tool.MAX_GRAPHQL_DOCUMENT_BYTES},
+        {"value": deeply_nested},
+        {"value": [None] * gql_tool.MAX_GRAPHQL_VARIABLE_NODES},
+    ]
+
+    for variables in cases:
+        result = gql_tool.query_paginated_wandb_gql(
+            "query Viewer { viewer { id } }",
+            variables,
+        )
+        assert result["errors"][0]["error"] == "query_too_complex"
+
+
 def test_limit_stop_preserves_truthful_page_info_and_cursor(monkeypatch):
     service = Service(
         [
@@ -175,6 +321,238 @@ def test_limit_stop_preserves_truthful_page_info_and_cursor(monkeypatch):
     assert result["extensions"]["wandb_mcp"]["next_cursor"] == "c1"
 
 
+def test_backward_limit_stop_requires_retained_edge_cursor(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"node": {"id": f"r{index}"}} for index in range(5)],
+                        "pageInfo": {"hasPreviousPage": False, "startCursor": "c0"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!) {
+          project(name: "p", entityName: "e") {
+            runs(last: $batch) {
+              edges { node { id } }
+              pageInfo { hasPreviousPage startCursor }
+            }
+          }
+        }
+        """,
+        {"batch": 100},
+        max_items=2,
+        items_per_page=2,
+    )
+
+    assert result["errors"][0]["error"] == "pagination_cursor_unavailable"
+
+
+def test_backward_limit_stop_uses_retained_boundary_cursor(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"cursor": f"c{index}", "node": {"id": f"r{index}"}} for index in range(5)],
+                        "pageInfo": {"hasPreviousPage": False, "startCursor": "c0"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!) {
+          project(name: "p", entityName: "e") {
+            runs(last: $batch) {
+              edges { cursor node { id } }
+              pageInfo { hasPreviousPage startCursor }
+            }
+          }
+        }
+        """,
+        {"batch": 100},
+        max_items=2,
+        items_per_page=2,
+    )
+
+    connection = result["project"]["runs"]
+    assert [edge["cursor"] for edge in connection["edges"]] == ["c3", "c4"]
+    assert connection["pageInfo"] == {"hasPreviousPage": True, "startCursor": "c3"}
+    assert result["extensions"]["wandb_mcp"]["next_cursor"] == "c3"
+
+
+def test_backward_page_cursor_must_advance_from_supplied_before(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"cursor": "same-cursor", "node": {"id": "r1"}}],
+                        "pageInfo": {"hasPreviousPage": True, "startCursor": "same-cursor"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!, $before: String) {
+          project(name: "p", entityName: "e") {
+            runs(last: $batch, before: $before) {
+              edges { cursor node { id } }
+              pageInfo { hasPreviousPage startCursor }
+            }
+          }
+        }
+        """,
+        {"batch": 1, "before": "same-cursor"},
+        max_items=2,
+        items_per_page=1,
+    )
+
+    assert result["errors"][0]["error"] == "pagination_cursor_non_advancing"
+    assert len(service.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "page_cursors",
+    [
+        ("page-1", "page-1"),
+        ("page-1", "page-2", "page-1"),
+    ],
+)
+def test_forward_pagination_rejects_non_advancing_and_cyclic_page_cursors(monkeypatch, page_cursors):
+    responses = [
+        {
+            "project": {
+                "runs": {
+                    "edges": [{"cursor": f"edge-{index}", "node": {"id": f"r{index}"}}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": cursor},
+                }
+            }
+        }
+        for index, cursor in enumerate(page_cursors, start=1)
+    ]
+    service = Service(responses)
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!, $after: String) {
+          project(name: "p", entityName: "e") {
+            runs(first: $batch, after: $after) {
+              edges { cursor node { id } }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+        """,
+        {"batch": 1, "after": None},
+        max_items=4,
+        items_per_page=1,
+    )
+
+    assert result["errors"][0]["error"] == "pagination_cursor_non_advancing"
+    assert len(service.calls) == len(page_cursors)
+
+
+def test_initial_page_cursor_must_advance_from_supplied_after(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"cursor": "edge-1", "node": {"id": "r1"}}],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "same-cursor"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+
+    result = gql_tool.query_paginated_wandb_gql(
+        """
+        query Runs($batch: Int!, $after: String) {
+          project(name: "p", entityName: "e") {
+            runs(first: $batch, after: $after) {
+              edges { cursor node { id } }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+        """,
+        {"batch": 1, "after": "same-cursor"},
+        max_items=2,
+        items_per_page=1,
+    )
+
+    assert result["errors"][0]["error"] == "pagination_cursor_non_advancing"
+    assert len(service.calls) == 1
+
+
+def test_paginated_response_aliases_preserve_truthful_cursor(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "aliasedRuns": {
+                        "aliasedEdges": [
+                            {"edgeCursor": "c1", "aliasedNode": {"nodeId": "r1"}},
+                            {"edgeCursor": "c2", "aliasedNode": {"nodeId": "r2"}},
+                        ],
+                        "aliasedPageInfo": {"more": True, "pageEnd": "c2"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+    query = """
+    query Runs($batch: Int!) {
+      project(name: "p", entityName: "e") {
+        aliasedRuns: runs(first: $batch) {
+          aliasedEdges: edges {
+            edgeCursor: cursor
+            aliasedNode: node { nodeId: id }
+          }
+          aliasedPageInfo: pageInfo {
+            more: hasNextPage
+            pageEnd: endCursor
+          }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        {"batch": 100},
+        max_items=1,
+        items_per_page=20,
+    )
+
+    connection = result["project"]["aliasedRuns"]
+    assert connection["aliasedEdges"] == [{"edgeCursor": "c1", "aliasedNode": {"nodeId": "r1"}}]
+    assert connection["aliasedPageInfo"] == {"more": True, "pageEnd": "c1"}
+    assert result["extensions"]["wandb_mcp"]["next_cursor"] == "c1"
+    assert "edges" not in connection
+    assert "pageInfo" not in connection
+
+
 def test_raw_query_and_variables_are_not_forwarded_to_analytics(monkeypatch):
     captured = {}
 
@@ -203,5 +581,95 @@ def test_oversized_non_connection_response_returns_bounded_error(monkeypatch):
     monkeypatch.setattr("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 100)
 
     result = gql_tool.query_paginated_wandb_gql("query Viewer { viewer { custom } }")
+
+    assert result["errors"][0]["error"] == "response_too_large"
+
+
+def test_response_budget_uses_real_token_count_for_unicode(monkeypatch):
+    service = Service([{"viewer": {"custom": "漢" * 200}}])
+    _install(monkeypatch, service)
+    monkeypatch.setattr("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 100)
+
+    result = gql_tool.query_paginated_wandb_gql("query Viewer { viewer { custom } }")
+
+    assert result["errors"][0]["error"] == "response_too_large"
+
+
+def test_budget_truncation_keeps_a_truthful_resume_cursor(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [
+                            {"cursor": "c1", "node": {"id": "r1", "custom": "漢" * 200}},
+                            {"cursor": "c2", "node": {"id": "r2", "custom": "漢" * 200}},
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": "c2"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+    budget = 650
+    monkeypatch.setattr("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", budget)
+    query = """
+    query Runs($first: Int!) {
+      project(name: "p", entityName: "e") {
+        runs(first: $first) {
+          edges { cursor node { id custom } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(
+        query,
+        {"first": 2},
+        max_items=2,
+        items_per_page=2,
+    )
+
+    connection = result["project"]["runs"]
+    assert [edge["cursor"] for edge in connection["edges"]] == ["c1"]
+    assert connection["pageInfo"] == {"hasNextPage": True, "endCursor": "c1"}
+    assert result["extensions"]["wandb_mcp"] == {
+        "returned_count": 1,
+        "has_more": True,
+        "next_cursor": "c1",
+        "truncated_by_response_budget": True,
+    }
+    assert count_tokens(json.dumps(result, ensure_ascii=False)) <= budget
+
+
+def test_budget_truncation_without_a_retained_cursor_fails_safely(monkeypatch):
+    service = Service(
+        [
+            {
+                "project": {
+                    "runs": {
+                        "edges": [{"node": {"id": "r1", "custom": "漢" * 500}}],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                    }
+                }
+            }
+        ]
+    )
+    _install(monkeypatch, service)
+    monkeypatch.setattr("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 100)
+    query = """
+    query Runs($first: Int!) {
+      project(name: "p", entityName: "e") {
+        runs(first: $first) {
+          edges { node { id custom } }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+    """
+
+    result = gql_tool.query_paginated_wandb_gql(query, {"first": 1})
 
     assert result["errors"][0]["error"] == "response_too_large"

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -10,6 +10,8 @@ from wandb_mcp_server.wandb_selective_reads import (
     METRIC_VALUE_STEPS_QUERY,
     PROJECTED_RUNS_QUERY,
     PROJECTED_RUN_QUERY,
+    PROJECTED_REPORTS_QUERY,
+    PROJECTED_SWEEPS_QUERY,
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
     REGISTRY_ARTIFACT_VERSIONS_QUERY,
@@ -146,6 +148,8 @@ def test_every_application_owned_document_is_query_only():
     for document in (
         PROJECTED_RUNS_QUERY,
         PROJECTED_RUN_QUERY,
+        PROJECTED_REPORTS_QUERY,
+        PROJECTED_SWEEPS_QUERY,
         PROJECT_COUNTS_QUERY,
         PROJECT_FIELDS_QUERY,
         ARTIFACT_INVENTORY_QUERY,

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from wandb_mcp_server.wandb_graphql import validate_read_only_graphql
 from wandb_mcp_server.wandb_selective_reads import (
     ARTIFACT_INVENTORY_QUERY,
@@ -15,12 +17,15 @@ from wandb_mcp_server.wandb_selective_reads import (
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
     REGISTRY_ARTIFACT_VERSIONS_QUERY,
+    SelectiveReadUnavailable,
     fetch_registry_artifact_versions,
     fetch_project_counts,
     fetch_project_fields,
     fetch_metric_value_steps,
+    fetch_projected_reports,
     fetch_projected_run,
     fetch_projected_runs,
+    fetch_projected_sweeps,
 )
 
 
@@ -144,6 +149,49 @@ class FakeApi:
         self._service_api = FakeServiceApi()
 
 
+def _projected_collection_response(query: str, *, cursor: str, has_more: bool = True):
+    connection = {
+        "edges": [],
+        "pageInfo": {"endCursor": cursor, "hasNextPage": has_more},
+    }
+    if query == PROJECTED_RUNS_QUERY:
+        return {"project": {"runCount": 50, "runs": connection}}
+    if query == PROJECTED_SWEEPS_QUERY:
+        return {"project": {"totalSweeps": 50, "sweeps": connection}}
+    if query == PROJECTED_REPORTS_QUERY:
+        return {"project": {"allViews": connection}}
+    raise AssertionError("unexpected query")
+
+
+def _fetch_projected_collection(
+    kind: str,
+    api,
+    *,
+    cursor: str | None = None,
+    limit: int = 50,
+    page_size: int = 20,
+):
+    common = {
+        "api": api,
+        "entity": "entity",
+        "project": "project",
+        "limit": limit,
+        "page_size": page_size,
+        "cursor": cursor,
+    }
+    if kind == "runs":
+        return fetch_projected_runs(
+            **common,
+            filters=None,
+            order="-created_at",
+        )
+    if kind == "sweeps":
+        return fetch_projected_sweeps(**common)
+    if kind == "reports":
+        return fetch_projected_reports(**common, report_name=None)
+    raise AssertionError("unexpected collection")
+
+
 def test_every_application_owned_document_is_query_only():
     for document in (
         PROJECTED_RUNS_QUERY,
@@ -183,6 +231,136 @@ def test_projected_collection_fetches_only_requested_fields_in_one_request():
     assert variables["summaryKeys"] == ["accuracy", "loss"]
     assert variables["configKeys"] == ["learning_rate"]
     assert json.loads(variables["filters"]) == {"state": "finished"}
+
+
+@pytest.mark.parametrize("kind", ["runs", "sweeps", "reports"])
+def test_projected_collections_reject_a_non_advancing_cursor(kind):
+    class RepeatingServiceApi:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return _projected_collection_response(query, cursor="same-cursor")
+
+    api = type("Api", (), {"_service_api": RepeatingServiceApi()})()
+
+    with pytest.raises(SelectiveReadUnavailable, match="repeated a continuation cursor"):
+        _fetch_projected_collection(kind, api, cursor="same-cursor")
+
+    assert api._service_api.calls == 1
+
+
+@pytest.mark.parametrize("kind", ["runs", "sweeps", "reports"])
+def test_projected_collections_stop_at_the_page_request_ceiling(kind):
+    class AdvancingEmptyServiceApi:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return _projected_collection_response(query, cursor=f"cursor-{self.calls}")
+
+    api = type("Api", (), {"_service_api": AdvancingEmptyServiceApi()})()
+
+    result = _fetch_projected_collection(kind, api)
+
+    # ceil(50 / 20) plus one short-page allowance, independently capped in
+    # production, prevents an empty but cursor-advancing backend from spinning.
+    assert result.requests == 4
+    assert api._service_api.calls == 4
+    assert result.items == []
+    assert result.has_more is True
+    assert result.next_cursor == "cursor-4"
+
+
+def test_projected_page_requests_have_an_absolute_ceiling():
+    class AdvancingEmptyServiceApi:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return _projected_collection_response(query, cursor=f"cursor-{self.calls}")
+
+    api = type("Api", (), {"_service_api": AdvancingEmptyServiceApi()})()
+
+    result = _fetch_projected_collection("runs", api, limit=50, page_size=1)
+
+    assert result.requests == 10
+    assert api._service_api.calls == 10
+    assert result.has_more is True
+    assert result.next_cursor == "cursor-10"
+
+
+def test_projected_collections_reject_a_previously_seen_cursor():
+    class CyclingServiceApi:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            cursors = ("cursor-1", "cursor-2", "cursor-1")
+            cursor = cursors[self.calls]
+            self.calls += 1
+            return _projected_collection_response(query, cursor=cursor)
+
+    api = type("Api", (), {"_service_api": CyclingServiceApi()})()
+
+    with pytest.raises(SelectiveReadUnavailable, match="repeated a continuation cursor"):
+        _fetch_projected_collection("reports", api, limit=50, page_size=1)
+
+    assert api._service_api.calls == 3
+
+
+@pytest.mark.parametrize("kind", ["runs", "sweeps", "reports"])
+def test_projected_collections_reject_missing_continuation_cursor(kind):
+    class MissingCursorServiceApi:
+        def execute_graphql(self, query, variables=None):
+            return _projected_collection_response(query, cursor="")
+
+    api = type("Api", (), {"_service_api": MissingCursorServiceApi()})()
+
+    with pytest.raises(SelectiveReadUnavailable, match="without a continuation cursor"):
+        _fetch_projected_collection(kind, api)
+
+
+@pytest.mark.parametrize("kind", ["runs", "sweeps", "reports"])
+def test_projected_collections_resume_after_last_retained_edge_when_backend_overreturns(kind):
+    class OverReturningServiceApi:
+        def execute_graphql(self, query, variables=None):
+            after = (variables or {}).get("after")
+            start = 0 if after is None else int(after.removeprefix("cursor-"))
+            edges = []
+            for index in range(start + 1, 4):
+                if kind == "runs":
+                    node = {"name": f"run-{index}"}
+                elif kind == "sweeps":
+                    node = {"name": f"sweep-{index}"}
+                else:
+                    node = {"id": f"report-{index}", "name": f"report-{index}"}
+                edges.append({"cursor": f"cursor-{index}", "node": node})
+            connection = {
+                "edges": edges,
+                "pageInfo": {"endCursor": "cursor-3", "hasNextPage": False},
+            }
+            if kind == "runs":
+                return {"project": {"runCount": 3, "runs": connection}}
+            if kind == "sweeps":
+                return {"project": {"totalSweeps": 3, "sweeps": connection}}
+            return {"project": {"allViews": connection}}
+
+    api = type("Api", (), {"_service_api": OverReturningServiceApi()})()
+
+    first = _fetch_projected_collection(kind, api, limit=1, page_size=1)
+    second = _fetch_projected_collection(kind, api, cursor=first.next_cursor, limit=1, page_size=1)
+
+    expected_prefix = {"runs": "run", "sweeps": "sweep", "reports": "report"}[kind]
+    assert first.items[0]["id"] == f"{expected_prefix}-1"
+    assert first.has_more is True
+    assert first.next_cursor == "cursor-1"
+    assert second.items[0]["id"] == f"{expected_prefix}-2"
+    assert second.has_more is True
+    assert second.next_cursor == "cursor-2"
 
 
 def test_single_projected_run_supports_nested_and_literal_config_keys():


### PR DESCRIPTION
## Summary

Hardens the v0.4 structured W&B query surface before release PR #117 is approved.

- Adds optional cursor continuation for runs, sweeps, and reports without adding a new MCP tool.
- Eliminates collection N+1 behavior with bounded, application-owned query-only projections where the W&B 0.28 public API cannot select metadata efficiently.
- Keeps run summaries out of collections by default, supports targeted `summary_keys` and `config_keys`, and preserves the documented default summary for single-run reads.
- Normalizes projected and SDK fallback responses, distinguishes selected nulls from missing keys, fixes count/truncation/exhaustion semantics, and enforces a serialized response budget for cyclic, deeply nested, non-finite, and oversized values.
- Binds SDK fallback cursors to their originating entity/project/filter/order/detail query and rejects mismatched or excessively deep continuation windows before API construction.
- Maps authentication, authorization, not-found, timeout, rate-limit, and overload failures to stable errors.

## Query-only compatibility boundary

The normal query path follows documented W&B Public API behavior where it is semantically and operationally adequate. Fixed application-owned documents are query-only, accept no caller-selected operation text, and are used only to avoid run/sweep/report collection fan-out.

Caller-supplied GraphQL remains disabled by default. Administrators can opt into the separate query-only compatibility tool with `WANDB_MCP_ENABLE_RAW_GRAPHQL=true` for genuinely unmodeled reads.

The opt-in raw path now:

- accepts exactly one query operation and rejects mutations, subscriptions, mixed documents, and multiple operations;
- resolves fragments and inline fragments under a hard expansion-work budget;
- enforces 64-KiB documents and variables, depth 12, 200 selected fields, 32 fragments, one paginated connection, positive bounds, and bounded variable shape;
- evaluates the actual variable bound to `first`/`last`, rejects malformed `after`/`before` cursors, detects repeated cursors, and retains truthful continuation metadata when MCP limits stop a page;
- never forwards raw query text or variables to analytics or logs.

See `docs/query-capabilities.md` for the migration/capability matrix.

## Validation

- Python 3.11 full non-integration suite: `994 passed, 10 deselected`
- Python 3.12 full non-integration suite: `994 passed, 10 deselected`
- Focused typed/raw/selective query suite: `142 passed`
- Ruff check and format check: passed
- `uv lock --check`: passed
- Bandit Medium/High scan: passed
- Grype fixable High/Critical scan: no vulnerabilities found
- Wheel and sdist build: passed
- Installed-wheel MCP STDIO harness with MCP `1.29.0`: passed
- Installed-wheel MCP STDIO harness with minimum MCP `1.28.1`: passed
- Raw GraphQL disabled by default and opt-in registration smoke: passed

No live W&B calls or writes were performed.

This PR targets `staging/0.4.0`. Release PR #117 remains draft and unmerged until the runtime, hosted, Helm, human-review, and live-staging gates are satisfied.
