### PR TITLE
fix: harden v0.4 runtime safety boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ resp = client.responses.create(
 print(resp.output_text)
 ```
 
-> **Note**: OpenAI's MCP is server-side, so localhost URLs won't work. For local servers, see [Option 2](#general-installation-guide) with ngrok.
+> **Note**: OpenAI's MCP is server-side, so localhost URLs won't work. Use the
+> hosted W&B endpoint or an authenticated Helm deployment.
 </details>
 
 ### Claude Code
@@ -460,47 +461,35 @@ notepad %APPDATA%\Claude\claude_desktop_config.json
 
 Restart Claude Desktop to activate.
 
-### Testing with ngrok (for server-side clients)
-
-For clients like OpenAI and LeChat that require public URLs:
-
-```bash
-# 1. Start HTTP server
-uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
-  --transport http \
-  --port 8080
-
-# 2. Expose with ngrok
-ngrok http 8080
-
-# 3. Use the ngrok URL in your client configuration
-```
+The standalone HTTP entrypoint is intentionally loopback-only and must not be
+published through ngrok or another tunnel. Use the authenticated hosted wrapper
+or the `operator-wandb` Helm deployment for a remotely accessible endpoint.
 
 </details>
 
 <details>
-<summary><strong>Option 3: Self-Hosted HTTP Server (Advanced)</strong></summary>
+<summary><strong>Option 3: Local HTTP Development</strong></summary>
 
-The public server supports both STDIO and Streamable HTTP transports. Operators
-running HTTP are responsible for TLS termination, authentication, scaling, and
-deployment-level limits. Do not expose a development server directly to the
-internet.
+The package exposes an unauthenticated Streamable HTTP transport only for local
+development. It requires an explicit acknowledgement and accepts loopback binds
+only. Use the authenticated hosted wrapper or Helm image for production HTTP.
 
 ### Running HTTP Server Locally
 
 For lightweight experimentation and testing, you can run the FastMCP HTTP transport directly:
 
 ```bash
-# Basic HTTP server
+# Basic loopback HTTP server
+export MCP_AUTH_DISABLED=true
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
   --transport http \
-  --host 0.0.0.0 \
+  --host 127.0.0.1 \
   --port 8080
 
 # With Weave tracing enabled
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
   --transport http \
-  --host 0.0.0.0 \
+  --host 127.0.0.1 \
   --port 8080 \
   --weave_entity your-entity \
   --weave_project mcp-server-logs
@@ -508,8 +497,8 @@ uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
 
 > 📖 For all available command line options, see the [Command Line Reference](#command-line-reference) in the More Information section.
 
-**Note**: HTTP clients must provide a W&B API key as a bearer token unless
-authentication is explicitly disabled for local development.
+**Note**: This entrypoint has no bearer-authentication middleware. It uses the
+single server-side `WANDB_API_KEY` and refuses non-loopback binds.
 </details>
 
 <details>
@@ -583,7 +572,7 @@ When running the server locally, you can customize its behavior with command lin
 | `WANDB_SILENT` | Set to `"True"` to suppress W&B SDK output (default: `true`) | No |
 | `WEAVE_SILENT` | Set to `"True"` to suppress Weave SDK output (default: `true`) | No |
 | `WANDB_DEBUG` | Set to `"true"` to enable detailed W&B logging | No |
-| `MCP_AUTH_DISABLED` | Disable HTTP authentication (development only) | No |
+| `MCP_AUTH_DISABLED` | Must be `true` to acknowledge unauthenticated loopback HTTP development | No |
 | `WANDB_MCP_PROXY_DOCS` | Enable/disable docs search proxy (default: `true`) | No |
 | `WANDB_MCP_ENABLE_WEAVE_TOOLS` | Enable Weave trace tools (default: `true`; set `false` for installs without a trace backend) | No |
 | `WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS` | Enable Weave Agents (OTel/GenAI) tools (default: `false`) | No |
@@ -596,7 +585,9 @@ When running the server locally, you can customize its behavior with command lin
 | `MCP_ADMISSION_WAIT_MS` | Maximum queue wait before returning retryable `server_busy` (default: `2000`) | No |
 | `MCP_TOOL_TIMEOUT_SECONDS` | Hosted public-tool execution deadline (default: `30`) | No |
 | `MCP_WANDB_REQUEST_TIMEOUT_SECONDS` | Timeout for public W&B SDK requests (default: `20`) | No |
+| `MCP_SYNC_TOOL_WORKERS` | Bounded worker count for synchronous public tools (profile-derived default, capped at `16`) | No |
 | `MCP_ANALYTICS_DISABLED` | Disable structured MCP analytics events | No |
+| `MCP_ANALYTICS_QUEUE_CAPACITY` | Maximum outstanding events per optional Segment or Datadog forwarder (default: `256`) | No |
 | `MCP_REQUEST_SUCCESS_SAMPLE_RATE` | Deterministic sample rate for successful HTTP request telemetry (default: `0.10`; failures and requests over two seconds are always retained). | No |
 | `MCP_LOG_PRIVACY_LEVEL` | Telemetry privacy level: `off`, `standard`, or `strict` (default: `off`) | No |
 | `MAX_RESPONSE_TOKENS` | Token budget for response truncation (default: `30000`) | No |
@@ -629,16 +620,11 @@ diagnostics as protocol messages.
 **HTTP Transport (for testing and development):**
 ```bash
 # Basic HTTP server on localhost:8080
+export MCP_AUTH_DISABLED=true
 uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
   --transport http \
   --host 127.0.0.1 \
   --port 8080
-
-# Bind to all interfaces with custom port
-uvx --from git+https://github.com/wandb/wandb-mcp-server wandb_mcp_server \
-  --transport http \
-  --host 0.0.0.0 \
-  --port 9090
 ```
 
 **With Weave Tracing (log MCP calls to W&B):**

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
+from wandb_mcp_server.config import MCP_REQUEST_SUCCESS_SAMPLE_RATE
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -44,7 +45,6 @@ _MAX_PARAM_KEYS = 20
 _MAX_PARAM_LIST_ITEMS = 20
 _MAX_USAGE_DIMENSIONS = 12
 _MAX_EVENT_BYTES = 4096
-_DEFAULT_REQUEST_SUCCESS_SAMPLE_RATE = 0.10
 _SLOW_REQUEST_MS = 2_000.0
 
 _configured_transport: Optional[str] = None
@@ -56,7 +56,7 @@ _USAGE_ENUM_VALUES: Dict[str, frozenset[str]] = {
     "kind": frozenset({"slack", "webhook"}),
     "mode": frozenset({"sampled", "scan", "full"}),
     "cost_class": frozenset({"light", "expensive", "heavy"}),
-    "admission_outcome": frozenset({"disabled", "admitted", "rejected"}),
+    "admission_outcome": frozenset({"disabled", "admitted", "rejected", "cancelled"}),
 }
 
 _USAGE_COUNTABLE_NUMBER_KEYS = frozenset(
@@ -451,6 +451,9 @@ def _compact_value(value: Any) -> Any:
 
 def _prepare_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """Compact and hard-bound an analytics event to the 4 KiB contract."""
+    from wandb_mcp_server.error_sanitizer import sanitize_sensitive_value
+
+    event = sanitize_sensitive_value(event)
     compacted = _compact_value(event)
     if not isinstance(compacted, dict):
         return {}
@@ -604,14 +607,7 @@ def _request_should_be_emitted(
         return False
     if status_code >= 400 or (duration_ms is not None and duration_ms >= _SLOW_REQUEST_MS):
         return True
-    raw_rate = os.environ.get(
-        "MCP_REQUEST_SUCCESS_SAMPLE_RATE",
-        str(_DEFAULT_REQUEST_SUCCESS_SAMPLE_RATE),
-    )
-    try:
-        rate = min(1.0, max(0.0, float(raw_rate)))
-    except ValueError:
-        rate = _DEFAULT_REQUEST_SUCCESS_SAMPLE_RATE
+    rate = MCP_REQUEST_SUCCESS_SAMPLE_RATE
     if rate <= 0:
         return False
     if rate >= 1:
@@ -818,8 +814,14 @@ class AnalyticsTracker:
         The Segment and Datadog forwarders are called after Cloud Logging
         emission; each is gated by its own env vars and fails silently.
         """
+        from wandb_mcp_server.error_sanitizer import sanitize_sensitive_text
+
         event = _prepare_event(event)
-        labels = {str(key): str(value) for key, value in labels.items() if value not in (None, "", {}, [])}
+        labels = {
+            sanitize_sensitive_text(key): sanitize_sensitive_text(value)
+            for key, value in labels.items()
+            if value not in (None, "", {}, [])
+        }
         missing = _REQUIRED_BASE_FIELDS - event.keys()
         if missing:
             logger.warning(f"Analytics event missing required fields: {missing}")

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -19,13 +19,18 @@ PII leakage into ops logs.
 
 import os
 import threading
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from wandb_mcp_server.bounded_worker import BoundedWorkerQueue
+from wandb_mcp_server.config import (
+    MCP_ANALYTICS_QUEUE_CAPACITY,
+    MCP_ANALYTICS_TEST_BUFFER_CAPACITY,
+)
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -328,7 +333,7 @@ class DatadogForwarder:
     Live POSTs run in a daemon thread so they never block the MCP request path.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, capture_payloads: bool = False) -> None:
         self.live = os.environ.get("MCP_DATADOG_FORWARD", "false").lower() == "true"
         self._api_key = _resolve_dd_api_key() if self.live else ""
         self._site = os.environ.get("DD_SITE", "datadoghq.com")
@@ -336,8 +341,11 @@ class DatadogForwarder:
         self._version = os.environ.get("DD_VERSION", "0.0.0")
         self._service = os.environ.get("DD_SERVICE", "wandb-mcp-server")
         self._intake_url = f"https://http-intake.logs.{self._site}/api/v2/logs"
-        self._forwarded_payloads: List[Dict[str, Any]] = []
-        self._executor: Optional[ThreadPoolExecutor] = None
+        self._forwarded_payloads: Deque[Dict[str, Any]] | None = (
+            deque(maxlen=MCP_ANALYTICS_TEST_BUFFER_CAPACITY) if capture_payloads else None
+        )
+        self._executor: Optional[BoundedWorkerQueue[Dict[str, Any]]] = None
+        self._executor_lock = threading.Lock()
         self._thread_local = threading.local()
 
         if self.live and not self._api_key:
@@ -377,10 +385,9 @@ class DatadogForwarder:
             dd_service=self._service,
         )
 
-        if self._executor is None:
-            self._executor = ThreadPoolExecutor(max_workers=2)
-        self._executor.submit(self._post, entry)
-        self._forwarded_payloads.append(entry)
+        self._get_executor().submit(entry)
+        if self._forwarded_payloads is not None:
+            self._forwarded_payloads.append(entry)
         return entry
 
     def _post(self, entry: Dict[str, Any]) -> None:
@@ -407,25 +414,54 @@ class DatadogForwarder:
 
     def get_forwarded_payloads(self) -> List[Dict[str, Any]]:
         """Return all payloads that were forwarded (for testing/inspection)."""
-        return list(self._forwarded_payloads)
+        return list(self._forwarded_payloads or ())
 
     def clear_forwarded_payloads(self) -> None:
         """Clear the forwarded payloads buffer."""
-        self._forwarded_payloads.clear()
+        if self._forwarded_payloads is not None:
+            self._forwarded_payloads.clear()
+
+    @property
+    def dropped_count(self) -> int:
+        """Number of forwarding events dropped because the queue was full."""
+        return self._executor.dropped_count if self._executor is not None else 0
+
+    def _get_executor(self) -> BoundedWorkerQueue[Dict[str, Any]]:
+        if self._executor is None:
+            with self._executor_lock:
+                if self._executor is None:
+                    self._executor = BoundedWorkerQueue(
+                        self._post,
+                        capacity=MCP_ANALYTICS_QUEUE_CAPACITY,
+                        worker_count=2,
+                        on_drop=lambda count: logger.warning(
+                            "Datadog forwarding queue full; dropped_count=%s",
+                            count,
+                        ),
+                        thread_name_prefix="mcp-datadog",
+                    )
+        return self._executor
 
 
 _datadog_forwarder: Optional[DatadogForwarder] = None
+_datadog_forwarder_lock = threading.Lock()
 
 
-def get_datadog_forwarder() -> DatadogForwarder:
+def get_datadog_forwarder(*, capture_payloads: bool = False) -> DatadogForwarder:
     """Get or create the global DatadogForwarder singleton."""
     global _datadog_forwarder
     if _datadog_forwarder is None:
-        _datadog_forwarder = DatadogForwarder()
+        with _datadog_forwarder_lock:
+            if _datadog_forwarder is None:
+                _datadog_forwarder = DatadogForwarder(capture_payloads=capture_payloads)
     return _datadog_forwarder
 
 
 def reset_datadog_forwarder() -> None:
     """Reset the global DatadogForwarder (for testing)."""
     global _datadog_forwarder
-    _datadog_forwarder = None
+    with _datadog_forwarder_lock:
+        previous = _datadog_forwarder
+        _datadog_forwarder = None
+    if previous is not None and previous._executor is not None:
+        previous._executor.shutdown(wait=False, cancel_futures=True)

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -25,14 +25,17 @@ uses ``WANDB_INTERNAL_BASE_URL`` when configured, otherwise ``WANDB_BASE_URL``.
 import logging
 import os
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from collections import deque
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional
 
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
+from wandb_mcp_server.bounded_worker import BoundedWorkerQueue
+from wandb_mcp_server.config import (
+    MCP_ANALYTICS_QUEUE_CAPACITY,
+    MCP_ANALYTICS_TEST_BUFFER_CAPACITY,
+)
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -130,18 +133,12 @@ def map_to_segment_track(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
 
 def _build_retry_session() -> requests.Session:
-    """Build a requests session with retry logic for Gorilla POSTs."""
-    session = requests.Session()
-    retry = Retry(
-        total=2,
-        backoff_factor=0.3,
-        status_forcelist=(429, 500, 502, 503, 504),
-        allowed_methods=["POST"],
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
+    """Build a single-attempt session for best-effort Gorilla analytics.
+
+    Analytics must not amplify W&B overloads. A failed event remains in the
+    canonical local log and is dropped after this one forwarding attempt.
+    """
+    return requests.Session()
 
 
 class SegmentForwarder:
@@ -168,8 +165,9 @@ class SegmentForwarder:
         ).rstrip("/")
         self._segment_logger = logging.getLogger("wandb_mcp_server.segment_dryrun")
         self._segment_logger.setLevel(logging.INFO)
-        self._forwarded_payloads: List[Dict[str, Any]] = []
-        self._executor: Optional[ThreadPoolExecutor] = None
+        self._forwarded_payloads: Deque[Dict[str, Any]] = deque(maxlen=MCP_ANALYTICS_TEST_BUFFER_CAPACITY)
+        self._executor: Optional[BoundedWorkerQueue[Dict[str, Any]]] = None
+        self._executor_lock = threading.Lock()
         self._thread_local = threading.local()
 
     @property
@@ -199,9 +197,8 @@ class SegmentForwarder:
             return payload
 
         if self.live:
-            if self._executor is None:
-                self._executor = ThreadPoolExecutor(max_workers=4)
-            self._executor.submit(self._post, payload)
+            executor = self._get_executor()
+            executor.submit(payload)
             return payload
 
         return None
@@ -236,21 +233,49 @@ class SegmentForwarder:
         """Clear the forwarded payloads buffer."""
         self._forwarded_payloads.clear()
 
+    @property
+    def dropped_count(self) -> int:
+        """Number of forwarding events dropped because the queue was full."""
+        return self._executor.dropped_count if self._executor is not None else 0
+
+    def _get_executor(self) -> BoundedWorkerQueue[Dict[str, Any]]:
+        if self._executor is None:
+            with self._executor_lock:
+                if self._executor is None:
+                    self._executor = BoundedWorkerQueue(
+                        self._post,
+                        capacity=MCP_ANALYTICS_QUEUE_CAPACITY,
+                        worker_count=4,
+                        on_drop=lambda count: logger.warning(
+                            "Segment forwarding queue full; dropped_count=%s",
+                            count,
+                        ),
+                        thread_name_prefix="mcp-segment",
+                    )
+        return self._executor
+
 
 # -- Singleton access -------------------------------------------------------
 
 _segment_forwarder: Optional[SegmentForwarder] = None
+_segment_forwarder_lock = threading.Lock()
 
 
 def get_segment_forwarder() -> SegmentForwarder:
     """Get or create the global SegmentForwarder singleton."""
     global _segment_forwarder
     if _segment_forwarder is None:
-        _segment_forwarder = SegmentForwarder()
+        with _segment_forwarder_lock:
+            if _segment_forwarder is None:
+                _segment_forwarder = SegmentForwarder()
     return _segment_forwarder
 
 
 def reset_segment_forwarder() -> None:
     """Reset the global SegmentForwarder (for testing)."""
     global _segment_forwarder
-    _segment_forwarder = None
+    with _segment_forwarder_lock:
+        previous = _segment_forwarder
+        _segment_forwarder = None
+    if previous is not None and previous._executor is not None:
+        previous._executor.shutdown(wait=False, cancel_futures=True)

--- a/src/wandb_mcp_server/api_client.py
+++ b/src/wandb_mcp_server/api_client.py
@@ -3,10 +3,13 @@
 from collections import OrderedDict
 from concurrent.futures import Future
 from contextvars import ContextVar
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import hashlib
+import re
 import threading
 import time
-from typing import Any, Optional
+from typing import Any, Iterator, Mapping, Optional
 
 import wandb
 
@@ -15,8 +18,116 @@ from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
 
+_DEFAULT_RETRY_AFTER_MS = 1_000
+_MAX_RETRY_AFTER_MS = 60_000
+_OVERLOAD_STATUS_RE = re.compile(r"\b(?:HTTP\s*)?(429|503)\b", re.IGNORECASE)
+_OVERLOAD_HINT_RE = re.compile(
+    r"\b(overload(?:ed)?|busy|capacity|rate.?limit|service unavailable|"
+    r"temporar(?:y|ily)|too many requests|try again)\b",
+    re.IGNORECASE,
+)
+
 # Context variable for storing the current request's API key
 api_key_context: ContextVar[Optional[str]] = ContextVar("wandb_api_key", default=None)
+
+
+class WandBServerBusy(RuntimeError):
+    """Retryable W&B backend saturation surfaced to the MCP boundary."""
+
+    def __init__(self, *, status_code: int, retry_after_ms: int) -> None:
+        self.status_code = status_code
+        self.retry_after_ms = retry_after_ms
+        super().__init__("The W&B service is busy; retry this tool call.")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "error": "server_busy",
+            "message": str(self),
+            "retryable": True,
+            "retry_after_ms": self.retry_after_ms,
+        }
+
+
+def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+        for nested in (
+            getattr(current, "exc", None),
+            getattr(current, "__cause__", None),
+            getattr(current, "__context__", None),
+        ):
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+
+
+def _retry_after_ms(value: object) -> int:
+    if value is None:
+        return _DEFAULT_RETRY_AFTER_MS
+    raw = str(value).strip()
+    try:
+        seconds = max(0.0, float(raw))
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(raw)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            seconds = max(0.0, (parsed - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError, OverflowError):
+            return _DEFAULT_RETRY_AFTER_MS
+    return min(_MAX_RETRY_AFTER_MS, max(_DEFAULT_RETRY_AFTER_MS, round(seconds * 1_000)))
+
+
+def wandb_server_busy_from_exception(exc: BaseException) -> WandBServerBusy | None:
+    """Classify nested W&B overload errors without retry amplification."""
+    if isinstance(exc, WandBServerBusy):
+        return exc
+
+    status_code: int | None = None
+    retry_after: object = None
+    messages: list[str] = []
+    for current in _exception_chain(exc):
+        if isinstance(current, WandBServerBusy):
+            return current
+        messages.append(str(current))
+        response = getattr(current, "response", None)
+        candidate = getattr(response, "status_code", None)
+        if candidate in {429, 503}:
+            status_code = int(candidate)
+            headers = getattr(response, "headers", None)
+            if isinstance(headers, Mapping):
+                retry_after = headers.get("Retry-After") or headers.get("retry-after")
+            for attr in ("reason", "text"):
+                response_text = getattr(response, attr, None)
+                if response_text:
+                    messages.append(str(response_text))
+            break
+
+    combined_message = " ".join(messages)
+    if status_code is None:
+        match = _OVERLOAD_STATUS_RE.search(combined_message)
+        if match:
+            status_code = int(match.group(1))
+
+    if status_code == 503 and not _OVERLOAD_HINT_RE.search(combined_message):
+        return None
+    if status_code not in {429, 503}:
+        return None
+    return WandBServerBusy(
+        status_code=status_code,
+        retry_after_ms=_retry_after_ms(retry_after),
+    )
+
+
+def raise_for_wandb_server_busy(exc: BaseException) -> None:
+    """Preserve overload backpressure across tool-specific fallback paths."""
+    if busy := wandb_server_busy_from_exception(exc):
+        raise busy from exc
 
 
 class WandBApiManager:

--- a/src/wandb_mcp_server/bounded_worker.py
+++ b/src/wandb_mcp_server/bounded_worker.py
@@ -1,0 +1,134 @@
+"""Small, non-blocking background worker queues for optional telemetry sinks."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+_MAX_DROP_COUNT = 2_147_483_647
+
+
+class BoundedWorkerQueue(Generic[T]):
+    """Run best-effort work without blocking or growing memory without bound.
+
+    Submissions are deliberately non-blocking. The caller remains responsible
+    for the canonical local log; this queue is only for optional forwarding.
+    """
+
+    def __init__(
+        self,
+        handler: Callable[[T], object],
+        *,
+        capacity: int,
+        worker_count: int,
+        on_drop: Callable[[int], object] | None = None,
+        thread_name_prefix: str = "mcp-background",
+    ) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        if worker_count <= 0:
+            raise ValueError("worker_count must be positive")
+        self._handler = handler
+        self._queue: queue.Queue[T] = queue.Queue(maxsize=capacity)
+        self._on_drop = on_drop
+        self._state_lock = threading.Lock()
+        self._stopping = False
+        self._dropped_count = 0
+        self._outstanding_count = 0
+        self._threads = [
+            threading.Thread(
+                target=self._run,
+                name=f"{thread_name_prefix}-{index}",
+                daemon=True,
+            )
+            for index in range(worker_count)
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    @property
+    def dropped_count(self) -> int:
+        with self._state_lock:
+            return self._dropped_count
+
+    @property
+    def pending_count(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def outstanding_count(self) -> int:
+        with self._state_lock:
+            return self._outstanding_count
+
+    @property
+    def capacity(self) -> int:
+        return self._queue.maxsize
+
+    def submit(self, item: T) -> bool:
+        """Queue an item immediately, or report a bounded drop."""
+        with self._state_lock:
+            if self._stopping:
+                return False
+            if self._outstanding_count >= self.capacity:
+                self._dropped_count = min(_MAX_DROP_COUNT, self._dropped_count + 1)
+                dropped_count = self._dropped_count
+            else:
+                self._outstanding_count += 1
+                self._queue.put_nowait(item)
+                return True
+        # Log at exponentially increasing intervals to avoid an outage
+        # turning the drop signal itself into a logging flood.
+        if self._on_drop is not None and (dropped_count == 1 or dropped_count & (dropped_count - 1) == 0):
+            self._on_drop(dropped_count)
+        return False
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        """Stop accepting work and optionally drain queued work.
+
+        ``cancel_futures`` mirrors ``ThreadPoolExecutor`` enough for existing
+        controlled-shutdown callers. Pending events are discarded only when
+        explicitly requested.
+        """
+        with self._state_lock:
+            self._stopping = True
+        if cancel_futures:
+            while True:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                else:
+                    with self._state_lock:
+                        self._outstanding_count -= 1
+                    self._queue.task_done()
+        if wait:
+            self._queue.join()
+            for thread in self._threads:
+                thread.join(timeout=5)
+
+    def _run(self) -> None:
+        while True:
+            with self._state_lock:
+                should_stop = self._stopping and self._queue.empty()
+            if should_stop:
+                return
+            try:
+                item = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                self._handler(item)
+            except Exception:
+                # Forwarder handlers log their own failures. Keep the worker
+                # alive so one unexpected sink error cannot strand the queue.
+                pass
+            finally:
+                with self._state_lock:
+                    self._outstanding_count -= 1
+                self._queue.task_done()
+
+
+__all__ = ["BoundedWorkerQueue"]

--- a/src/wandb_mcp_server/config.py
+++ b/src/wandb_mcp_server/config.py
@@ -2,19 +2,67 @@ import os
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
-    """Read a boolean environment variable."""
+    """Read a strict boolean environment variable."""
     value = os.getenv(name)
     if value is None:
         return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean")
 
 
-def _env_int(name: str, default: int) -> int:
-    """Read an integer environment variable."""
-    try:
-        return int(os.getenv(name, str(default)))
-    except (ValueError, TypeError):
+def _env_int(
+    name: str,
+    default: int,
+    *,
+    minimum: int = 1,
+    maximum: int | None = None,
+) -> int:
+    """Read and validate an integer environment variable.
+
+    Safety limits must fail closed. Silently replacing malformed production
+    configuration with a default can remove the intended bound without an
+    operator noticing.
+    """
+    raw = os.getenv(name)
+    if raw is None:
         return default
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        raise ValueError(f"{name} must be an integer") from None
+    if value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return value
+
+
+def _env_float(
+    name: str,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    """Read a finite, bounded floating-point environment variable."""
+    import math
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        raise ValueError(f"{name} must be a number") from None
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
 
 
 # Centralized configuration for base URLs used across the project.
@@ -36,17 +84,15 @@ WF_TRACE_SERVER_URL: str = (
 
 # Token budget for response truncation. When a query result exceeds this
 # budget, least-recent traces are dropped and a truncation note is appended.
-try:
-    MAX_RESPONSE_TOKENS: int = int(os.getenv("MAX_RESPONSE_TOKENS", "30000"))
-except (ValueError, TypeError):
-    MAX_RESPONSE_TOKENS: int = 30000
+MAX_RESPONSE_TOKENS: int = _env_int("MAX_RESPONSE_TOKENS", 30_000, maximum=100_000)
 
 # Memory guard for trace queries. Stops accumulating trace data when this
 # threshold is reached, returning a partial result instead of OOM-crashing.
-try:
-    MAX_ACCUMULATED_BYTES: int = int(os.getenv("MAX_ACCUMULATED_BYTES", str(1024 * 1024 * 1024)))
-except (ValueError, TypeError):
-    MAX_ACCUMULATED_BYTES: int = 1024 * 1024 * 1024  # 1GB
+MAX_ACCUMULATED_BYTES: int = _env_int(
+    "MAX_ACCUMULATED_BYTES",
+    1024 * 1024 * 1024,
+    maximum=1024 * 1024 * 1024,
+)
 
 # Workload profiles keep the common deployment choices simple while retaining
 # the existing per-setting environment overrides for advanced operators.
@@ -99,8 +145,12 @@ _PROFILE_DEFAULTS: dict[str, dict[str, int]] = {
 }
 _profile_defaults = _PROFILE_DEFAULTS[MCP_WORKLOAD_PROFILE]
 
-MCP_TOOL_TIMEOUT_SECONDS: int = _env_int("MCP_TOOL_TIMEOUT_SECONDS", 30)
-MCP_WANDB_REQUEST_TIMEOUT_SECONDS: int = _env_int("MCP_WANDB_REQUEST_TIMEOUT_SECONDS", 20)
+MCP_TOOL_TIMEOUT_SECONDS: int = _env_int("MCP_TOOL_TIMEOUT_SECONDS", 30, maximum=300)
+MCP_WANDB_REQUEST_TIMEOUT_SECONDS: int = _env_int(
+    "MCP_WANDB_REQUEST_TIMEOUT_SECONDS",
+    20,
+    maximum=120,
+)
 MCP_ADMISSION_CONTROL_ENABLED: bool = _env_bool(
     "MCP_ADMISSION_CONTROL_ENABLED",
     MCP_WORKLOAD_PROFILE != "local",
@@ -108,56 +158,128 @@ MCP_ADMISSION_CONTROL_ENABLED: bool = _env_bool(
 MCP_ADMISSION_ACTOR_CAPACITY: int = _env_int(
     "MCP_ADMISSION_ACTOR_CAPACITY",
     _profile_defaults["actor_capacity"],
+    maximum=64,
 )
 MCP_ADMISSION_PROCESS_CAPACITY: int = _env_int(
     "MCP_ADMISSION_PROCESS_CAPACITY",
     _profile_defaults["process_capacity"],
+    maximum=64,
 )
-MCP_ADMISSION_WAIT_MS: int = _env_int("MCP_ADMISSION_WAIT_MS", 2000)
-MCP_MAX_QUERY_LIMIT: int = _env_int("MCP_MAX_QUERY_LIMIT", _profile_defaults["collection_items"])
+MCP_ADMISSION_WAIT_MS: int = _env_int(
+    "MCP_ADMISSION_WAIT_MS",
+    2000,
+    minimum=0,
+    maximum=30_000,
+)
+MCP_MAX_QUERY_LIMIT: int = _env_int(
+    "MCP_MAX_QUERY_LIMIT",
+    _profile_defaults["collection_items"],
+    maximum=10_000,
+)
 MCP_MAX_FULL_TRACE_LIMIT: int = _env_int(
     "MCP_MAX_FULL_TRACE_LIMIT",
     25 if MCP_WORKLOAD_PROFILE == "shared" else _profile_defaults["collection_items"],
+    maximum=1_000,
 )
-MCP_MAX_HISTORY_SAMPLES: int = _env_int("MCP_MAX_HISTORY_SAMPLES", _profile_defaults["history_samples"])
-MCP_MAX_HISTORY_KEYS: int = _env_int("MCP_MAX_HISTORY_KEYS", _profile_defaults["history_keys"])
+MCP_MAX_HISTORY_SAMPLES: int = _env_int(
+    "MCP_MAX_HISTORY_SAMPLES",
+    _profile_defaults["history_samples"],
+    maximum=10_000,
+)
+MCP_MAX_HISTORY_KEYS: int = _env_int(
+    "MCP_MAX_HISTORY_KEYS",
+    _profile_defaults["history_keys"],
+    maximum=500,
+)
 MCP_MAX_HISTORY_RANGE_STEPS: int = _env_int(
     "MCP_MAX_HISTORY_RANGE_STEPS",
     _profile_defaults["history_range_steps"],
+    maximum=1_000_000,
 )
 MCP_MAX_WANDB_QUERY_ITEMS: int = _env_int(
     "MCP_MAX_WANDB_QUERY_ITEMS",
     _profile_defaults["collection_items"],
+    maximum=10_000,
 )
 MCP_MAX_FULL_DETAIL_ITEMS: int = _env_int(
     "MCP_MAX_FULL_DETAIL_ITEMS",
     _profile_defaults["full_detail_items"],
+    maximum=100,
 )
 MCP_MAX_PROJECT_FIELDS: int = _env_int(
     "MCP_MAX_PROJECT_FIELDS",
     _profile_defaults["project_fields"],
+    maximum=10_000,
 )
 MCP_MAX_PROBE_RUNS: int = _env_int(
     "MCP_MAX_PROBE_RUNS",
     _profile_defaults["probe_runs"],
+    maximum=100,
 )
 MCP_MAX_EVALUATION_ROWS: int = _env_int(
     "MCP_MAX_EVALUATION_ROWS",
     _profile_defaults["evaluation_rows"],
+    maximum=10_000,
 )
 MCP_MAX_SCHEMA_SAMPLE_ROWS: int = _env_int(
     "MCP_MAX_SCHEMA_SAMPLE_ROWS",
     _profile_defaults["schema_rows"],
+    maximum=1_000,
 )
 MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE: int = _env_int(
     "MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE",
     50 if MCP_WORKLOAD_PROFILE == "shared" else 200,
+    maximum=500,
 )
-MCP_MAX_GQL_ITEMS: int = _env_int("MCP_MAX_GQL_ITEMS", _profile_defaults["collection_items"])
+MCP_MAX_GQL_ITEMS: int = _env_int(
+    "MCP_MAX_GQL_ITEMS",
+    _profile_defaults["collection_items"],
+    maximum=1_000,
+)
 MCP_MAX_GQL_ITEMS_PER_PAGE: int = _env_int(
     "MCP_MAX_GQL_ITEMS_PER_PAGE",
     50 if MCP_WORKLOAD_PROFILE == "shared" else 200,
+    maximum=200,
 )
+MCP_SYNC_TOOL_WORKERS: int = _env_int(
+    "MCP_SYNC_TOOL_WORKERS",
+    min(MCP_ADMISSION_PROCESS_CAPACITY, 16),
+    maximum=16,
+)
+MCP_COUNT_TOOL_WORKERS: int = _env_int(
+    "MCP_COUNT_TOOL_WORKERS",
+    min(MCP_ADMISSION_PROCESS_CAPACITY, 8),
+    maximum=16,
+)
+MCP_ANALYTICS_QUEUE_CAPACITY: int = _env_int(
+    "MCP_ANALYTICS_QUEUE_CAPACITY",
+    256,
+    maximum=256,
+)
+MCP_ANALYTICS_TEST_BUFFER_CAPACITY: int = _env_int(
+    "MCP_ANALYTICS_TEST_BUFFER_CAPACITY",
+    100,
+    maximum=1_000,
+)
+MCP_REQUEST_SUCCESS_SAMPLE_RATE: float = _env_float(
+    "MCP_REQUEST_SUCCESS_SAMPLE_RATE",
+    0.1,
+    minimum=0.0,
+    maximum=1.0,
+)
+SESSION_TTL_SECONDS: int = _env_int("SESSION_TTL_SECONDS", 3600, maximum=86_400)
+MAX_SESSIONS_PER_KEY: int = _env_int("MAX_SESSIONS_PER_KEY", 10, maximum=1_000)
+
+if MCP_ADMISSION_ACTOR_CAPACITY > MCP_ADMISSION_PROCESS_CAPACITY:
+    raise ValueError("MCP_ADMISSION_ACTOR_CAPACITY must not exceed MCP_ADMISSION_PROCESS_CAPACITY")
+if MCP_ADMISSION_CONTROL_ENABLED and MCP_ADMISSION_ACTOR_CAPACITY < 4:
+    raise ValueError("MCP_ADMISSION_ACTOR_CAPACITY must be at least 4 when admission control is enabled")
+if MCP_ADMISSION_CONTROL_ENABLED and MCP_ADMISSION_PROCESS_CAPACITY < 4:
+    raise ValueError("MCP_ADMISSION_PROCESS_CAPACITY must be at least 4 when admission control is enabled")
+if MCP_SYNC_TOOL_WORKERS > MCP_ADMISSION_PROCESS_CAPACITY:
+    raise ValueError("MCP_SYNC_TOOL_WORKERS must not exceed MCP_ADMISSION_PROCESS_CAPACITY")
+if MCP_COUNT_TOOL_WORKERS > MCP_ADMISSION_PROCESS_CAPACITY:
+    raise ValueError("MCP_COUNT_TOOL_WORKERS must not exceed MCP_ADMISSION_PROCESS_CAPACITY")
 WANDB_MCP_ENABLE_WEAVE_TOOLS: bool = _env_bool("WANDB_MCP_ENABLE_WEAVE_TOOLS", True)
 WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS: bool = _env_bool(
     "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
@@ -165,6 +287,10 @@ WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS: bool = _env_bool(
 )
 WANDB_MCP_READ_ONLY: bool = _env_bool("WANDB_MCP_READ_ONLY", False)
 WANDB_MCP_ENABLE_RAW_GRAPHQL: bool = _env_bool("WANDB_MCP_ENABLE_RAW_GRAPHQL", False)
+MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS: bool = _env_bool(
+    "MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS",
+    False,
+)
 COST_SORT_FIELDS: frozenset[str] = frozenset({"total_cost", "completion_cost", "prompt_cost"})
 
 

--- a/src/wandb_mcp_server/error_sanitizer.py
+++ b/src/wandb_mcp_server/error_sanitizer.py
@@ -1,0 +1,189 @@
+"""Redact infrastructure and credentials from externally visible error data."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import urlparse
+
+_REDACTED_INTERNAL = "<internal W&B API>"
+_REDACTED_SECRET = "<redacted>"
+MAX_EXTERNAL_ERROR_CHARS = 4_096
+_KUBERNETES_URL_RE = re.compile(
+    r"(?i)\bhttps?://(?:[^/\s@]+@)?"
+    r"[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?\.svc(?:\.cluster\.local)?"
+    r"(?::\d{1,5})?(?:/[^\s\"'<>]*)?"
+)
+_KUBERNETES_HOST_RE = re.compile(
+    r"(?i)\b[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?"
+    r"\.svc(?:\.cluster\.local)?(?::\d{1,5})?\b"
+)
+_URL_CREDENTIAL_RE = re.compile(r"(?i)\b(https?://)[^/\s:@]+:[^/\s@]+@")
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+_BASIC_AUTH_RE = re.compile(r"(?i)\bBasic\s+[A-Za-z0-9+/=_-]+")
+_NAMED_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|password|secret|token)"
+    r"(\s*[=:]\s*[\"']?)([^\s,;}\"']+)"
+)
+
+
+def _configured_secrets() -> tuple[str, ...]:
+    values: set[str] = set()
+    for name, value in os.environ.items():
+        upper_name = name.upper()
+        if (
+            "API_KEY" in upper_name
+            or upper_name.endswith("_TOKEN")
+            or upper_name.endswith("_SECRET")
+            or upper_name.endswith("_PASSWORD")
+        ) and len(value) >= 8:
+            values.add(value)
+    # Hosted authentication stores the customer W&B key in a request-local
+    # ContextVar rather than WANDB_API_KEY. Resolve it lazily to avoid an import
+    # cycle during api_client initialization, and redact it if an upstream SDK
+    # exception happens to echo the credential.
+    try:
+        from wandb_mcp_server.api_client import WandBApiManager
+
+        request_api_key = WandBApiManager.get_api_key()
+    except (ImportError, RuntimeError, ValueError):
+        request_api_key = None
+    if request_api_key and len(request_api_key) >= 8:
+        values.add(request_api_key)
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def sanitize_sensitive_text(
+    value: object,
+    *,
+    max_chars: int | None = None,
+) -> str:
+    """Return text with known secrets and internal service addresses removed."""
+    text = str(value)
+    internal_url = (os.environ.get("WANDB_INTERNAL_BASE_URL") or "").rstrip("/")
+    if internal_url:
+        text = text.replace(internal_url, _REDACTED_INTERNAL)
+        parsed = urlparse(internal_url if "://" in internal_url else f"http://{internal_url}")
+        if parsed.netloc:
+            text = text.replace(parsed.netloc, _REDACTED_INTERNAL)
+        if parsed.hostname:
+            text = text.replace(parsed.hostname, _REDACTED_INTERNAL)
+    text = _KUBERNETES_URL_RE.sub(_REDACTED_INTERNAL, text)
+    text = _KUBERNETES_HOST_RE.sub(_REDACTED_INTERNAL, text)
+    text = _URL_CREDENTIAL_RE.sub(r"\1<redacted>@", text)
+    text = _BEARER_RE.sub(f"Bearer {_REDACTED_SECRET}", text)
+    text = _BASIC_AUTH_RE.sub(f"Basic {_REDACTED_SECRET}", text)
+    text = _NAMED_SECRET_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}{_REDACTED_SECRET}",
+        text,
+    )
+    for secret in _configured_secrets():
+        text = text.replace(secret, _REDACTED_SECRET)
+    if max_chars is not None and len(text) > max_chars:
+        omitted = len(text) - max_chars
+        text = f"{text[:max_chars]}… <truncated {omitted} chars>"
+    return text
+
+
+def sanitize_sensitive_value(
+    value: Any,
+    *,
+    _seen: set[int] | None = None,
+    _depth: int = 0,
+    _error_context: bool = False,
+) -> Any:
+    """Recursively sanitize common MCP result and telemetry value shapes."""
+    if isinstance(value, str):
+        return sanitize_sensitive_text(
+            value,
+            max_chars=MAX_EXTERNAL_ERROR_CHARS if _error_context else None,
+        )
+    if isinstance(value, (bytes, bytearray)):
+        decoded = bytes(value).decode("utf-8", errors="replace")
+        return sanitize_sensitive_text(
+            decoded,
+            max_chars=MAX_EXTERNAL_ERROR_CHARS if _error_context else None,
+        )
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if _depth >= 12:
+        return "<value omitted>"
+
+    seen = _seen if _seen is not None else set()
+    identity = id(value)
+    if identity in seen:
+        return "<cyclic value>"
+    seen.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            result = {}
+            for key, child in value.items():
+                sanitized_key = sanitize_sensitive_text(key)
+                result[sanitized_key] = sanitize_sensitive_value(
+                    child,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                    _error_context=(
+                        _error_context or sanitized_key.lower() in {"error", "message", "detail", "reason", "exception"}
+                    ),
+                )
+            return result
+        if isinstance(value, tuple):
+            return tuple(
+                sanitize_sensitive_value(
+                    child,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                    _error_context=_error_context,
+                )
+                for child in value
+            )
+        if isinstance(value, list):
+            return [
+                sanitize_sensitive_value(
+                    child,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                    _error_context=_error_context,
+                )
+                for child in value
+            ]
+        if isinstance(value, Sequence):
+            return [
+                sanitize_sensitive_value(
+                    child,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                    _error_context=_error_context,
+                )
+                for child in value
+            ]
+
+        model_copy = getattr(value, "model_copy", None)
+        model_fields = getattr(type(value), "model_fields", None)
+        if callable(model_copy) and isinstance(model_fields, Mapping):
+            updates = {
+                field_name: sanitize_sensitive_value(
+                    getattr(value, field_name),
+                    _seen=seen,
+                    _depth=_depth + 1,
+                    _error_context=(
+                        _error_context or field_name.lower() in {"error", "message", "detail", "reason", "exception"}
+                    ),
+                )
+                for field_name in model_fields
+                if hasattr(value, field_name)
+            }
+            return model_copy(update=updates)
+        return value
+    finally:
+        seen.discard(identity)
+
+
+__all__ = [
+    "MAX_EXTERNAL_ERROR_CHARS",
+    "sanitize_sensitive_text",
+    "sanitize_sensitive_value",
+]

--- a/src/wandb_mcp_server/instrumented_server.py
+++ b/src/wandb_mcp_server/instrumented_server.py
@@ -8,11 +8,15 @@ import inspect
 import json
 import time
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar, copy_context
+from dataclasses import dataclass, field
 from typing import Any
 
 import anyio
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import TextContent
 
 from wandb_mcp_server.admission import (
     AdmissionRejected,
@@ -20,13 +24,20 @@ from wandb_mcp_server.admission import (
     current_tool_deadline,
     tool_cost,
 )
+from wandb_mcp_server.api_client import wandb_server_busy_from_exception
 from wandb_mcp_server.config import (
     MCP_ADMISSION_ACTOR_CAPACITY,
     MCP_ADMISSION_CONTROL_ENABLED,
     MCP_ADMISSION_PROCESS_CAPACITY,
     MCP_ADMISSION_WAIT_MS,
     MCP_HOSTED_MODE,
+    MCP_SYNC_TOOL_WORKERS,
     MCP_TOOL_TIMEOUT_SECONDS,
+)
+from wandb_mcp_server.error_sanitizer import (
+    MAX_EXTERNAL_ERROR_CHARS,
+    sanitize_sensitive_text,
+    sanitize_sensitive_value,
 )
 from wandb_mcp_server.harness import (
     HarnessContext,
@@ -36,6 +47,54 @@ from wandb_mcp_server.harness import (
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
+_NON_IDEMPOTENT_WRITE_TOOLS = frozenset({"create_wandb_report_tool", "log_analysis_to_wandb"})
+
+
+@dataclass
+class _SyncCallState:
+    futures: list[asyncio.Future[Any]] = field(default_factory=list)
+
+
+_current_sync_call_state: ContextVar[_SyncCallState | None] = ContextVar(
+    "mcp_sync_call_state",
+    default=None,
+)
+_current_sync_executor: ContextVar[ThreadPoolExecutor | None] = ContextVar(
+    "mcp_sync_executor",
+    default=None,
+)
+
+
+def register_current_sync_future(future: asyncio.Future[Any]) -> None:
+    """Associate externally scheduled sync work with the active tool call.
+
+    A small number of async tools schedule blocking library work themselves.
+    Registering those futures here lets admission retain the physical permit
+    after protocol cancellation or timeout, just like ordinary synchronous
+    tools dispatched by :meth:`add_tool`.
+    """
+    state = _current_sync_call_state.get()
+    if state is not None:
+        state.futures.append(future)
+
+
+async def run_sync_in_current_tool(call: Any) -> Any:
+    """Run blocking work in the active server's bounded executor.
+
+    Async public tools use this for isolated blocking SDK sections. The
+    resulting future participates in the same timeout/cancellation lease
+    tracking as tools that are synchronous end-to-end.
+    """
+    executor = _current_sync_executor.get()
+    if executor is None:
+        # Local stdio and direct library callers retain the historical AnyIO
+        # worker behavior. Hosted/admission-controlled dispatch installs the
+        # bounded executor so timed-out work cannot be replaced indefinitely.
+        return await anyio.to_thread.run_sync(call, abandon_on_cancel=False)
+    context = copy_context()
+    future = asyncio.get_running_loop().run_in_executor(executor, context.run, call)
+    register_current_sync_future(future)
+    return await asyncio.shield(future)
 
 
 def _error_from_mapping(value: dict[str, Any]) -> str | None:
@@ -94,11 +153,58 @@ def structured_result_error(result: Any) -> str | None:
     return None
 
 
+def _structured_error_code(result: Any) -> str:
+    """Preserve a bounded public error code when replacing oversized details."""
+    if isinstance(result, dict):
+        error = result.get("error")
+        if isinstance(error, str) and 0 < len(error) <= 64:
+            return error if error.replace("_", "").replace("-", "").isalnum() else "upstream_error"
+        if isinstance(error, dict):
+            code = error.get("code") or error.get("type")
+            if isinstance(code, str) and 0 < len(code) <= 64:
+                return code if code.replace("_", "").replace("-", "").isalnum() else "upstream_error"
+        nested = result.get("result")
+        if nested is not None and nested is not result:
+            return _structured_error_code(nested)
+    structured_content = getattr(result, "structuredContent", None)
+    if structured_content is None:
+        structured_content = getattr(result, "structured_content", None)
+    if structured_content is not None and structured_content is not result:
+        return _structured_error_code(structured_content)
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+        for child in result:
+            code = _structured_error_code(child)
+            if code != "upstream_error":
+                return code
+    return "upstream_error"
+
+
+def _bounded_error_result(result: Any) -> Any:
+    """Replace an oversized structured error while retaining FastMCP's shape."""
+    if len(str(result)) <= MAX_EXTERNAL_ERROR_CHARS:
+        return result
+    payload = {
+        "error": _structured_error_code(result),
+        "message": "Upstream error details exceeded the safe response limit.",
+        "details_truncated": True,
+    }
+    return (
+        [TextContent(type="text", text=json.dumps(payload, separators=(",", ":")))],
+        payload,
+    )
+
+
 class InstrumentedFastMCP(FastMCP):
     """FastMCP server with bounded dispatch and one event per public tool call."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self._bounded_dispatch_enabled = MCP_HOSTED_MODE or MCP_ADMISSION_CONTROL_ENABLED
+        self._sync_executor = ThreadPoolExecutor(
+            max_workers=MCP_SYNC_TOOL_WORKERS,
+            thread_name_prefix="mcp-tool",
+        )
+        self._deferred_release_tasks: set[asyncio.Task[None]] = set()
         self._admission_controller = (
             WeightedAdmissionController(
                 actor_capacity=MCP_ADMISSION_ACTOR_CAPACITY,
@@ -117,7 +223,18 @@ class InstrumentedFastMCP(FastMCP):
             @functools.wraps(fn)
             async def _threaded_tool(*fn_args: Any, **fn_kwargs: Any) -> Any:
                 call = functools.partial(fn, *fn_args, **fn_kwargs)
-                return await anyio.to_thread.run_sync(call, abandon_on_cancel=False)
+                if not self._bounded_dispatch_enabled:
+                    return await anyio.to_thread.run_sync(call, abandon_on_cancel=False)
+                context = copy_context()
+                future = asyncio.get_running_loop().run_in_executor(
+                    self._sync_executor,
+                    context.run,
+                    call,
+                )
+                register_current_sync_future(future)
+                # The executor future must survive a protocol timeout. Its
+                # admission lease is released only when physical work ends.
+                return await asyncio.shield(future)
 
             registered_fn = _threaded_tool
         super().add_tool(registered_fn, *args, **kwargs)
@@ -141,6 +258,11 @@ class InstrumentedFastMCP(FastMCP):
 
     async def call_tool(self, name: str, arguments: dict[str, Any]):
         harness_token = current_harness_context.set(self._tool_harness_context())
+        sync_state = _SyncCallState()
+        sync_state_token = _current_sync_call_state.set(sync_state)
+        sync_executor_token = _current_sync_executor.set(
+            self._sync_executor if self._bounded_dispatch_enabled else None
+        )
         started = time.monotonic()
         success = True
         error: str | None = None
@@ -172,6 +294,12 @@ class InstrumentedFastMCP(FastMCP):
                             }
                         )
                     ) from exc
+                except asyncio.CancelledError:
+                    queue_ms = round((time.monotonic() - admission_started) * 1000, 2)
+                    admission_outcome = "cancelled"
+                    success = False
+                    error = "cancelled: tool admission wait was cancelled"
+                    raise
                 queue_ms = lease.queue_ms
                 admission_outcome = "admitted"
 
@@ -186,35 +314,96 @@ class InstrumentedFastMCP(FastMCP):
                     result = await super().call_tool(name, arguments)
             except TimeoutError as exc:
                 success = False
-                error = "tool_timeout: MCP tool execution deadline exceeded"
+                is_write = name in _NON_IDEMPOTENT_WRITE_TOOLS
+                error = (
+                    "outcome_unknown: write timed out before completion was confirmed"
+                    if is_write
+                    else "tool_timeout: MCP tool execution deadline exceeded"
+                )
                 raise ToolError(
                     json.dumps(
-                        {
-                            "error": "tool_timeout",
-                            "message": "The MCP tool exceeded its execution deadline.",
-                            "retryable": True,
-                            "retry_after_ms": 1000,
-                        }
+                        (
+                            {
+                                "error": "outcome_unknown",
+                                "message": (
+                                    "The write may have completed after the MCP deadline. "
+                                    "Verify W&B state before deciding whether to retry."
+                                ),
+                                "retryable": False,
+                            }
+                            if is_write
+                            else {
+                                "error": "tool_timeout",
+                                "message": "The MCP tool exceeded its execution deadline.",
+                                "retryable": True,
+                                "retry_after_ms": 1000,
+                            }
+                        )
                     )
                 ) from exc
             except BaseException as exc:
+                if busy := wandb_server_busy_from_exception(exc):
+                    success = False
+                    if name in _NON_IDEMPOTENT_WRITE_TOOLS:
+                        error = f"outcome_unknown: W&B did not confirm the write result (HTTP {busy.status_code})"
+                        raise ToolError(
+                            json.dumps(
+                                {
+                                    "error": "outcome_unknown",
+                                    "message": (
+                                        "W&B did not confirm whether the write completed. "
+                                        "Verify W&B state before deciding whether to retry."
+                                    ),
+                                    "retryable": False,
+                                    "upstream_status": busy.status_code,
+                                }
+                            )
+                        ) from exc
+                    error = f"server_busy: upstream HTTP {busy.status_code}"
+                    raise ToolError(json.dumps(busy.as_dict())) from exc
                 if success:
                     success = False
-                    error = f"{type(exc).__name__}: {str(exc)[:500]}"
+                    error = sanitize_sensitive_text(f"{type(exc).__name__}: {str(exc)[:500]}")
+                sanitized_message = sanitize_sensitive_text(
+                    str(exc),
+                    max_chars=MAX_EXTERNAL_ERROR_CHARS,
+                )
+                if sanitized_message != str(exc):
+                    # Do not let FastMCP serialize the original exception when
+                    # it contains request credentials or an internal service
+                    # address. Safe exceptions retain their original type.
+                    raise ToolError(sanitized_message) from exc
                 raise
             structured_error = structured_result_error(result)
+            result = sanitize_sensitive_value(
+                result,
+                _error_context=structured_error is not None,
+            )
             if structured_error:
+                result = _bounded_error_result(result)
                 success = False
-                error = structured_error
+                error = structured_result_error(result) or "ToolError: upstream error"
             return result
         finally:
             if deadline_token is not None:
                 current_tool_deadline.reset(deadline_token)
             if lease is not None:
-                try:
-                    await lease.release()
-                except Exception as release_error:
-                    logger.error("Tool admission release failed for %s: %s", name, release_error)
+                pending_workers = [future for future in sync_state.futures if not future.done()]
+                if pending_workers:
+                    self._defer_lease_release(
+                        lease=lease,
+                        worker_futures=pending_workers,
+                        tool_name=name,
+                    )
+                else:
+                    try:
+                        await lease.release()
+                    except Exception as release_error:
+                        logger.error(
+                            "Tool admission release failed for %s: %s",
+                            name,
+                            release_error,
+                        )
             duration_ms = round((time.monotonic() - started) * 1000, 2)
             try:
                 from wandb_mcp_server.analytics import get_analytics_tracker
@@ -238,7 +427,58 @@ class InstrumentedFastMCP(FastMCP):
             except Exception as analytics_error:
                 logger.debug("Tool analytics failed for %s: %s", name, analytics_error)
             finally:
+                _current_sync_executor.reset(sync_executor_token)
+                _current_sync_call_state.reset(sync_state_token)
                 current_harness_context.reset(harness_token)
+
+    def _defer_lease_release(
+        self,
+        *,
+        lease: Any,
+        worker_futures: list[asyncio.Future[Any]],
+        tool_name: str,
+    ) -> None:
+        """Keep the admission lease until timed-out synchronous work is done."""
+
+        async def _release_after_workers() -> None:
+            await asyncio.gather(
+                *(asyncio.shield(future) for future in worker_futures),
+                return_exceptions=True,
+            )
+            try:
+                await lease.release()
+            except Exception as release_error:
+                logger.error(
+                    "Deferred tool admission release failed for %s: %s",
+                    tool_name,
+                    release_error,
+                )
+
+        task = asyncio.create_task(_release_after_workers())
+        self._deferred_release_tasks.add(task)
+        task.add_done_callback(self._deferred_release_tasks.discard)
+
+    def shutdown_sync_executor(self) -> None:
+        """Stop accepting sync work without waiting on an uncooperative SDK call."""
+        self._sync_executor.shutdown(wait=False, cancel_futures=True)
+
+    async def run_stdio_async(self) -> None:
+        try:
+            await super().run_stdio_async()
+        finally:
+            self.shutdown_sync_executor()
+
+    async def run_streamable_http_async(self) -> None:
+        try:
+            await super().run_streamable_http_async()
+        finally:
+            self.shutdown_sync_executor()
+
+    async def run_sse_async(self, mount_path: str | None = None) -> None:
+        try:
+            await super().run_sse_async(mount_path)
+        finally:
+            self.shutdown_sync_executor()
 
     @staticmethod
     def _analytics_actor_id() -> str:

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, get_args
 from pydantic import PositiveInt
 from wandb.automations import EventType, SlackIntegration, WebhookIntegration
 
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 
@@ -213,6 +213,7 @@ def list_automations(
             return json.dumps(result)
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_automations: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
@@ -331,6 +332,7 @@ def list_integrations(
             return json.dumps(result)
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_integrations: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/compare_runs.py
+++ b/src/wandb_mcp_server/mcp_tools/compare_runs.py
@@ -5,7 +5,7 @@ import math
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.admission import ToolDeadlineExceeded
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_HISTORY_KEYS, MCP_MAX_HISTORY_SAMPLES
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -231,10 +231,12 @@ def compare_runs(
         except Exception as selective_error:
             if isinstance(selective_error, ToolDeadlineExceeded):
                 raise
+            raise_for_wandb_server_busy(selective_error)
             try:
                 run_a = api.run(f"{path}/{run_id_a}")
                 run_b = api.run(f"{path}/{run_id_b}")
             except Exception as e:
+                raise_for_wandb_server_busy(e)
                 ctx.mark_error(f"{type(e).__name__}: {e}")
                 return json.dumps({"error": "run_not_found", "message": str(e)[:500]})
 
@@ -358,6 +360,7 @@ def compare_runs(
                     ],
                 }
             except Exception as e:
+                raise_for_wandb_server_busy(e)
                 result["history_comparison"] = {"error": str(e)[:300], "sampled": True}
 
         return json.dumps(result, default=str)

--- a/src/wandb_mcp_server/mcp_tools/count_traces.py
+++ b/src/wandb_mcp_server/mcp_tools/count_traces.py
@@ -4,8 +4,9 @@ from typing import Any, Dict
 
 import requests
 
+from wandb_mcp_server.config import MCP_WANDB_REQUEST_TIMEOUT_SECONDS
 from wandb_mcp_server.weave_api.query_builder import QueryBuilder
-from wandb_mcp_server.mcp_tools.tools_utils import get_retry_session
+from wandb_mcp_server.mcp_tools.tools_utils import get_no_retry_session
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
@@ -78,7 +79,7 @@ def count_traces(
     entity_name: str,
     project_name: str,
     filters: dict = None,
-    request_timeout: int = 30,
+    request_timeout: int = MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
 ) -> int:
     """Count the number of traces matching the given filters.
 
@@ -239,7 +240,10 @@ def count_traces(
             "Authorization": f"Basic {auth_token}",
         }
 
-        session = get_retry_session()
+        # Count is part of the same functional MCP call as the surrounding
+        # query. Do not multiply load when Weave is already rate-limited or
+        # overloaded; the MCP client receives retryable backpressure instead.
+        session = get_no_retry_session()
 
         logger.debug(f"Posting to {url} with body: {json.dumps(request_body)}")
 
@@ -257,18 +261,17 @@ def count_traces(
                 if "40 characters" in response.text:
                     logger.error("W&B API key does not meet length requirements.")
                 logger.debug(f"Failed request body: {json.dumps(request_body)}")
-                raise Exception(error_msg)
+                # Preserve status and Retry-After for the shared overload
+                # classifier at the public MCP dispatch boundary.
+                raise requests.HTTPError(error_msg, response=response)
 
             response_json = response.json()
             return response_json.get("count", 0)
 
         except requests.exceptions.RequestException as e:
             logger.error(f"HTTP Request failed for project {project_id}: {e}")
-            if isinstance(e, requests.exceptions.RetryError):
-                if e.__cause__ and hasattr(e.__cause__, "reason") and e.__cause__.reason:
-                    logger.error(f"Specific reason for retry exhaustion: {e.__cause__.reason}")
             logger.debug(f"Failed request body during exception for {project_id}: {json.dumps(request_body)}")
-            raise Exception(f"Failed to query Weave trace count for {project_id} due to network error: {e}")
+            raise Exception(f"Failed to query Weave trace count for {project_id} due to network error: {e}") from e
         except json.JSONDecodeError as e:
             logger.error(
                 f"Failed to decode JSON response for {project_id}: {e}. Response text: {response.text if 'response' in locals() else 'N/A'}"

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -12,6 +12,7 @@ import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.reports.v2.interface as wr_interface
 
 import wandb
+from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.config import MCP_WANDB_REQUEST_TIMEOUT_SECONDS, WANDB_API_BASE_URL
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
@@ -333,8 +334,9 @@ def create_report(
             return {"url": publicize_wandb_url(report.url)}
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error creating report: {e}")
-            raise Exception(f"Error creating report: {e}")
+            raise Exception(f"Error creating report: {e}") from e
 
 
 def _build_panel_blocks(

--- a/src/wandb_mcp_server/mcp_tools/diagnose_run.py
+++ b/src/wandb_mcp_server/mcp_tools/diagnose_run.py
@@ -5,7 +5,7 @@ import math
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.admission import ToolDeadlineExceeded
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_HISTORY_KEYS, MCP_MAX_HISTORY_SAMPLES
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -231,9 +231,11 @@ def diagnose_run(
         except Exception as e:
             if isinstance(e, ToolDeadlineExceeded):
                 raise
+            raise_for_wandb_server_busy(e)
             try:
                 run = api.run(f"{entity_name}/{project_name}/{run_id}")
             except Exception as run_error:
+                raise_for_wandb_server_busy(run_error)
                 ctx.mark_error(f"{type(run_error).__name__}: {run_error}")
                 return json.dumps({"error": "run_not_found", "message": str(run_error)[:500]})
             summary = dict(getattr(run, "summary", {}) or {})
@@ -298,6 +300,7 @@ def diagnose_run(
                 )
             )
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "history_fetch_failed", "message": str(e)[:500]})
 

--- a/src/wandb_mcp_server/mcp_tools/infer_schema.py
+++ b/src/wandb_mcp_server/mcp_tools/infer_schema.py
@@ -145,6 +145,9 @@ def infer_trace_schema(
                 metadata_only=False,
             )
         except Exception as e:
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             logger.error(f"Failed to query traces for schema inference: {e}")
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": f"Failed to infer schema for {entity_name}/{project_name}: {type(e).__name__}"})

--- a/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
+++ b/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
@@ -3,6 +3,7 @@
 import json
 from typing import Optional
 
+from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 
@@ -94,6 +95,7 @@ def list_entity_projects(
                     )
                 entities_projects[ent] = projects_data
             except Exception as e:
+                raise_for_wandb_server_busy(e)
                 logger.warning(f"Failed to list projects for entity {ent}: {e}")
                 ctx.mark_error(f"{type(e).__name__}: {e}")
                 entities_projects[ent] = [{"error": str(e)}]

--- a/src/wandb_mcp_server/mcp_tools/log_analysis.py
+++ b/src/wandb_mcp_server/mcp_tools/log_analysis.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 
 import wandb
 
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_WANDB_REQUEST_TIMEOUT_SECONDS, WANDB_API_BASE_URL
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.wandb_urls import public_wandb_url
@@ -151,6 +151,7 @@ def log_analysis(
             run.update()
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Failed to update analysis run: {e}", exc_info=True)
             raise
 

--- a/src/wandb_mcp_server/mcp_tools/probe_project.py
+++ b/src/wandb_mcp_server/mcp_tools/probe_project.py
@@ -8,7 +8,7 @@ import json
 import re
 from typing import Any, Mapping
 
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_PROBE_RUNS, MCP_MAX_PROJECT_FIELDS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -272,6 +272,7 @@ def probe_project(
                     }.values()
                 )
             except SelectiveReadUnavailable as exc:
+                raise_for_wandb_server_busy(exc)
                 logger.warning("Project selective read unavailable; using bounded SDK fallback: %s", exc)
                 counts, fields, run_samples = _sdk_fallback(
                     api,
@@ -365,12 +366,14 @@ def probe_project(
                         project=project_name,
                     )
                 except SelectiveReadUnavailable as exc:
+                    raise_for_wandb_server_busy(exc)
                     result["artifact_inventory"] = {
                         "error": "artifact_inventory_unavailable",
                         "message": str(exc),
                     }
             return json.dumps(result, default=str)
         except Exception as exc:
+            raise_for_wandb_server_busy(exc)
             ctx.mark_error(f"{type(exc).__name__}: {exc}")
             return json.dumps({"error": "project_probe_failed", "message": str(exc)[:500]})
 

--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -179,7 +179,8 @@ def list_artifact_versions(
                     )
                     raw_versions: list[Any] = page.items
                     upstream_has_more = page.has_more
-                except SelectiveReadUnavailable:
+                except SelectiveReadUnavailable as exc:
+                    raise_for_wandb_server_busy(exc)
                     versions_iter = registry.collections(
                         filter={"name": collection_name},
                         per_page=min(scan_limit, 100),
@@ -248,6 +249,7 @@ def list_artifact_versions(
             return json.dumps(result)
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
@@ -346,6 +348,7 @@ def get_artifact_details(
             return json.dumps(result)
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in get_artifact_details: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
@@ -482,6 +485,7 @@ def compare_artifact_versions(
             return json.dumps(result)
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in compare_artifact_versions: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
@@ -641,7 +645,8 @@ def _get_logged_by(artifact: Any) -> Optional[Dict[str, Any]]:
     try:
         run = artifact.logged_by()
         return _serialize_run_info(run)
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("logged_by() failed", exc_info=True)
         return None
 
@@ -661,7 +666,8 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
                     used_by_truncated = True
                     break
                 used_by.append(_serialize_run_info(run))
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("used_by() failed", exc_info=True)
 
     source_artifact = None
@@ -669,7 +675,8 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
         src = artifact.source_artifact
         if src is not None and src is not artifact:
             source_artifact = getattr(src, "source_qualified_name", None) or getattr(src, "name", None)
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("source_artifact failed", exc_info=True)
 
     linked: Optional[List[str]] = None
@@ -681,7 +688,8 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
                 name = getattr(la, "source_qualified_name", None) or getattr(la, "name", None)
                 if name:
                     linked.append(name)
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("linked_artifacts failed", exc_info=True)
 
     lineage: Dict[str, Any] = {
@@ -709,7 +717,8 @@ def _list_files(artifact: Any, max_files: int) -> List[Dict[str, Any]]:
                     "digest": getattr(f, "digest", None),
                 }
             )
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("files() failed", exc_info=True)
     return files
 
@@ -741,7 +750,8 @@ def _compute_file_diff(art_a: Any, art_b: Any, max_entries: int) -> Dict[str, An
                 scan_truncated = True
                 break
             files_a[getattr(f, "name", "")] = getattr(f, "digest", "")
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("files() failed for artifact_a", exc_info=True)
 
     try:
@@ -750,7 +760,8 @@ def _compute_file_diff(art_a: Any, art_b: Any, max_entries: int) -> Dict[str, An
                 scan_truncated = True
                 break
             files_b[getattr(f, "name", "")] = getattr(f, "digest", "")
-    except Exception:
+    except Exception as exc:
+        raise_for_wandb_server_busy(exc)
         logger.debug("files() failed for artifact_b", exc_info=True)
 
     names_a, names_b = set(files_a.keys()), set(files_b.keys())

--- a/src/wandb_mcp_server/mcp_tools/query_registry.py
+++ b/src/wandb_mcp_server/mcp_tools/query_registry.py
@@ -10,7 +10,7 @@ import json
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -122,6 +122,7 @@ def list_registries(
             )
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_registries: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})
@@ -238,6 +239,7 @@ def list_registry_collections(
             )
 
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_registry_collections: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "api_error", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/query_weave.py
+++ b/src/wandb_mcp_server/mcp_tools/query_weave.py
@@ -483,21 +483,28 @@ async def query_paginated_weave_traces(
             "debug_raw_traces": debug_raw_traces,
         },
     ):
-        result = service.query_paginated_traces(
-            entity_name=entity_name,
-            project_name=project_name,
-            chunk_size=chunk_size,
-            filters=filters,
-            sort_by=sort_by,
-            sort_direction=sort_direction,
-            target_limit=target_limit,
-            include_costs=include_costs,
-            include_feedback=include_feedback,
-            columns=columns,
-            expand_columns=expand_columns,
-            truncate_length=truncate_length,
-            return_full_data=return_full_data,
-            metadata_only=metadata_only,
+        from functools import partial
+
+        from wandb_mcp_server.instrumented_server import run_sync_in_current_tool
+
+        result = await run_sync_in_current_tool(
+            partial(
+                service.query_paginated_traces,
+                entity_name=entity_name,
+                project_name=project_name,
+                chunk_size=chunk_size,
+                filters=filters,
+                sort_by=sort_by,
+                sort_direction=sort_direction,
+                target_limit=target_limit,
+                include_costs=include_costs,
+                include_feedback=include_feedback,
+                columns=columns,
+                expand_columns=expand_columns,
+                truncate_length=truncate_length,
+                return_full_data=return_full_data,
+                metadata_only=metadata_only,
+            )
         )
 
         if debug_raw_traces and result.traces:

--- a/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
+++ b/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
@@ -101,5 +101,8 @@ def resolve_trace_roots(
             )
 
         except Exception as e:
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "resolve_failed", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/run_history.py
+++ b/src/wandb_mcp_server/mcp_tools/run_history.py
@@ -14,7 +14,11 @@ from typing import Any, Dict, List, Literal, Optional
 
 import wandb
 
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import (
+    WandBApiManager,
+    raise_for_wandb_server_busy,
+    wandb_server_busy_from_exception,
+)
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
 from wandb_mcp_server.config import (
     MCP_HOSTED_MODE,
@@ -202,8 +206,12 @@ def get_run_history(
             run_path = f"{entity_name}/{project_name}/{run_id}"
             run = wandb_api.run(run_path)
         except wandb.errors.CommError as e:
+            if busy := wandb_server_busy_from_exception(e):
+                raise busy from e
             raise ValueError(f"Run not found: {run_path}. Error: {e}")
         except Exception as e:
+            if busy := wandb_server_busy_from_exception(e):
+                raise busy from e
             raise ValueError(f"Failed to access run {entity_name}/{project_name}/{run_id}: {type(e).__name__}")
 
         profile_limit_applied = samples > MCP_MAX_HISTORY_SAMPLES
@@ -269,6 +277,7 @@ def get_run_history(
                     rows_scanned=len(rows),
                 )
         except Exception as e:
+            raise_for_wandb_server_busy(e)
             raise ValueError(f"Failed to fetch history for run {run_id}: {e}")
 
         clean_rows = []
@@ -502,6 +511,7 @@ def _fetch_target_x(
             values=[target_x],
         )
     except SelectiveReadUnavailable as exc:
+        raise_for_wandb_server_busy(exc)
         rows, rows_scanned = _scan_history_rows(
             run,
             keys=requested_keys,

--- a/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
+++ b/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
@@ -285,5 +285,8 @@ def summarize_evaluation(
             )
 
         except Exception as e:
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             ctx.mark_error(f"{type(e).__name__}: {e}")
             return json.dumps({"error": "evaluation_query_failed", "message": str(e)[:500]})

--- a/src/wandb_mcp_server/mcp_tools/tools_utils.py
+++ b/src/wandb_mcp_server/mcp_tools/tools_utils.py
@@ -307,6 +307,17 @@ def get_retry_session(
     return session
 
 
+def get_no_retry_session() -> requests.Session:
+    """Return a session that performs exactly one HTTP attempt.
+
+    Functional MCP calls use this when retrying upstream overload would
+    amplify customer traffic. The normal ``requests`` adapters use a zero-retry
+    policy and return the original response, preserving status and headers for
+    the shared MCP overload mapper.
+    """
+    return requests.Session()
+
+
 class _ToolExecutionContext:
     """Mutable context yielded by ``track_tool_execution``.
 

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -15,6 +15,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from functools import partial
+import ipaddress
 import json
 import logging
 import os
@@ -26,8 +27,15 @@ import wandb
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
-from wandb_mcp_server.config import MCP_WANDB_REQUEST_TIMEOUT_SECONDS, WANDB_API_BASE_URL
-from wandb_mcp_server.instrumented_server import InstrumentedFastMCP
+from wandb_mcp_server.config import (
+    MCP_COUNT_TOOL_WORKERS,
+    MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
+    WANDB_API_BASE_URL,
+)
+from wandb_mcp_server.instrumented_server import (
+    InstrumentedFastMCP,
+    register_current_sync_future,
+)
 
 # Import Weave for tracing MCP tool calls
 try:
@@ -206,7 +214,7 @@ def _remove_registered_tools(mcp_instance: FastMCP, tool_names: Collection[str])
 
 
 _COUNT_EXECUTOR = ThreadPoolExecutor(
-    max_workers=int(os.environ.get("MCP_COUNT_TOOL_WORKERS", "8")),
+    max_workers=MCP_COUNT_TOOL_WORKERS,
     thread_name_prefix="mcp-count",
 )
 
@@ -248,7 +256,10 @@ async def _count_traces_with_deadline(
     deadline_seconds: int,
 ) -> int:
     """Run count_traces without letting executor shutdown extend wall time."""
-    request_timeout = max(1, deadline_seconds - 2)
+    request_timeout = min(
+        MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
+        max(1, deadline_seconds - 2),
+    )
     loop = asyncio.get_running_loop()
     future = loop.run_in_executor(
         _COUNT_EXECUTOR,
@@ -262,10 +273,12 @@ async def _count_traces_with_deadline(
             request_timeout,
         ),
     )
+    register_current_sync_future(future)
     try:
-        return await asyncio.wait_for(future, timeout=deadline_seconds)
+        # Shield the asyncio wrapper so timeout does not mark it done while
+        # the underlying thread is still consuming physical capacity.
+        return await asyncio.wait_for(asyncio.shield(future), timeout=deadline_seconds)
     except asyncio.TimeoutError:
-        future.cancel()
         raise
 
 
@@ -287,7 +300,13 @@ async def _count_traces_or_none(
             filters,
             deadline_seconds,
         )
-    except Exception:
+    except Exception as exc:
+        # A preflight count is part of the same functional request. If W&B is
+        # already applying backpressure, do not immediately amplify it with
+        # the larger query that the count was intended to guard.
+        from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+        raise_for_wandb_server_busy(exc)
         logger.info("count_traces skipped after timeout or error", exc_info=True)
         return None
 
@@ -328,8 +347,9 @@ def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
     """
     Validate and retrieve the W&B API key from various sources.
 
-    For HTTP transport: API key is optional (clients provide their own)
-    For STDIO transport: API key is required from environment
+    The console entrypoint requires one server-side API key for both STDIO and
+    loopback-only HTTP development. Authenticated multi-user HTTP is provided
+    by the hosted wrapper and Helm image, not this standalone entrypoint.
 
     Priority order:
     1. Command-line argument (--wandb-api-key)
@@ -348,18 +368,10 @@ def validate_and_get_api_key(args: ServerMCPArgs) -> Optional[str]:
     """
     api_key = args.wandb_api_key or get_server_args().wandb_api_key
 
-    # For HTTP transport, API key is optional (clients provide their own)
-    if args.transport == "http":
-        if api_key:
-            logger.info("Server W&B API key configured (for server operations)")
-        else:
-            logger.info("No server W&B API key configured (clients will provide their own)")
-        return api_key
-
-    # For STDIO transport, API key is required
     if not api_key:
+        transport_label = "STDIO" if args.transport == "stdio" else "standalone http"
         raise ValueError(
-            "WANDB_API_KEY must be set for STDIO transport. Options:\n"
+            f"WANDB_API_KEY must be set for {transport_label} transport. Options:\n"
             "1. Command-line: --wandb-api-key YOUR_KEY\n"
             "2. Environment: export WANDB_API_KEY=YOUR_KEY\n"
             "3. .env file: WANDB_API_KEY=YOUR_KEY\n"
@@ -719,6 +731,9 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
             if isinstance(e, HostedLimitExceeded):
                 return json.dumps(structured_error(e.error, str(e), **e.details))
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in query_weave_traces_tool: {e}", exc_info=True)
             return json.dumps(
                 {
@@ -775,6 +790,9 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 )
             )
         except Exception as e:
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in count_weave_traces_tool: {e}")
             return json.dumps({"error": f"Error counting traces: {str(e)}"})
 
@@ -846,7 +864,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
     if not WANDB_MCP_READ_ONLY:
 
         @mcp_instance.tool(description=CREATE_WANDB_REPORT_TOOL_DESCRIPTION)
-        async def create_wandb_report_tool(
+        def create_wandb_report_tool(
             entity_name: str,
             project_name: str,
             title: str,
@@ -867,8 +885,8 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 )
 
                 return f"The report was saved here: {result['url']}"
-            except Exception as e:
-                raise e
+            except Exception:
+                raise
 
         from wandb_mcp_server.mcp_tools.log_analysis import (
             LOG_ANALYSIS_TOOL_DESCRIPTION,
@@ -876,7 +894,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
         )
 
         @mcp_instance.tool(description=LOG_ANALYSIS_TOOL_DESCRIPTION)
-        async def log_analysis_to_wandb(
+        def log_analysis_to_wandb(
             entity_name: str,
             project_name: str,
             analysis_name: str,
@@ -884,28 +902,20 @@ def register_tools(mcp_instance: FastMCP) -> None:
             charts: Optional[List[Dict[str, Any]]] = None,
             scalars: Optional[Dict[str, float]] = None,
         ) -> str:
-            from concurrent.futures import ThreadPoolExecutor
-
-            from wandb_mcp_server.api_client import WandBApiManager
-
             try:
-                api_key = WandBApiManager.get_api_key()
-
-                def _log_with_context():
-                    WandBApiManager.set_context_api_key(api_key)
-                    return log_analysis(
-                        entity_name=entity_name,
-                        project_name=project_name,
-                        analysis_name=analysis_name,
-                        data=data,
-                        charts=charts,
-                        scalars=scalars,
-                    )
-
-                with ThreadPoolExecutor(max_workers=1) as pool:
-                    result = await asyncio.get_event_loop().run_in_executor(pool, _log_with_context)
+                result = log_analysis(
+                    entity_name=entity_name,
+                    project_name=project_name,
+                    analysis_name=analysis_name,
+                    data=data,
+                    charts=charts,
+                    scalars=scalars,
+                )
                 return json.dumps(result)
             except Exception as e:
+                from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+                raise_for_wandb_server_busy(e)
                 logger.error(f"Error in log_analysis_to_wandb: {e}", exc_info=True)
                 return json.dumps({"error": "log_failed", "message": str(e)[:500]})
 
@@ -1008,6 +1018,9 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 stream=stream,
             )
         except Exception as e:
+            from wandb_mcp_server.api_client import raise_for_wandb_server_busy
+
+            raise_for_wandb_server_busy(e)
             logger.error(f"Error in get_run_history_tool: {e}")
             return json.dumps({"error": str(e)})
 
@@ -1237,6 +1250,45 @@ def register_tools(mcp_instance: FastMCP) -> None:
 # ===============================================================================
 
 
+def _validate_standalone_transport(transport: str, host: str) -> str:
+    """Validate standalone transport safety and return the concrete bind host."""
+    if transport == "stdio":
+        return host
+    if transport != "http":
+        raise ValueError(f"Invalid transport type: {transport}. Must be 'stdio' or 'http'")
+
+    normalized_host = host.strip().strip("[]").rstrip(".").lower()
+    if normalized_host == "localhost":
+        # Avoid relying on mutable hostname resolution for the security
+        # boundary. A literal loopback address is passed to the socket binder.
+        bind_host = "127.0.0.1"
+    else:
+        try:
+            address = ipaddress.ip_address(normalized_host)
+        except ValueError:
+            address = None
+        if address is None or not address.is_loopback:
+            raise ValueError(
+                "Standalone --transport http is development-only and must bind "
+                "to a literal loopback host. Use the authenticated hosted wrapper "
+                "or Helm image for production HTTP."
+            )
+        bind_host = normalized_host
+
+    if os.environ.get("MCP_AUTH_DISABLED", "false").strip().lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        raise ValueError(
+            "Standalone --transport http has no bearer-authentication "
+            "middleware. Set MCP_AUTH_DISABLED=true for loopback development, "
+            "or use the authenticated hosted wrapper or Helm image."
+        )
+    return bind_host
+
+
 def create_mcp_server(transport: str, host: str = "localhost", port: Optional[int] = None) -> FastMCP:
     """
     Create and configure a FastMCP server for the specified transport.
@@ -1254,9 +1306,12 @@ def create_mcp_server(transport: str, host: str = "localhost", port: Optional[in
 
     Authentication:
         - STDIO transport: Uses environment variables (WANDB_API_KEY required)
-        - HTTP transport: Clients provide W&B API key as Bearer token
-          Set MCP_AUTH_DISABLED=true to disable auth (development only)
+        - Standalone HTTP transport: unauthenticated, loopback-only development
+          server. Set MCP_AUTH_DISABLED=true to acknowledge this explicitly.
+          Production HTTP uses the hosted wrapper or Helm deployment.
     """
+    host = _validate_standalone_transport(transport, host)
+
     from wandb_mcp_server.analytics import configure_analytics_runtime
 
     configure_analytics_runtime(transport)
@@ -1265,19 +1320,12 @@ def create_mcp_server(transport: str, host: str = "localhost", port: Optional[in
         port = port if port is not None else 8080
         logger.info(f"Configuring HTTP server on {host}:{port}")
         mcp = InstrumentedFastMCP("weave-mcp-server", host=host, port=port, stateless_http=True)
+        logger.warning("Standalone HTTP development server is unauthenticated and loopback-only")
 
-        # Log authentication status for HTTP
-        if os.environ.get("MCP_AUTH_DISABLED", "false").lower() == "true":
-            logger.warning("⚠️  MCP authentication is DISABLED - server is publicly accessible")
-        else:
-            logger.info("🔒 MCP authentication enabled - clients must provide W&B API key as Bearer token")
-
-    elif transport == "stdio":
+    else:
         logger.info("Configuring stdio server")
         mcp = InstrumentedFastMCP("weave-mcp-server")
         logger.info("STDIO transport uses environment variable authentication")
-    else:
-        raise ValueError(f"Invalid transport type: {transport}. Must be 'stdio' or 'http'")
 
     # Register all tools
     register_tools(mcp)
@@ -1304,12 +1352,12 @@ def cli():
         --wandb-api-key KEY         W&B API key (can also use env var)
 
     Environment Variables:
-        WANDB_API_KEY               W&B API key (required for STDIO, optional for HTTP)
+        WANDB_API_KEY               W&B API key (required for STDIO and development HTTP)
         MCP_SERVER_LOG_LEVEL        Server log level (DEBUG, INFO, WARNING, ERROR)
         WANDB_SILENT                Set to "False" to enable W&B output (default: True)
         WEAVE_SILENT                Set to "False" to enable Weave output (default: True)
         WANDB_DEBUG                 Set to "true" to enable W&B debug logging
-        MCP_AUTH_DISABLED           Set to "true" to disable HTTP auth (dev only)
+        MCP_AUTH_DISABLED           Must be "true" for loopback HTTP development
     """
     print("Starting W&B MCP Server...", file=sys.stderr)
 
@@ -1330,6 +1378,10 @@ def cli():
 
     args = simple_parsing.parse(ServerMCPArgs)
 
+    # Reject unsafe standalone HTTP before credential validation or any
+    # optional Weave initialization can perform network work.
+    bind_host = _validate_standalone_transport(args.transport, args.host)
+
     # Configure W&B logging behavior
     configure_wandb_logging()
 
@@ -1338,34 +1390,37 @@ def cli():
 
     # Validate API key if we have one (but don't set global state)
     if api_key:
-        validate_api_key(api_key)
+        from wandb_mcp_server.api_client import WandBApiManager
 
-        # For STDIO transport, set the API key in context for all operations
-        # This is essential since STDIO doesn't have per-request auth
-        if args.transport == "stdio":
-            from wandb_mcp_server.api_client import WandBApiManager
+        # Upstream SDK errors can echo request details. Make the candidate key
+        # available to the shared sanitizer while validation is in flight, then
+        # discard that temporary context regardless of the result.
+        validation_token = WandBApiManager.set_context_api_key(api_key)
+        try:
+            api_key_is_valid = validate_api_key(api_key)
+        finally:
+            WandBApiManager.reset_context_api_key(validation_token)
 
-            # Set the API key in context for the entire session
-            # No need to reset since STDIO runs for the whole session
-            WandBApiManager.set_context_api_key(api_key)
-            logger.info("API key set in context for STDIO session")
+        if not api_key_is_valid:
+            raise ValueError("WANDB_API_KEY validation failed")
+
+        # The console entrypoint is single-actor. Authenticated hosted HTTP
+        # supplies a per-request context in its wrapper instead.
+        WandBApiManager.set_context_api_key(api_key)
+        logger.info("API key set in context for standalone session")
 
     # Initialize Weave tracing for MCP tool calls
     initialize_weave_tracing()
 
     logger.info("Starting Weights & Biases MCP Server")
     logger.info(f"Transport: {args.transport}")
-    logger.info(f"API Key configured: {'Yes' if api_key else 'No (clients provide their own)'}")
-
-    # Validate transport type
-    if args.transport not in ["stdio", "http"]:
-        raise ValueError(f"Invalid transport type: {args.transport}. Must be 'stdio' or 'http'")
+    logger.info(f"API Key configured: {'Yes' if api_key else 'No'}")
 
     # Create and run the MCP server
-    server = create_mcp_server(args.transport, args.host, args.port)
+    server = create_mcp_server(args.transport, bind_host, args.port)
 
     if args.transport == "http":
-        logger.info(f"Starting HTTP server on {args.host}:{args.port or 8080}")
+        logger.info(f"Starting HTTP server on {bind_host}:{args.port or 8080}")
         server.run(transport="streamable-http")
     else:
         logger.info("Starting stdio server")

--- a/src/wandb_mcp_server/session_manager.py
+++ b/src/wandb_mcp_server/session_manager.py
@@ -14,7 +14,6 @@ Key features:
 import base64
 import hashlib
 import hmac
-import os
 import time
 import uuid
 from collections import defaultdict
@@ -520,22 +519,17 @@ def get_session_manager() -> MultiTenantSessionManager:
     with _session_manager_lock:
         if _session_manager is not None:
             return _session_manager
-        try:
-            ttl = int(os.environ.get("SESSION_TTL_SECONDS", "3600"))
-        except ValueError:
-            raise ValueError("SESSION_TTL_SECONDS must be an integer (got: %r)" % os.environ.get("SESSION_TTL_SECONDS"))
-        try:
-            max_sessions = int(os.environ.get("MAX_SESSIONS_PER_KEY", "10"))
-        except ValueError:
-            raise ValueError(
-                "MAX_SESSIONS_PER_KEY must be an integer (got: %r)" % os.environ.get("MAX_SESSIONS_PER_KEY")
-            )
-        enable_hmac_sessions = os.environ.get("MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS", "false").lower() == "true"
+        from wandb_mcp_server.config import (
+            MAX_SESSIONS_PER_KEY,
+            MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS,
+            SESSION_TTL_SECONDS,
+        )
+
         try:
             _session_manager = MultiTenantSessionManager(
-                session_ttl_seconds=ttl,
-                max_sessions_per_key=max_sessions,
-                enable_hmac_sha256_sessions=enable_hmac_sessions,
+                session_ttl_seconds=SESSION_TTL_SECONDS,
+                max_sessions_per_key=MAX_SESSIONS_PER_KEY,
+                enable_hmac_sha256_sessions=MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS,
             )
         except Exception as e:
             raise RuntimeError(f"Unable to initialize session manager: {e}") from e

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -6,6 +6,7 @@ import netrc
 import os
 import subprocess
 import sys
+import traceback
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
@@ -14,6 +15,12 @@ from urllib.parse import urlparse
 import simple_parsing
 from rich.logging import RichHandler
 from rich.console import Console
+
+from wandb_mcp_server.error_sanitizer import (
+    MAX_EXTERNAL_ERROR_CHARS,
+    sanitize_sensitive_text,
+    sanitize_sensitive_value,
+)
 
 os.environ["WANDB_SILENT"] = "True"
 os.environ["WEAVE_SILENT"] = "True"
@@ -65,10 +72,61 @@ class _JsonLogFormatter(logging.Formatter):
             payload["session_id_prefix"] = session_prefix
         if record.exc_info:
             payload["exc_info"] = self.formatException(record.exc_info)
+        else:
+            sanitized_exc_info = getattr(record, "_wandb_mcp_sanitized_exc_info", None)
+            if sanitized_exc_info:
+                payload["exc_info"] = sanitized_exc_info
         # stack_info is separate from exc_info; include if present
         if record.stack_info:
             payload["stack_info"] = self.formatStack(record.stack_info)
         return _json.dumps(payload, default=str)
+
+
+class _SensitiveDataFilter(logging.Filter):
+    """Ensure credentials and internal service addresses never reach logs."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = sanitize_sensitive_text(
+                record.getMessage(),
+                max_chars=MAX_EXTERNAL_ERROR_CHARS,
+            )
+            if record.exc_info:
+                exception_text = sanitize_sensitive_text(
+                    "".join(traceback.format_exception(*record.exc_info)),
+                    max_chars=MAX_EXTERNAL_ERROR_CHARS,
+                )
+                record._wandb_mcp_sanitized_exc_info = exception_text
+                if os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower() != "json":
+                    message = f"{message}\n{exception_text}"
+                record.exc_info = None
+                record.exc_text = None
+            record.msg = message
+            record.args = ()
+            if hasattr(record, "json_fields"):
+                record.json_fields = sanitize_sensitive_value(record.json_fields)
+        except Exception:
+            # Logging must remain non-fatal. The sanitizer is intentionally
+            # conservative, but a malformed third-party record cannot break
+            # request handling.
+            pass
+        return True
+
+
+def _install_sensitive_record_factory() -> None:
+    """Sanitize every log record, including third-party/root logger output."""
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_wandb_mcp_sensitive", False):
+        return
+    sanitizer = _SensitiveDataFilter()
+
+    def _sanitizing_factory(*args, **kwargs):
+        record = current_factory(*args, **kwargs)
+        sanitizer.filter(record)
+        return record
+
+    _sanitizing_factory._wandb_mcp_sensitive = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(_sanitizing_factory)
 
 
 def _build_log_handler() -> logging.Handler:
@@ -85,16 +143,18 @@ def _build_log_handler() -> logging.Handler:
     if log_format == "json":
         handler: logging.Handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(_JsonLogFormatter())
-        return handler
-    # Default: rich output, preserves today's behavior for local dev + Cloud Run.
-    stderr_console = Console(stderr=True)
-    return RichHandler(
-        console=stderr_console,
-        show_time=True,
-        show_level=True,
-        show_path=False,
-        markup=True,
-    )
+    else:
+        # Default: rich output, preserves today's behavior for local dev + Cloud Run.
+        stderr_console = Console(stderr=True)
+        handler = RichHandler(
+            console=stderr_console,
+            show_time=True,
+            show_level=True,
+            show_path=False,
+            markup=True,
+        )
+    handler.addFilter(_SensitiveDataFilter())
+    return handler
 
 
 # Third-party loggers we explicitly reconfigure in JSON mode so every line emitted by
@@ -135,6 +195,7 @@ def configure_process_logging() -> None:
     if _process_logging_configured:
         return
     _process_logging_configured = True
+    _install_sensitive_record_factory()
 
     if os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower() != "json":
         return

--- a/src/wandb_mcp_server/weave_api/client.py
+++ b/src/wandb_mcp_server/weave_api/client.py
@@ -10,12 +10,9 @@ import json
 from typing import Any, Dict, Iterator, Optional
 
 import requests
-from requests.adapters import HTTPAdapter
-from requests.exceptions import RetryError
-from urllib3.util.retry import Retry
 
-from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.config import WF_TRACE_SERVER_URL
+from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
 
@@ -24,13 +21,12 @@ class WeaveApiClient:
     """Client for interacting with the Weights & Biases Weave API."""
 
     DEFAULT_TIMEOUT = 30
-    RETRYABLE_STATUS_CODES = (429, 500, 502, 503, 504)
 
     def __init__(
         self,
         api_key: Optional[str] = None,
         server_url: Optional[str] = None,
-        retries: int = 3,
+        retries: int = 0,
         timeout: int = DEFAULT_TIMEOUT,
     ):
         """Initialize the WeaveApiClient.
@@ -38,22 +34,15 @@ class WeaveApiClient:
         Args:
             api_key: API key for authentication. If None, try to get from environment.
             server_url: Weave API server URL. Defaults to 'https://trace.wandb.ai'.
-            retries: Number of retries for failed requests.
+            retries: Retained for compatibility. Functional trace queries are
+                never retried automatically because the MCP caller owns retry
+                policy and upstream overload must be surfaced immediately.
             timeout: Request timeout in seconds.
 
         Raises:
             ValueError: If no API key is provided or found in environment.
         """
         self.session = requests.Session()
-        retry_strategy = Retry(
-            total=retries,
-            backoff_factor=1.0,
-            status_forcelist=self.RETRYABLE_STATUS_CODES,
-            allowed_methods=["POST", "GET"],
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("https://", adapter)
-        self.session.mount("http://", adapter)
 
         # NO FALLBACKS! API key must be explicitly provided
         # For HTTP: Comes from auth middleware via TraceService
@@ -67,7 +56,11 @@ class WeaveApiClient:
 
         self.api_key = api_key
         self.server_url = server_url or WF_TRACE_SERVER_URL
-        self.retries = retries
+        # Automatic retries amplify 429/503 overload and consume an MCP
+        # admission permit for longer than one backend attempt. Keep the
+        # constructor argument for compatibility but make the effective policy
+        # explicit and invariant.
+        self.retries = 0
         self.timeout = timeout
 
     def _get_auth_headers(self) -> Dict[str, str]:
@@ -123,7 +116,9 @@ class WeaveApiClient:
             if response.status_code != 200:
                 error_msg = f"Error {response.status_code}: {response.text}"
                 logger.error(error_msg)
-                raise Exception(error_msg)
+                # Keep the response (including Retry-After) attached so the
+                # common MCP boundary can produce a stable server_busy result.
+                raise requests.HTTPError(error_msg, response=response)
 
             logger.info(f"Response status: {response.status_code}")
 
@@ -139,11 +134,7 @@ class WeaveApiClient:
             logger.error(
                 f"Error executing HTTP request to Weave server: {e}. Request body snippet: {str(query_params)[:1000]}"
             )
-            if isinstance(e, RetryError):
-                cause = e.__cause__
-                if cause and hasattr(cause, "reason"):
-                    logger.error(f"Specific reason for retry exhaustion: {cause.reason}")
-            raise Exception(f"Failed to query Weave traces due to network error: {e}")
+            raise Exception(f"Failed to query Weave traces due to network error: {e}") from e
         except json.JSONDecodeError as e:
             logger.error(f"Error decoding JSON from Weave server: {e}")
             raise Exception(f"Failed to parse Weave API response: {e}")

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -100,7 +100,7 @@ class TraceService:
         self,
         api_key: Optional[str] = None,
         server_url: Optional[str] = None,
-        retries: int = 3,
+        retries: int = 0,
         timeout: int = 10,
     ):
         """Initialize the TraceService.
@@ -108,7 +108,8 @@ class TraceService:
         Args:
             api_key: W&B API key. If not provided, uses WANDB_API_KEY env var.
             server_url: Weave API server URL. Defaults to env-driven config.
-            retries: Number of retries for failed requests.
+            retries: Retained for compatibility. Functional trace requests are
+                not retried automatically.
             timeout: Request timeout in seconds.
         """
         # If no API key provided, try to get from context only (no fallbacks!)

--- a/tests/test_admission_control.py
+++ b/tests/test_admission_control.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
@@ -186,8 +189,122 @@ async def test_public_boundary_enforces_async_tool_deadline(monkeypatch) -> None
         await server.call_tool("slow_async_tool", {})
 
 
-def test_sync_tools_are_registered_as_async_threaded_calls(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_public_boundary_maps_upstream_rate_limit_without_retry(monkeypatch) -> None:
     monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = InstrumentedFastMCP("upstream-rate-limit-test")
+
+    @server.tool(name="list_entities_tool")
+    async def rate_limited_tool() -> str:
+        error = RuntimeError("HTTP 429 Too Many Requests")
+        error.response = SimpleNamespace(
+            status_code=429,
+            headers={"Retry-After": "3"},
+            reason="Too Many Requests",
+            text="",
+        )
+        raise error
+
+    with pytest.raises(ToolError) as caught:
+        await server.call_tool("list_entities_tool", {})
+
+    assert '"error": "server_busy"' in str(caught.value)
+    assert '"retry_after_ms": 3000' in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_write_timeout_reports_unknown_outcome_and_is_not_retryable(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", True)
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_TOOL_TIMEOUT_SECONDS", 0.01)
+    server = InstrumentedFastMCP("write-timeout-test")
+
+    @server.tool(name="create_wandb_report_tool")
+    def slow_write() -> str:
+        time.sleep(0.05)
+        return "created"
+
+    with pytest.raises(ToolError) as caught:
+        await server.call_tool("create_wandb_report_tool", {})
+
+    rendered = str(caught.value)
+    assert '"error": "outcome_unknown"' in rendered
+    assert '"retryable": false' in rendered
+    assert "retry_after" not in rendered
+    await asyncio.sleep(0.06)
+
+
+@pytest.mark.asyncio
+async def test_write_rate_limit_reports_unknown_outcome_and_is_not_retryable(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = InstrumentedFastMCP("write-rate-limit-test")
+
+    @server.tool(name="log_analysis_to_wandb")
+    async def rate_limited_write() -> None:
+        error = RuntimeError("HTTP 429 Too Many Requests")
+        error.response = SimpleNamespace(
+            status_code=429,
+            headers={"Retry-After": "3"},
+            reason="Too Many Requests",
+            text="",
+        )
+        raise error
+
+    with pytest.raises(ToolError) as caught:
+        await server.call_tool("log_analysis_to_wandb", {})
+
+    rendered = str(caught.value)
+    assert '"error": "outcome_unknown"' in rendered
+    assert '"retryable": false' in rendered
+    assert "retry_after" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_wait_is_recorded_as_cancelled(monkeypatch) -> None:
+    tracker = MagicMock()
+    monkeypatch.setattr(
+        "wandb_mcp_server.analytics.get_analytics_tracker",
+        lambda: tracker,
+    )
+    server = InstrumentedFastMCP("admission-cancel-analytics-test")
+    server._admission_controller = WeightedAdmissionController(
+        actor_capacity=1,
+        process_capacity=1,
+        wait_timeout_seconds=1,
+    )
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    @server.tool(name="list_entities_tool")
+    async def held_tool() -> str:
+        started.set()
+        await finish.wait()
+        return "ok"
+
+    first = asyncio.create_task(server.call_tool("list_entities_tool", {}))
+    await started.wait()
+    queued = asyncio.create_task(server.call_tool("list_entities_tool", {}))
+    await asyncio.sleep(0.01)
+    queued.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await queued
+
+    cancelled_events = [
+        call.kwargs
+        for call in tracker.track_tool_call.call_args_list
+        if call.kwargs["params"]["admission_outcome"] == "cancelled"
+    ]
+    assert len(cancelled_events) == 1
+    assert cancelled_events[0]["success"] is False
+    assert cancelled_events[0]["error"].startswith("cancelled:")
+
+    finish.set()
+    await first
+
+
+def test_sync_tools_are_registered_as_async_threaded_calls_when_bounded(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", True)
     server = InstrumentedFastMCP("threaded-test")
 
     @server.tool(name="sync_tool")
@@ -195,3 +312,164 @@ def test_sync_tools_are_registered_as_async_threaded_calls(monkeypatch) -> None:
         return threading.current_thread().name
 
     assert server._tool_manager.get_tool("sync_tool").is_async is True
+
+
+@pytest.mark.asyncio
+async def test_local_dispatch_keeps_sync_work_off_event_loop(monkeypatch) -> None:
+    from wandb_mcp_server.instrumented_server import run_sync_in_current_tool
+
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", False)
+    monkeypatch.setattr(
+        "wandb_mcp_server.instrumented_server.MCP_ADMISSION_CONTROL_ENABLED",
+        False,
+    )
+    server = InstrumentedFastMCP("local-off-loop-test")
+    caller_thread = threading.get_ident()
+    observed_threads: list[int] = []
+
+    @server.tool(name="local_sync_tool")
+    def local_sync_tool() -> str:
+        observed_threads.append(threading.get_ident())
+        return "sync"
+
+    @server.tool(name="local_async_tool")
+    async def local_async_tool() -> str:
+        return await run_sync_in_current_tool(lambda: observed_threads.append(threading.get_ident()) or "async")
+
+    assert server._tool_manager.get_tool("local_sync_tool").is_async is True
+    await server.call_tool("local_sync_tool", {})
+    await server.call_tool("local_async_tool", {})
+
+    assert len(observed_threads) == 2
+    assert all(thread_id != caller_thread for thread_id in observed_threads)
+
+
+@pytest.mark.asyncio
+async def test_timed_out_sync_tool_holds_permit_until_worker_finishes(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", True)
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_TOOL_TIMEOUT_SECONDS", 0.02)
+    server = InstrumentedFastMCP("sync-timeout-test")
+    server._admission_controller = WeightedAdmissionController(
+        actor_capacity=1,
+        process_capacity=1,
+        wait_timeout_seconds=0.01,
+    )
+    started = threading.Event()
+    finish = threading.Event()
+    state_lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    @server.tool(name="list_entities_tool")
+    def blocking_tool() -> str:
+        nonlocal active, peak
+        with state_lock:
+            active += 1
+            peak = max(peak, active)
+        started.set()
+        finish.wait(timeout=2)
+        with state_lock:
+            active -= 1
+        return "done"
+
+    first = asyncio.create_task(server.call_tool("list_entities_tool", {}))
+    assert await asyncio.to_thread(started.wait, 1)
+    with pytest.raises(ToolError, match="tool_timeout"):
+        await first
+
+    assert server._admission_controller.process_in_use == 1
+    with pytest.raises(ToolError, match="server_busy"):
+        await server.call_tool("list_entities_tool", {})
+    assert peak == 1
+
+    finish.set()
+    deadline = time.monotonic() + 1
+    while server._admission_controller.process_in_use and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert server._admission_controller.process_in_use == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_sync_tool_holds_permit_until_worker_finishes(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", True)
+    server = InstrumentedFastMCP("sync-cancel-test")
+    server._admission_controller = WeightedAdmissionController(
+        actor_capacity=1,
+        process_capacity=1,
+        wait_timeout_seconds=0.01,
+    )
+    started = threading.Event()
+    finish = threading.Event()
+
+    @server.tool(name="list_entities_tool")
+    def blocking_tool() -> str:
+        started.set()
+        finish.wait(timeout=2)
+        return "done"
+
+    first = asyncio.create_task(server.call_tool("list_entities_tool", {}))
+    assert await asyncio.to_thread(started.wait, 1)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert server._admission_controller.process_in_use == 1
+    with pytest.raises(ToolError, match="server_busy"):
+        await server.call_tool("list_entities_tool", {})
+
+    finish.set()
+    deadline = time.monotonic() + 1
+    while server._admission_controller.process_in_use and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert server._admission_controller.process_in_use == 0
+
+
+@pytest.mark.asyncio
+async def test_async_tool_blocking_section_uses_bounded_tracked_executor(monkeypatch) -> None:
+    from wandb_mcp_server.instrumented_server import run_sync_in_current_tool
+
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_HOSTED_MODE", True)
+    monkeypatch.setattr("wandb_mcp_server.instrumented_server.MCP_TOOL_TIMEOUT_SECONDS", 0.02)
+    server = InstrumentedFastMCP("async-sync-section-test")
+    server._admission_controller = WeightedAdmissionController(
+        actor_capacity=4,
+        process_capacity=4,
+        wait_timeout_seconds=0.01,
+    )
+    started = threading.Event()
+    finish = threading.Event()
+
+    @server.tool(name="query_weave_traces_tool")
+    async def tool_with_blocking_sdk_section() -> str:
+        def blocking_sdk_call() -> str:
+            started.set()
+            finish.wait(timeout=2)
+            return "done"
+
+        return await run_sync_in_current_tool(blocking_sdk_call)
+
+    first = asyncio.create_task(server.call_tool("query_weave_traces_tool", {}))
+    assert await asyncio.to_thread(started.wait, 1)
+    heartbeat = False
+
+    async def pulse() -> None:
+        nonlocal heartbeat
+        await asyncio.sleep(0)
+        heartbeat = True
+
+    await asyncio.wait_for(pulse(), timeout=0.1)
+    assert heartbeat
+    with pytest.raises(ToolError, match="tool_timeout"):
+        await first
+    assert server._admission_controller.process_in_use == 4
+    with pytest.raises(ToolError, match="server_busy"):
+        await server.call_tool("query_weave_traces_tool", {})
+
+    finish.set()
+    deadline = time.monotonic() + 1
+    while server._admission_controller.process_in_use and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+    assert server._admission_controller.process_in_use == 0

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -30,7 +30,7 @@ from wandb_mcp_server.harness import HarnessContext, current_harness_context
 
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch):
-    monkeypatch.setenv("MCP_REQUEST_SUCCESS_SAMPLE_RATE", "1")
+    monkeypatch.setattr(analytics_module, "MCP_REQUEST_SUCCESS_SAMPLE_RATE", 1.0)
     monkeypatch.setattr(analytics_module, "_analytics_startup_logged", False)
     reset_analytics_tracker()
     configure_analytics_logging("stdout")
@@ -559,6 +559,18 @@ class TestTrackToolCall:
         )
         assert capture.event["duration_ms"] == 123.4
 
+    def test_cancelled_admission_outcome_survives_event_emission(self, capture):
+        AnalyticsTracker(enabled=True).track_tool_call(
+            tool_name="t",
+            session_id="s",
+            viewer_info=None,
+            success=False,
+            error="cancelled: tool admission wait was cancelled",
+            params={"admission_outcome": "cancelled"},
+        )
+
+        assert capture.event["usage_dimensions"]["admission_outcome"] == "cancelled"
+
     def test_mcp_tool_name_recorded_when_available(self, capture):
         AnalyticsTracker(enabled=True).track_tool_call(
             tool_name="query_paginated_wandb_gql",
@@ -718,7 +730,7 @@ class TestTrackRequest:
         assert e["mcp_client_version"] == "2.1.89"
 
     def test_success_sampling_can_drop_request(self, capture, monkeypatch):
-        monkeypatch.setenv("MCP_REQUEST_SUCCESS_SAMPLE_RATE", "0")
+        monkeypatch.setattr(analytics_module, "MCP_REQUEST_SUCCESS_SAMPLE_RATE", 0.0)
         AnalyticsTracker(enabled=True).track_request(
             request_id="drop-me",
             session_id="s",
@@ -730,7 +742,7 @@ class TestTrackRequest:
         assert capture.event is None
 
     def test_errors_and_slow_requests_bypass_sampling(self, capture, monkeypatch):
-        monkeypatch.setenv("MCP_REQUEST_SUCCESS_SAMPLE_RATE", "0")
+        monkeypatch.setattr(analytics_module, "MCP_REQUEST_SUCCESS_SAMPLE_RATE", 0.0)
         tracker = AnalyticsTracker(enabled=True)
         tracker.track_request("error", "s", "POST", "/mcp", 500, duration_ms=10)
         assert capture.event["status_code"] == 500

--- a/tests/test_analytics_datadog.py
+++ b/tests/test_analytics_datadog.py
@@ -5,6 +5,8 @@ Tests the mapper (severity, attributes, PII exclusion), the gated forwarder
 where AnalyticsTracker._emit() feeds the DatadogForwarder.
 """
 
+import threading
+import time
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -450,7 +452,7 @@ class TestDatadogForwarder:
     )
     def test_forward_builds_entry_and_records(self):
         reset_datadog_forwarder()
-        fwd = DatadogForwarder()
+        fwd = DatadogForwarder(capture_payloads=True)
         with patch.object(fwd, "_post"):
             event = _make_event("tool_call", tool_name="query_traces", success=True, duration_ms=100)
             entry = fwd.forward(event)
@@ -458,6 +460,20 @@ class TestDatadogForwarder:
             assert entry["status"] == "info"
             assert entry["service"] == "test-mcp"
             assert len(fwd.get_forwarded_payloads()) == 1
+
+    @patch.dict(
+        "os.environ",
+        {
+            "MCP_DATADOG_FORWARD": "true",
+            "DD_API_KEY": "testkey",
+        },
+        clear=False,
+    )
+    def test_production_forwarder_does_not_retain_payload_history(self):
+        fwd = DatadogForwarder()
+        with patch.object(fwd, "_post"):
+            assert fwd.forward(_make_event("tool_call", tool_name="x", success=True))
+            assert fwd.get_forwarded_payloads() == []
 
     @patch.dict(
         "os.environ",
@@ -481,12 +497,49 @@ class TestDatadogForwarder:
     )
     def test_clear_forwarded_payloads(self):
         reset_datadog_forwarder()
-        fwd = DatadogForwarder()
+        fwd = DatadogForwarder(capture_payloads=True)
         with patch.object(fwd, "_post"):
             fwd.forward(_make_event("tool_call", tool_name="x", success=True))
             assert len(fwd.get_forwarded_payloads()) == 1
             fwd.clear_forwarded_payloads()
             assert fwd.get_forwarded_payloads() == []
+
+    @patch.dict(
+        "os.environ",
+        {"MCP_DATADOG_FORWARD": "true", "DD_API_KEY": "testkey"},
+        clear=False,
+    )
+    def test_live_queue_is_non_blocking_and_memory_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            "wandb_mcp_server.analytics_datadog.MCP_ANALYTICS_QUEUE_CAPACITY",
+            2,
+        )
+        monkeypatch.setattr(
+            "wandb_mcp_server.analytics_datadog.MCP_ANALYTICS_TEST_BUFFER_CAPACITY",
+            2,
+        )
+        fwd = DatadogForwarder(capture_payloads=True)
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_post(_entry):
+            started.set()
+            release.wait(timeout=2)
+
+        monkeypatch.setattr(fwd, "_post", blocked_post)
+        event = _make_event("tool_call", tool_name="query_wandb_tool", success=True)
+        fwd.forward(event)
+        assert started.wait(timeout=1)
+        fwd.forward(event)
+        before = time.monotonic()
+        fwd.forward(event)
+
+        assert time.monotonic() - before < 0.1
+        assert fwd._executor.outstanding_count <= 2
+        assert fwd.dropped_count == 1
+        assert len(fwd.get_forwarded_payloads()) == 2
+        release.set()
+        fwd._executor.shutdown(wait=True)
 
 
 # ---------------------------------------------------------------------------
@@ -590,6 +643,25 @@ class TestSingleton:
         b = get_datadog_forwarder()
         assert a is not b
 
+    @patch.dict("os.environ", {"MCP_DATADOG_FORWARD": "false"}, clear=False)
+    def test_concurrent_initialization_returns_one_instance(self):
+        reset_datadog_forwarder()
+        barrier = threading.Barrier(8)
+        results = []
+
+        def resolve() -> None:
+            barrier.wait()
+            results.append(get_datadog_forwarder())
+
+        threads = [threading.Thread(target=resolve) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=1)
+
+        assert len(results) == 8
+        assert len({id(result) for result in results}) == 1
+
 
 # ---------------------------------------------------------------------------
 # E2E: AnalyticsTracker -> DatadogForwarder
@@ -614,7 +686,7 @@ class TestE2ETrackerToDatadog:
     def test_tool_call_reaches_datadog(self):
         reset_datadog_forwarder()
         reset_analytics_tracker()
-        fwd = get_datadog_forwarder()
+        fwd = get_datadog_forwarder(capture_payloads=True)
         with patch.object(fwd, "_post"):
             tracker = AnalyticsTracker(enabled=True)
             tracker.track_tool_call(
@@ -645,7 +717,7 @@ class TestE2ETrackerToDatadog:
     def test_failed_tool_call_reaches_datadog_as_error(self):
         reset_datadog_forwarder()
         reset_analytics_tracker()
-        fwd = get_datadog_forwarder()
+        fwd = get_datadog_forwarder(capture_payloads=True)
         with patch.object(fwd, "_post"):
             tracker = AnalyticsTracker(enabled=True)
             tracker.track_tool_call(
@@ -675,7 +747,7 @@ class TestE2ETrackerToDatadog:
     def test_request_500_reaches_datadog_as_error(self):
         reset_datadog_forwarder()
         reset_analytics_tracker()
-        fwd = get_datadog_forwarder()
+        fwd = get_datadog_forwarder(capture_payloads=True)
         with patch.object(fwd, "_post"):
             tracker = AnalyticsTracker(enabled=True)
             tracker.track_request(

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -48,6 +48,7 @@ def _enable_analytics(monkeypatch):
     reset_analytics_tracker()
     reset_segment_forwarder()
     reset_datadog_forwarder()
+    get_datadog_forwarder(capture_payloads=True)
     yield api_key
     WandBApiManager.reset_context_api_key(token)
 

--- a/tests/test_analytics_segment.py
+++ b/tests/test_analytics_segment.py
@@ -6,6 +6,7 @@ AnalyticsTracker._emit() automatically feeds the SegmentForwarder.
 """
 
 import time
+import threading
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -284,6 +285,56 @@ class TestSegmentForwarder:
         f.clear_forwarded_payloads()
         assert len(f.get_forwarded_payloads()) == 0
 
+    @patch.dict("os.environ", {"MCP_SEGMENT_FORWARD": "true"})
+    def test_live_queue_is_non_blocking_and_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            "wandb_mcp_server.analytics_segment.MCP_ANALYTICS_QUEUE_CAPACITY",
+            2,
+        )
+        f = SegmentForwarder(base_url="https://api.wandb.test")
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocked_post(_payload):
+            started.set()
+            release.wait(timeout=2)
+
+        monkeypatch.setattr(f, "_post", blocked_post)
+        event = {
+            "event_type": "tool_call",
+            "user_id": "actor",
+            "tool_name": "query_wandb_tool",
+        }
+        f.forward(event)
+        assert started.wait(timeout=1)
+        f.forward(event)
+        before = time.monotonic()
+        f.forward(event)
+
+        assert time.monotonic() - before < 0.1
+        assert f._executor.outstanding_count <= 2
+        assert f.dropped_count == 1
+        release.set()
+        f._executor.shutdown(wait=True)
+
+    @patch.dict("os.environ", {"MCP_SEGMENT_DRY_RUN": "true"})
+    def test_test_payload_history_is_bounded(self, monkeypatch):
+        monkeypatch.setattr(
+            "wandb_mcp_server.analytics_segment.MCP_ANALYTICS_TEST_BUFFER_CAPACITY",
+            2,
+        )
+        f = SegmentForwarder()
+        for index in range(3):
+            f.forward(
+                {
+                    "event_type": "tool_call",
+                    "user_id": "actor",
+                    "tool_name": f"tool-{index}",
+                }
+            )
+
+        assert len(f.get_forwarded_payloads()) == 2
+
 
 # ---------------------------------------------------------------------------
 # Singleton lifecycle
@@ -298,6 +349,32 @@ class TestSingleton:
         f1 = get_segment_forwarder()
         reset_segment_forwarder()
         assert get_segment_forwarder() is not f1
+
+    def test_concurrent_initialization_returns_one_instance(self):
+        barrier = threading.Barrier(8)
+        results = []
+
+        def resolve() -> None:
+            barrier.wait()
+            results.append(get_segment_forwarder())
+
+        threads = [threading.Thread(target=resolve) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=1)
+
+        assert len(results) == 8
+        assert len({id(result) for result in results}) == 1
+
+
+def test_segment_session_does_not_retry_wandb_overload() -> None:
+    session = __import__(
+        "wandb_mcp_server.analytics_segment",
+        fromlist=["_build_retry_session"],
+    )._build_retry_session()
+
+    assert session.get_adapter("https://").max_retries.total == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 import threading
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from wandb_mcp_server import api_client
-from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.api_client import (
+    WandBApiManager,
+    wandb_server_busy_from_exception,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -107,3 +112,47 @@ def test_get_api_initializes_different_actors_concurrently(monkeypatch) -> None:
         second = pool.submit(WandBApiManager.get_api, "second-actor-key")
 
     assert first.result() is not second.result()
+
+
+def _http_error(status_code: int, *, body: str = "", retry_after: str | None = None):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body.encode()
+    if retry_after is not None:
+        response.headers["Retry-After"] = retry_after
+    return requests.HTTPError(f"{status_code} {body}", response=response)
+
+
+def test_rate_limit_maps_to_bounded_retryable_server_busy() -> None:
+    busy = wandb_server_busy_from_exception(_http_error(429, body="Too many requests", retry_after="120"))
+
+    assert busy is not None
+    assert busy.status_code == 429
+    assert busy.as_dict() == {
+        "error": "server_busy",
+        "message": "The W&B service is busy; retry this tool call.",
+        "retryable": True,
+        "retry_after_ms": 60_000,
+    }
+
+
+def test_overload_service_unavailable_maps_to_server_busy() -> None:
+    busy = wandb_server_busy_from_exception(_http_error(503, body="Service unavailable: capacity exhausted"))
+
+    assert busy is not None
+    assert busy.status_code == 503
+    assert busy.retry_after_ms == 1_000
+
+
+def test_unrelated_503_is_not_misclassified_as_capacity() -> None:
+    assert wandb_server_busy_from_exception(_http_error(503, body="upstream certificate validation failed")) is None
+
+
+def test_runtime_release_does_not_add_deferred_core_workload_header() -> None:
+    package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
+    application_source = "\n".join(
+        path.read_text() for path in package_root.rglob("*.py") if "__pycache__" not in path.parts
+    )
+
+    assert "X-WandB-Workload" not in application_source
+    assert "GORILLA_MCP_" not in application_source

--- a/tests/test_error_sanitizer.py
+++ b/tests/test_error_sanitizer.py
@@ -1,0 +1,180 @@
+"""Infrastructure and credential canaries stay out of every output boundary."""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from wandb_mcp_server.analytics import _prepare_event
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.error_sanitizer import (
+    MAX_EXTERNAL_ERROR_CHARS,
+    sanitize_sensitive_text,
+    sanitize_sensitive_value,
+)
+from wandb_mcp_server.instrumented_server import InstrumentedFastMCP
+from wandb_mcp_server.utils import _SensitiveDataFilter
+
+INTERNAL_URL = "http://wandb-api.default.svc.cluster.local:8081/graphql"
+SECRET = "test-secret-api-key-123456"
+
+
+@pytest.fixture(autouse=True)
+def _canaries(monkeypatch):
+    monkeypatch.setenv(
+        "WANDB_INTERNAL_BASE_URL",
+        "http://wandb-api.default.svc.cluster.local:8081",
+    )
+    monkeypatch.setenv("WANDB_API_KEY", SECRET)
+
+
+def _assert_canaries_absent(value: object) -> None:
+    rendered = str(value)
+    assert INTERNAL_URL not in rendered
+    assert "wandb-api.default.svc.cluster.local" not in rendered
+    assert SECRET not in rendered
+
+
+def test_sanitizes_nested_cyclic_and_credential_values() -> None:
+    value: dict[str, object] = {
+        "error": f"POST {INTERNAL_URL} Authorization: Bearer {SECRET}",
+        "secret": SECRET,
+    }
+    value["cycle"] = value
+
+    sanitized = sanitize_sensitive_value(value)
+
+    _assert_canaries_absent(sanitized)
+    assert sanitized["cycle"] == "<cyclic value>"
+
+
+def test_log_filter_sanitizes_message_arguments_and_exception() -> None:
+    try:
+        raise RuntimeError(f"upstream {INTERNAL_URL} api_key={SECRET}")
+    except RuntimeError:
+        record = logging.LogRecord(
+            "test",
+            logging.ERROR,
+            __file__,
+            1,
+            "failed %s",
+            (INTERNAL_URL,),
+            __import__("sys").exc_info(),
+        )
+
+    assert _SensitiveDataFilter().filter(record)
+    _assert_canaries_absent(record.getMessage())
+    _assert_canaries_absent(record._wandb_mcp_sanitized_exc_info)
+    assert record.exc_info is None
+
+
+def test_analytics_preparation_sanitizes_before_forwarding() -> None:
+    event = _prepare_event(
+        {
+            "schema_version": "1.1",
+            "event_type": "tool_call",
+            "error": f"upstream {INTERNAL_URL}",
+            "usage_dimensions": {"token": SECRET},
+        }
+    )
+
+    _assert_canaries_absent(event)
+
+
+@pytest.mark.asyncio
+async def test_public_tool_result_is_sanitized(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = InstrumentedFastMCP("sanitizer-test")
+
+    @server.tool(name="list_entities_tool")
+    def leaking_tool() -> dict[str, str]:
+        return {
+            "error": "upstream_error",
+            "message": f"{INTERNAL_URL} Bearer {SECRET}",
+        }
+
+    result = await server.call_tool("list_entities_tool", {})
+
+    _assert_canaries_absent(result)
+    assert "<internal W&B API>" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_oversized_structured_tool_error_is_bounded(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = InstrumentedFastMCP("bounded-error-test")
+
+    @server.tool(name="list_entities_tool")
+    def oversized_error() -> dict[str, str]:
+        return {
+            "error": "upstream_error",
+            "message": f"{SECRET}{'x' * (MAX_EXTERNAL_ERROR_CHARS * 3)}",
+        }
+
+    result = await server.call_tool("list_entities_tool", {})
+
+    _assert_canaries_absent(result)
+    assert len(str(result)) <= MAX_EXTERNAL_ERROR_CHARS
+    assert "details_truncated" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_raised_tool_error_is_sanitized(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = InstrumentedFastMCP("sanitizer-error-test")
+
+    @server.tool(name="list_entities_tool")
+    def leaking_tool() -> None:
+        raise ToolError(f"upstream {INTERNAL_URL} api_key={SECRET}")
+
+    with pytest.raises(ToolError) as caught:
+        await server.call_tool("list_entities_tool", {})
+
+    _assert_canaries_absent(caught.value)
+    assert "<internal W&B API>" in str(caught.value)
+
+
+def test_request_context_api_key_is_sanitized_without_environment(monkeypatch) -> None:
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    token = WandBApiManager.set_context_api_key(SECRET)
+    try:
+        sanitized = sanitize_sensitive_text(f"upstream echoed {SECRET}")
+    finally:
+        WandBApiManager.reset_context_api_key(token)
+
+    _assert_canaries_absent(sanitized)
+
+
+def test_sanitizes_internal_host_without_url_scheme() -> None:
+    sanitized = sanitize_sensitive_text("dial wandb-api.default.svc.cluster.local:8081 failed")
+
+    _assert_canaries_absent(sanitized)
+
+
+def test_sanitizes_basic_auth_and_binary_error_payloads(monkeypatch) -> None:
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    encoded = base64.b64encode(f":{SECRET}".encode()).decode()
+    token = WandBApiManager.set_context_api_key(SECRET)
+    try:
+        sanitized = sanitize_sensitive_value(
+            {
+                "message": f"Authorization: Basic {encoded}".encode(),
+                "detail": f"api_key={SECRET}".encode(),
+            }
+        )
+    finally:
+        WandBApiManager.reset_context_api_key(token)
+
+    _assert_canaries_absent(sanitized)
+    assert encoded not in str(sanitized)
+
+
+def test_external_error_text_is_bounded_after_redaction() -> None:
+    sanitized = sanitize_sensitive_value({"error": f"{SECRET}{'x' * (MAX_EXTERNAL_ERROR_CHARS * 2)}"})
+
+    _assert_canaries_absent(sanitized)
+    assert "<truncated" in sanitized["error"]
+    assert len(sanitized["error"]) < MAX_EXTERNAL_ERROR_CHARS + 100

--- a/tests/test_latency_optimization.py
+++ b/tests/test_latency_optimization.py
@@ -70,7 +70,7 @@ class TestErrorFormatStandardization:
     """Verify tools return JSON errors, not plain strings."""
 
     @patch("wandb_mcp_server.mcp_tools.count_traces.WandBApiManager")
-    @patch("wandb_mcp_server.mcp_tools.count_traces.get_retry_session")
+    @patch("wandb_mcp_server.mcp_tools.count_traces.get_no_retry_session")
     def test_count_traces_error_returns_json(self, mock_session, mock_api_mgr):
         mock_api_mgr.get_api_key.return_value = "test-key-1234567890123456789012345678"
         mock_session.return_value.post.side_effect = Exception("Connection refused")

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -308,6 +308,7 @@ async def test_public_query_tools_run_sync_sdk_work_off_event_loop(fake_api, mon
 @pytest.mark.asyncio
 async def test_public_mcp_dispatch_enforces_hosted_summary_limit(monkeypatch):
     monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
     monkeypatch.setattr(sdk_query, "MCP_HOSTED_MODE", True)
     monkeypatch.setattr(
         sdk_query.WandBApiManager,

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,202 @@
+"""Runtime safety configuration must fail closed during process startup."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+_LOAD_CONFIG = "import runpy; runpy.run_path('src/wandb_mcp_server/config.py')"
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "MAX_RESPONSE_TOKENS",
+        "MAX_ACCUMULATED_BYTES",
+        "MCP_TOOL_TIMEOUT_SECONDS",
+        "MCP_WANDB_REQUEST_TIMEOUT_SECONDS",
+        "MCP_ADMISSION_ACTOR_CAPACITY",
+        "MCP_ADMISSION_PROCESS_CAPACITY",
+        "MCP_MAX_QUERY_LIMIT",
+        "MCP_MAX_FULL_TRACE_LIMIT",
+        "MCP_MAX_HISTORY_SAMPLES",
+        "MCP_MAX_HISTORY_KEYS",
+        "MCP_MAX_HISTORY_RANGE_STEPS",
+        "MCP_MAX_WANDB_QUERY_ITEMS",
+        "MCP_MAX_FULL_DETAIL_ITEMS",
+        "MCP_MAX_PROJECT_FIELDS",
+        "MCP_MAX_PROBE_RUNS",
+        "MCP_MAX_EVALUATION_ROWS",
+        "MCP_MAX_SCHEMA_SAMPLE_ROWS",
+        "MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE",
+        "MCP_MAX_GQL_ITEMS",
+        "MCP_MAX_GQL_ITEMS_PER_PAGE",
+        "MCP_SYNC_TOOL_WORKERS",
+        "MCP_COUNT_TOOL_WORKERS",
+        "MCP_ANALYTICS_QUEUE_CAPACITY",
+        "MCP_ANALYTICS_TEST_BUFFER_CAPACITY",
+        "SESSION_TTL_SECONDS",
+        "MAX_SESSIONS_PER_KEY",
+    ],
+)
+def test_positive_runtime_bounds_reject_zero_with_variable_name(variable: str) -> None:
+    environment = os.environ.copy()
+    environment[variable] = "0"
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert variable in result.stderr
+
+
+@pytest.mark.parametrize("value", ["-0.1", "1.1", "nan", "inf", "invalid"])
+def test_sampling_rate_rejects_invalid_values(value: str) -> None:
+    environment = os.environ.copy()
+    environment["MCP_REQUEST_SUCCESS_SAMPLE_RATE"] = value
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "MCP_REQUEST_SUCCESS_SAMPLE_RATE" in result.stderr
+
+
+def test_admission_wait_allows_zero_but_rejects_negative() -> None:
+    environment = os.environ.copy()
+    environment["MCP_ADMISSION_WAIT_MS"] = "-1"
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "MCP_ADMISSION_WAIT_MS" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "worker_variable",
+    ["MCP_SYNC_TOOL_WORKERS", "MCP_COUNT_TOOL_WORKERS"],
+)
+def test_worker_pool_cannot_exceed_process_admission_capacity(worker_variable: str) -> None:
+    environment = os.environ.copy()
+    environment["MCP_ADMISSION_ACTOR_CAPACITY"] = "4"
+    environment["MCP_ADMISSION_PROCESS_CAPACITY"] = "4"
+    environment["MCP_SYNC_TOOL_WORKERS"] = "4"
+    environment["MCP_COUNT_TOOL_WORKERS"] = "4"
+    environment[worker_variable] = "5"
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert worker_variable in result.stderr
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "MCP_HOSTED_MODE",
+        "MCP_ADMISSION_CONTROL_ENABLED",
+        "WANDB_MCP_ENABLE_WEAVE_TOOLS",
+        "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
+        "WANDB_MCP_READ_ONLY",
+        "WANDB_MCP_ENABLE_RAW_GRAPHQL",
+        "MCP_SERVER_ENABLE_HMAC_SHA256_SESSIONS",
+    ],
+)
+def test_runtime_booleans_reject_typos(variable: str) -> None:
+    environment = os.environ.copy()
+    environment[variable] = "treu"
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert variable in result.stderr
+
+
+@pytest.mark.parametrize(
+    "variable",
+    ["MCP_ADMISSION_ACTOR_CAPACITY", "MCP_ADMISSION_PROCESS_CAPACITY"],
+)
+def test_enabled_admission_requires_capacity_for_heavy_tools(variable: str) -> None:
+    environment = os.environ.copy()
+    environment["MCP_ADMISSION_CONTROL_ENABLED"] = "true"
+    environment["MCP_ADMISSION_ACTOR_CAPACITY"] = "3" if variable == "MCP_ADMISSION_ACTOR_CAPACITY" else "4"
+    environment["MCP_ADMISSION_PROCESS_CAPACITY"] = "3" if variable == "MCP_ADMISSION_PROCESS_CAPACITY" else "4"
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert variable in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("variable", "value"),
+    [
+        ("MAX_RESPONSE_TOKENS", "100001"),
+        ("MAX_ACCUMULATED_BYTES", str(1024 * 1024 * 1024 + 1)),
+        ("MCP_TOOL_TIMEOUT_SECONDS", "301"),
+        ("MCP_WANDB_REQUEST_TIMEOUT_SECONDS", "121"),
+        ("MCP_ADMISSION_PROCESS_CAPACITY", "65"),
+        ("MCP_ADMISSION_WAIT_MS", "30001"),
+        ("MCP_MAX_WANDB_QUERY_ITEMS", "10001"),
+        ("MCP_MAX_GQL_ITEMS", "1001"),
+        ("MCP_MAX_GQL_ITEMS_PER_PAGE", "201"),
+        ("MCP_SYNC_TOOL_WORKERS", "17"),
+        ("MCP_COUNT_TOOL_WORKERS", "17"),
+        ("MCP_ANALYTICS_QUEUE_CAPACITY", "257"),
+        ("MCP_ANALYTICS_TEST_BUFFER_CAPACITY", "1001"),
+        ("SESSION_TTL_SECONDS", "86401"),
+        ("MAX_SESSIONS_PER_KEY", "1001"),
+    ],
+)
+def test_runtime_bounds_reject_oversized_values(variable: str, value: str) -> None:
+    environment = os.environ.copy()
+    environment[variable] = value
+    result = subprocess.run(
+        [sys.executable, "-c", _LOAD_CONFIG],
+        cwd=Path(__file__).parents[1],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert variable in result.stderr

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,8 +1,11 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
 import simple_parsing
 
 from wandb_mcp_server import server
+from wandb_mcp_server.api_client import WandBApiManager
 
 
 class _DummyMCPServer:
@@ -34,3 +37,144 @@ def test_cli_runs_stdio_transport(monkeypatch):
     server.cli()
 
     assert dummy_server.run_transport == "stdio"
+
+
+def test_standalone_http_requires_explicit_auth_disable(monkeypatch):
+    monkeypatch.delenv("MCP_AUTH_DISABLED", raising=False)
+
+    with pytest.raises(ValueError, match="MCP_AUTH_DISABLED"):
+        server.create_mcp_server("http", host="127.0.0.1")
+
+
+def test_standalone_http_refuses_non_loopback_binding(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+
+    with pytest.raises(ValueError, match="loopback"):
+        server.create_mcp_server("http", host="0.0.0.0")
+
+
+def test_standalone_http_allows_explicit_loopback_development(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+
+    mcp = server.create_mcp_server("http", host="::1")
+
+    assert mcp.settings.host == "::1"
+
+
+def test_standalone_http_normalizes_localhost_to_literal_loopback(monkeypatch):
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+
+    mcp = server.create_mcp_server("http", host="localhost")
+
+    assert mcp.settings.host == "127.0.0.1"
+
+
+def test_cli_rejects_unsafe_http_before_network_initialization(monkeypatch):
+    validate_api_key = MagicMock()
+    initialize_weave = MagicMock()
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+    monkeypatch.setattr(
+        simple_parsing,
+        "parse",
+        lambda _: SimpleNamespace(
+            transport="http",
+            host="0.0.0.0",
+            port=8080,
+            wandb_api_key="test-key",
+        ),
+    )
+    monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
+    monkeypatch.setattr(server, "validate_api_key", validate_api_key)
+    monkeypatch.setattr(server, "initialize_weave_tracing", initialize_weave)
+
+    with pytest.raises(ValueError, match="loopback"):
+        server.cli()
+
+    validate_api_key.assert_not_called()
+    initialize_weave.assert_not_called()
+
+
+def test_standalone_http_requires_server_api_key(monkeypatch):
+    args = SimpleNamespace(
+        transport="http",
+        wandb_api_key=None,
+    )
+    monkeypatch.setattr(
+        server,
+        "get_server_args",
+        lambda: SimpleNamespace(wandb_api_key=None),
+    )
+
+    with pytest.raises(ValueError, match="standalone http"):
+        server.validate_and_get_api_key(args)
+
+
+def test_cli_sets_single_actor_context_for_loopback_http(monkeypatch):
+    dummy_server = _DummyMCPServer()
+    set_context = MagicMock()
+    reset_context = MagicMock()
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
+    monkeypatch.setattr(
+        simple_parsing,
+        "parse",
+        lambda _: SimpleNamespace(
+            transport="http",
+            host="127.0.0.1",
+            port=8080,
+            wandb_api_key="test-key",
+        ),
+    )
+    monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "validate_and_get_api_key",
+        lambda args: "test-key",
+    )
+    monkeypatch.setattr(server, "validate_api_key", lambda _: True)
+    monkeypatch.setattr(server, "initialize_weave_tracing", lambda: False)
+    monkeypatch.setattr(server, "create_mcp_server", lambda *args: dummy_server)
+    monkeypatch.setattr(WandBApiManager, "set_context_api_key", set_context)
+    monkeypatch.setattr(WandBApiManager, "reset_context_api_key", reset_context)
+
+    server.cli()
+
+    assert [entry.args for entry in set_context.call_args_list] == [
+        ("test-key",),
+        ("test-key",),
+    ]
+    reset_context.assert_called_once_with(set_context.return_value)
+    assert dummy_server.run_transport == "streamable-http"
+
+
+def test_cli_validation_context_redacts_candidate_key_and_resets_on_failure(monkeypatch):
+    candidate_key = "candidate-secret-key-123456"
+    monkeypatch.setattr(
+        simple_parsing,
+        "parse",
+        lambda _: SimpleNamespace(
+            transport="stdio",
+            host="localhost",
+            port=None,
+            wandb_api_key=candidate_key,
+        ),
+    )
+    monkeypatch.setattr(server, "configure_wandb_logging", lambda: None)
+    monkeypatch.setattr(
+        server,
+        "validate_and_get_api_key",
+        lambda args: candidate_key,
+    )
+
+    def reject_key(api_key):
+        from wandb_mcp_server.error_sanitizer import sanitize_sensitive_text
+
+        assert WandBApiManager.get_api_key() == api_key
+        assert api_key not in sanitize_sensitive_text(f"upstream echoed {api_key}")
+        return False
+
+    monkeypatch.setattr(server, "validate_api_key", reject_key)
+
+    with pytest.raises(ValueError, match="validation failed"):
+        server.cli()
+
+    assert WandBApiManager.get_api_key() is None

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -9,6 +9,10 @@ Tests cover:
 """
 
 import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
@@ -713,24 +717,28 @@ class TestSessionTTLAndRequests:
 
 
 class TestSessionEnvVarValidation:
-    def test_invalid_ttl_raises_clear_error(self):
-        with patch.dict("os.environ", {"SESSION_TTL_SECONDS": "30m"}):
-            from wandb_mcp_server.session_manager import reset_session_manager
+    @pytest.mark.parametrize(
+        ("variable", "value"),
+        [
+            ("SESSION_TTL_SECONDS", "30m"),
+            ("MAX_SESSIONS_PER_KEY", ""),
+        ],
+    )
+    def test_invalid_session_capacity_fails_at_startup(self, variable: str, value: str):
+        environment = os.environ.copy()
+        environment[variable] = value
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import runpy; runpy.run_path('src/wandb_mcp_server/config.py')",
+            ],
+            cwd=Path(__file__).parents[1],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-            reset_session_manager()
-            with pytest.raises(ValueError, match="SESSION_TTL_SECONDS must be an integer"):
-                from wandb_mcp_server.session_manager import get_session_manager
-
-                get_session_manager()
-            reset_session_manager()
-
-    def test_invalid_max_sessions_raises_clear_error(self):
-        with patch.dict("os.environ", {"MAX_SESSIONS_PER_KEY": ""}):
-            from wandb_mcp_server.session_manager import reset_session_manager
-
-            reset_session_manager()
-            with pytest.raises(ValueError, match="MAX_SESSIONS_PER_KEY must be an integer"):
-                from wandb_mcp_server.session_manager import get_session_manager
-
-                get_session_manager()
-            reset_session_manager()
+        assert result.returncode != 0
+        assert variable in result.stderr

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -199,6 +199,7 @@ def test_constructed_servers_use_public_boundary_instrumentation(monkeypatch):
     assert isinstance(stdio, InstrumentedFastMCP)
     assert analytics._resolve_transport() == "stdio"
 
+    monkeypatch.setenv("MCP_AUTH_DISABLED", "true")
     http = create_mcp_server("http")
     assert isinstance(http, InstrumentedFastMCP)
     assert analytics._resolve_transport() == "http"

--- a/tests/test_weave_api.py
+++ b/tests/test_weave_api.py
@@ -266,7 +266,7 @@ class TestWeaveApiClient(unittest.TestCase):
     def test_init_with_explicit_key(self):
         client = WeaveApiClient(api_key="test_key_12345")
         assert client.api_key == "test_key_12345"
-        assert client.retries == 3
+        assert client.retries == 0
         assert client.timeout == WeaveApiClient.DEFAULT_TIMEOUT
 
     def test_init_without_key_raises(self):
@@ -313,27 +313,28 @@ class TestWeaveApiClient(unittest.TestCase):
         with pytest.raises(Exception, match="Failed to query Weave traces"):
             list(client.query_traces({"project_id": "entity/project"}))
 
-    def test_retry_adapter_mounted(self):
-        """Verify retry adapter is mounted on the session for https and http."""
+    def test_functional_queries_never_mount_retry_adapter(self):
+        """Functional trace calls leave retry policy with the MCP caller."""
         client = WeaveApiClient(api_key="test_key")
         https_adapter = client.session.get_adapter("https://trace.wandb.ai")
         http_adapter = client.session.get_adapter("http://localhost:8080")
-        assert https_adapter.max_retries.total == 3
-        assert 429 in https_adapter.max_retries.status_forcelist
-        assert 503 in https_adapter.max_retries.status_forcelist
-        assert http_adapter.max_retries.total == 3
+        assert https_adapter.max_retries.total == 0
+        assert not https_adapter.max_retries.status_forcelist
+        assert http_adapter.max_retries.total == 0
 
     def test_custom_retries_and_timeout(self):
-        """Verify custom retries and timeout are applied."""
+        """Legacy retry input cannot re-enable amplification."""
         client = WeaveApiClient(api_key="test_key", retries=5, timeout=60)
         assert client.timeout == 60
+        assert client.retries == 0
         adapter = client.session.get_adapter("https://trace.wandb.ai")
-        assert adapter.max_retries.total == 5
+        assert adapter.max_retries.total == 0
 
-    def test_no_retry_on_client_error_status(self):
-        """Status codes like 400 should not be in the retry list."""
+    def test_no_status_code_is_retried(self):
         client = WeaveApiClient(api_key="test_key")
         adapter = client.session.get_adapter("https://trace.wandb.ai")
+        assert 429 not in adapter.max_retries.status_forcelist
+        assert 503 not in adapter.max_retries.status_forcelist
         assert 400 not in adapter.max_retries.status_forcelist
         assert 401 not in adapter.max_retries.status_forcelist
         assert 404 not in adapter.max_retries.status_forcelist

--- a/tests/test_weave_retry_safety.py
+++ b/tests/test_weave_retry_safety.py
@@ -1,0 +1,162 @@
+"""Regression tests for non-amplifying functional Weave requests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import threading
+from typing import Iterator
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from wandb_mcp_server.api_client import WandBApiManager, wandb_server_busy_from_exception
+from wandb_mcp_server.mcp_tools import count_traces as count_module
+from wandb_mcp_server.server import create_mcp_server
+from wandb_mcp_server.weave_api.client import WeaveApiClient
+
+
+@contextmanager
+def _overloaded_weave_server(
+    *,
+    status_code: int,
+    retry_after: str,
+    body: bytes,
+) -> Iterator[tuple[str, list[str]]]:
+    attempts: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - stdlib callback name
+            attempts.append(self.path)
+            self.send_response(status_code)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Retry-After", retry_after)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", attempts
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_trace_query_attempts_once_and_preserves_retry_after() -> None:
+    with _overloaded_weave_server(
+        status_code=429,
+        retry_after="7",
+        body=b"Too many requests",
+    ) as (server_url, attempts):
+        client = WeaveApiClient(
+            api_key="test-key",
+            server_url=server_url,
+            retries=99,
+        )
+
+        with pytest.raises(Exception) as caught:
+            list(client.query_traces({"project_id": "entity/project"}))
+
+    busy = wandb_server_busy_from_exception(caught.value)
+    assert attempts == ["/calls/stream_query"]
+    assert busy is not None
+    assert busy.status_code == 429
+    assert busy.retry_after_ms == 7_000
+    assert busy.as_dict() == {
+        "error": "server_busy",
+        "message": "The W&B service is busy; retry this tool call.",
+        "retryable": True,
+        "retry_after_ms": 7_000,
+    }
+
+
+def test_trace_count_attempts_once_and_preserves_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    with _overloaded_weave_server(
+        status_code=503,
+        retry_after="4",
+        body=b"Service unavailable: capacity exhausted",
+    ) as (server_url, attempts):
+        monkeypatch.setattr(count_module.WandBApiManager, "get_api_key", lambda: "test-key")
+        monkeypatch.setattr(count_module.WandBApiManager, "get_api", lambda: object())
+        monkeypatch.setattr("wandb_mcp_server.config.WF_TRACE_SERVER_URL", server_url)
+
+        with pytest.raises(Exception) as caught:
+            count_module.count_traces("entity", "project")
+
+    busy = wandb_server_busy_from_exception(caught.value)
+    assert attempts == ["/calls/query_stats"]
+    assert busy is not None
+    assert busy.status_code == 503
+    assert busy.retry_after_ms == 4_000
+    assert busy.as_dict() == {
+        "error": "server_busy",
+        "message": "The W&B service is busy; retry this tool call.",
+        "retryable": True,
+        "retry_after_ms": 4_000,
+    }
+
+
+def test_trace_count_default_uses_validated_wandb_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, int]:
+            return {"count": 3}
+
+    class Session:
+        @staticmethod
+        def post(url: str, **kwargs: object) -> Response:
+            captured["url"] = url
+            captured.update(kwargs)
+            return Response()
+
+    monkeypatch.setattr(count_module.WandBApiManager, "get_api_key", lambda: "test-key")
+    monkeypatch.setattr(count_module.WandBApiManager, "get_api", lambda: object())
+    monkeypatch.setattr(count_module, "get_no_retry_session", lambda: Session())
+
+    assert count_module.count_traces("entity", "project") == 3
+    assert captured["timeout"] == count_module.MCP_WANDB_REQUEST_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_trace_query_preflight_stops_after_one_overloaded_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    with _overloaded_weave_server(
+        status_code=429,
+        retry_after="7",
+        body=b"Too many requests",
+    ) as (server_url, attempts):
+        monkeypatch.setattr(count_module.WandBApiManager, "get_api", lambda: object())
+        monkeypatch.setattr("wandb_mcp_server.config.WF_TRACE_SERVER_URL", server_url)
+        token = WandBApiManager.set_context_api_key("test-key")
+        mcp = create_mcp_server("stdio")
+        try:
+            with pytest.raises(ToolError) as caught:
+                await mcp.call_tool(
+                    "query_weave_traces_tool",
+                    {
+                        "entity_name": "entity",
+                        "project_name": "project",
+                        "limit": 101,
+                    },
+                )
+        finally:
+            WandBApiManager.reset_context_api_key(token)
+            mcp.shutdown_sync_executor()
+
+    assert attempts == ["/calls/query_stats"]
+    assert '"error": "server_busy"' in str(caught.value)
+    assert '"retry_after_ms": 7000' in str(caught.value)


### PR DESCRIPTION
## Summary

Hardens the v0.4 runtime boundary before release PR #117 is approved.

- Retains hosted admission permits after a timed-out or cancelled synchronous call until the physical worker exits, and uses a bounded worker pool so replacement calls cannot exceed real concurrency.
- Replaces unbounded Segment and Datadog executor queues with non-blocking bounded queues (maximum 256 events), bounded test-only capture buffers, and bounded drop counters while preserving the canonical local analytics log.
- Applies one sanitizer to tool results, raised errors, logs, and analytics so credentials, internal URLs, and Kubernetes `.svc` hosts cannot escape.
- Maps upstream 429 and overload-related 503 responses to retryable `server_busy`, honors bounded `Retry-After`, and removes automatic retry amplification. Write timeout/overload returns non-retryable `outcome_unknown` because commit state cannot be proven safely.
- Validates capacities, deadlines, pagination and response limits, queue sizes, worker counts, booleans, and sampling rates at startup with exact environment-variable names.
- Makes standalone `--transport http` development-only: it requires `MCP_AUTH_DISABLED=true`, loopback binding, and a single server API key. Hosted and Helm remain the production HTTP surfaces.
- Preserves local STDIO behavior: synchronous work stays off the event loop without enabling hosted admission/deadlines by default.

No workload header, Core dependency, new tool, tool signature, or response-shape change is included.

## Integration status

Query hardening PR #128 merged into `staging/0.4.0` as `f184ccca8c74947a72a837ef8f3ee2b862adfe72`. This branch merged that exact staging commit without conflicts and retains cursor/query compatibility plus the runtime safety boundary. Current head: `1debf61b0bca3866b2d35465d53ede9272ae6c3a`.

## Validation

- Combined focused query/runtime suite: `349 passed`
- Earlier full non-integration suite on Python 3.11: `1015 passed, 10 deselected`
- Earlier full non-integration suite on Python 3.12: `1015 passed, 10 deselected`
- Ruff check and format check: passed
- `uv lock --check`: passed
- Bandit Medium/High scan: passed
- Grype fixable High/Critical scan: no vulnerabilities found
- Wheel and sdist build: passed
- Installed-wheel STDIO harness with MCP `1.29.0`: passed
- Installed-wheel STDIO harness with minimum MCP `1.28.1`: passed

No live W&B calls or writes were performed on this branch. It is ready for the final GitHub CI pass and merge into `staging/0.4.0`; release PR #117 remains unmerged.
