### PR TITLE
fix: bound W&B report persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
             tests/test_summarize_evaluation.py \
             tests/test_infer_schema.py \
             tests/test_tool_registration.py \
+            tests/test_report_writer.py \
             tests/test_wandb_graphql.py \
             tests/test_wandb_graphql_read_only.py \
             tests/test_hosted_gql_guardrails.py \

--- a/src/wandb_mcp_server/api_client.py
+++ b/src/wandb_mcp_server/api_client.py
@@ -48,6 +48,20 @@ class WandBServerBusy(RuntimeError):
         }
 
 
+class WandBWriteOutcomeUnknown(RuntimeError):
+    """A dispatched W&B write ended without a confirmed response."""
+
+    def __init__(self) -> None:
+        super().__init__("W&B did not confirm whether the write completed.")
+
+
+class WandBReportCreationFailed(RuntimeError):
+    """A confirmed report-creation failure safe to expose at the MCP boundary."""
+
+    def __init__(self) -> None:
+        super().__init__("The W&B report could not be created.")
+
+
 def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
     pending: list[BaseException] = [exc]
     seen: set[int] = set()
@@ -64,6 +78,16 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
         ):
             if isinstance(nested, BaseException):
                 pending.append(nested)
+
+
+def wandb_write_outcome_unknown_from_exception(exc: BaseException) -> bool:
+    """Return whether an exception chain contains an unconfirmed W&B write."""
+    return any(isinstance(current, WandBWriteOutcomeUnknown) for current in _exception_chain(exc))
+
+
+def wandb_report_creation_failed_from_exception(exc: BaseException) -> bool:
+    """Return whether an exception chain contains a safe report failure."""
+    return any(isinstance(current, WandBReportCreationFailed) for current in _exception_chain(exc))
 
 
 def _retry_after_ms(value: object) -> int:

--- a/src/wandb_mcp_server/instrumented_server.py
+++ b/src/wandb_mcp_server/instrumented_server.py
@@ -24,7 +24,11 @@ from wandb_mcp_server.admission import (
     current_tool_deadline,
     tool_cost,
 )
-from wandb_mcp_server.api_client import wandb_server_busy_from_exception
+from wandb_mcp_server.api_client import (
+    wandb_report_creation_failed_from_exception,
+    wandb_write_outcome_unknown_from_exception,
+    wandb_server_busy_from_exception,
+)
 from wandb_mcp_server.config import (
     MCP_ADMISSION_ACTOR_CAPACITY,
     MCP_ADMISSION_CONTROL_ENABLED,
@@ -342,6 +346,33 @@ class InstrumentedFastMCP(FastMCP):
                     )
                 ) from exc
             except BaseException as exc:
+                if name in _NON_IDEMPOTENT_WRITE_TOOLS and wandb_write_outcome_unknown_from_exception(exc):
+                    success = False
+                    error = "outcome_unknown: W&B did not confirm the write result"
+                    raise ToolError(
+                        json.dumps(
+                            {
+                                "error": "outcome_unknown",
+                                "message": (
+                                    "W&B did not confirm whether the write completed. "
+                                    "Verify W&B state before deciding whether to retry."
+                                ),
+                                "retryable": False,
+                            }
+                        )
+                    ) from exc
+                if name == "create_wandb_report_tool" and wandb_report_creation_failed_from_exception(exc):
+                    success = False
+                    error = "report_creation_failed: W&B rejected the report write"
+                    raise ToolError(
+                        json.dumps(
+                            {
+                                "error": "report_creation_failed",
+                                "message": "The W&B report could not be created.",
+                                "retryable": False,
+                            }
+                        )
+                    ) from exc
                 if busy := wandb_server_busy_from_exception(exc):
                     success = False
                     if name in _NON_IDEMPOTENT_WRITE_TOOLS:

--- a/src/wandb_mcp_server/mcp_tools/create_report.py
+++ b/src/wandb_mcp_server/mcp_tools/create_report.py
@@ -11,11 +11,15 @@ import re
 import wandb_workspaces.reports.v2 as wr
 import wandb_workspaces.reports.v2.interface as wr_interface
 
-import wandb
-from wandb_mcp_server.api_client import raise_for_wandb_server_busy
-from wandb_mcp_server.utils import get_rich_logger
-from wandb_mcp_server.config import MCP_WANDB_REQUEST_TIMEOUT_SECONDS, WANDB_API_BASE_URL
+from wandb_mcp_server.api_client import (
+    WandBReportCreationFailed,
+    WandBWriteOutcomeUnknown,
+    raise_for_wandb_server_busy,
+)
+from wandb_mcp_server.error_sanitizer import MAX_EXTERNAL_ERROR_CHARS, sanitize_sensitive_text
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.utils import get_rich_logger
+from wandb_mcp_server.wandb_report_writer import save_report_bounded
 from wandb_mcp_server.wandb_urls import publicize_wandb_url
 
 logger = get_rich_logger(__name__)
@@ -27,21 +31,9 @@ def _get_api_from_context():
     """Patched _get_api that reads API key from request context."""
     from wandb_mcp_server.api_client import WandBApiManager
 
-    api_key = WandBApiManager.get_api_key()
-
-    if not api_key:
-        raise Exception("No W&B API key available in context")
-
-    try:
-        # Uses explicit api_key from contextvar, not singleton
-        # and points to the configured base URL
-        return wandb.Api(
-            api_key=api_key,
-            overrides={"base_url": WANDB_API_BASE_URL},
-            timeout=MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
-        )
-    except wandb.errors.UsageError as e:
-        raise Exception("Not logged in to W&B, check API key") from e
+    # The manager reads the API key from a ContextVar and returns a client
+    # configured with the resolved internal/public base URL and request timeout.
+    return WandBApiManager.get_api()
 
 
 # Patch once at import - concurrent-safe because it reads from contextvar
@@ -327,7 +319,8 @@ def create_report(
                         report.blocks.append(wr.H2("Charts"))
                     report.blocks.extend(panel_blocks)
 
-            report.save()
+            api = WandBApiManager.get_api(api_key)
+            save_report_bounded(report, api)
 
             logger.info(f"Created report: {title} (panels={len(panels or [])})")
 
@@ -335,8 +328,12 @@ def create_report(
 
         except Exception as e:
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error creating report: {e}")
-            raise Exception(f"Error creating report: {e}") from e
+            if isinstance(e, WandBWriteOutcomeUnknown):
+                logger.error("W&B did not confirm the bounded report write")
+                raise
+            safe_error = sanitize_sensitive_text(e, max_chars=MAX_EXTERNAL_ERROR_CHARS)
+            logger.error("Report creation failed after a bounded W&B write: %s", safe_error)
+            raise WandBReportCreationFailed() from e
 
 
 def _build_panel_blocks(

--- a/src/wandb_mcp_server/wandb_report_writer.py
+++ b/src/wandb_mcp_server/wandb_report_writer.py
@@ -1,0 +1,140 @@
+"""Bounded persistence for W&B Workspaces reports.
+
+``wandb_workspaces.Report.save`` currently enumerates every project in an
+entity before creating the target project.  That existence check is
+unbounded, and can exhaust the MCP tool deadline for large entities.  A
+public ``Api.project`` point lookup can establish whether creation is needed
+without requiring project-update permission for an existing project.
+
+This module intentionally owns the only application-side GraphQL mutation.
+Callers cannot provide a document or alter the selected operation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+import requests
+import wandb_workspaces.reports.v2.interface as wr_interface
+
+from wandb_mcp_server.api_client import WandBWriteOutcomeUnknown
+
+
+class WandBReportWriteError(RuntimeError):
+    """Raised when W&B does not acknowledge a report upsert."""
+
+
+def save_report_bounded(report: Any, api: Any) -> Any:
+    """Persist one Workspaces report with bounded point operations.
+
+    The supplied ``api`` is the request-scoped, centrally configured
+    ``wandb.Api``.  Its base URL, API key, and timeout therefore match every
+    other MCP W&B call. Existing projects take one lookup and one report
+    upsert; missing projects add one project-create call. No global API state
+    is changed.
+    """
+    model = report._to_model()
+
+    _ensure_project_exists(
+        api,
+        entity_name=model.project.entity_name,
+        project_name=model.project.name,
+    )
+
+    variables = {
+        "id": model.id or None,
+        "name": model.name or wr_interface.internal._generate_name(),
+        "entityName": model.project.entity_name,
+        "projectName": model.project.name,
+        "description": model.description,
+        "displayName": model.display_name,
+        "type": "runs",
+        "spec": model.spec.model_dump_json(by_alias=True, exclude_none=True),
+    }
+    result = _execute_fixed_report_upsert(api, variables)
+    report_id = _extract_report_id(result)
+    report.id = report_id
+    return report
+
+
+def _ensure_project_exists(
+    api: Any,
+    *,
+    entity_name: str,
+    project_name: str,
+) -> None:
+    """Use a bounded public point lookup, creating only on genuine absence."""
+    project = api.project(project_name, entity=entity_name)
+    try:
+        # Api.project is lazy. Accessing id performs one GET_PROJECT_GQL query.
+        project.id
+    except ValueError as exc:
+        if str(exc) != f"Project {project_name} not found":
+            # Permission, authentication, and transport failures must not be
+            # mistaken for absence. In particular, an unconditional
+            # create_project call can require ProjectUpdatePermission.
+            raise
+        api.create_project(project_name, entity_name)
+
+
+def _execute_fixed_report_upsert(api: Any, variables: Mapping[str, Any]) -> object:
+    """Run the fixed mutation through Workspaces' supported SDK adapter."""
+    try:
+        return wr_interface.execute_graphql(
+            api,
+            wr_interface.gql.upsert_view,
+            dict(variables),
+        )
+    except Exception as exc:
+        if _is_transport_outcome_uncertain(exc):
+            raise WandBWriteOutcomeUnknown() from exc
+        raise
+
+
+def _is_transport_outcome_uncertain(exc: BaseException) -> bool:
+    """Recognize transport loss after the fixed write was dispatched."""
+    uncertain_types = (
+        TimeoutError,
+        ConnectionError,
+        httpx.TimeoutException,
+        httpx.NetworkError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ConnectionError,
+    )
+    pending = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, uncertain_types):
+            return True
+        for nested in (
+            getattr(current, "exc", None),
+            getattr(current, "__cause__", None),
+            getattr(current, "__context__", None),
+        ):
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+    return False
+
+
+def _extract_report_id(result: object) -> str:
+    """Validate only the stable response field needed by ``Report.url``."""
+    if isinstance(result, Mapping):
+        upsert = result.get("upsertView")
+        if isinstance(upsert, Mapping):
+            view = upsert.get("view")
+            if isinstance(view, Mapping):
+                report_id = view.get("id")
+                if isinstance(report_id, str) and report_id:
+                    return report_id
+    # Do not include the upstream payload: it may contain customer report
+    # content or infrastructure details.
+    raise WandBReportWriteError("W&B returned an invalid report upsert response.")
+
+
+__all__ = ["WandBReportWriteError", "save_report_bounded"]

--- a/tests/test_create_report_panels.py
+++ b/tests/test_create_report_panels.py
@@ -3,6 +3,7 @@
 import importlib
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from wandb_mcp_server.mcp_tools.create_report import (
     CREATE_WANDB_REPORT_TOOL_DESCRIPTION,
@@ -411,6 +412,14 @@ class TestBuildPanelBlocks:
 
 
 class TestCreateReportWithPanels:
+    @pytest.fixture(autouse=True)
+    def _stub_bounded_report_save(self, monkeypatch):
+        monkeypatch.setattr(
+            create_report_module,
+            "save_report_bounded",
+            lambda report, api: report,
+        )
+
     @patch("wandb_mcp_server.mcp_tools.create_report.wr")
     @patch("wandb_mcp_server.api_client.WandBApiManager")
     def test_panels_none_backward_compat(self, mock_api_mgr, mock_wr):
@@ -562,7 +571,7 @@ class TestRealWorkspacesReportObjects:
             report.id = "report-id"
 
         with (
-            patch.object(create_report_module.wr.Report, "save", fake_save),
+            patch.object(create_report_module, "save_report_bounded", fake_save),
             patch("wandb_workspaces.reports.v2.interface._get_api", return_value=fake_api),
         ):
             result = create_report(

--- a/tests/test_internal_wandb_routing.py
+++ b/tests/test_internal_wandb_routing.py
@@ -130,15 +130,23 @@ def test_structured_query_never_returns_internal_sdk_links(monkeypatch) -> None:
 
 def test_backend_wandb_constructors_use_only_resolved_api_url() -> None:
     package_root = Path(query_wandb.__file__).parents[1]
-    backend_modules = (
+    constructor_modules = (
         package_root / "api_client.py",
         package_root / "server.py",
-        package_root / "mcp_tools" / "create_report.py",
         package_root / "mcp_tools" / "log_analysis.py",
         package_root / "mcp_tools" / "run_history.py",
     )
 
-    for module in backend_modules:
+    for module in constructor_modules:
         source = module.read_text()
         assert "WANDB_API_BASE_URL" in source, module
         assert "WANDB_BASE_URL" not in source, module
+
+    create_report_source = (package_root / "mcp_tools" / "create_report.py").read_text()
+    report_writer_source = (package_root / "wandb_report_writer.py").read_text()
+    assert "WandBApiManager.get_api" in create_report_source
+    assert "wandb.Api(" not in create_report_source
+    assert "WANDB_BASE_URL" not in create_report_source
+    assert "WANDB_API_BASE_URL" not in create_report_source
+    assert "WANDB_BASE_URL" not in report_writer_source
+    assert "WANDB_API_BASE_URL" not in report_writer_source

--- a/tests/test_report_improvements.py
+++ b/tests/test_report_improvements.py
@@ -2,8 +2,19 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 
+import wandb_mcp_server.mcp_tools.create_report as create_report_module
 from wandb_mcp_server.mcp_tools.create_report import _build_panel_blocks
+
+
+@pytest.fixture(autouse=True)
+def _stub_bounded_report_save(monkeypatch):
+    monkeypatch.setattr(
+        create_report_module,
+        "save_report_bounded",
+        lambda report, api: report,
+    )
 
 
 class TestSVGSupport:

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -1,0 +1,417 @@
+"""Regression tests for bounded W&B report persistence."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import wandb_workspaces.reports.v2 as wr
+import wandb_workspaces.reports.v2.interface as wr_interface
+from mcp.server.fastmcp.exceptions import ToolError
+from wandb.apis.public.api import Api
+from wandb.apis.public.projects import Project
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+
+import wandb_mcp_server.mcp_tools.create_report as create_report_module
+import wandb_mcp_server.wandb_urls as wandb_urls
+from wandb_mcp_server.api_client import (
+    WandBReportCreationFailed,
+    WandBServerBusy,
+    WandBWriteOutcomeUnknown,
+)
+from wandb_mcp_server.instrumented_server import InstrumentedFastMCP
+from wandb_mcp_server.mcp_tools.create_report import create_report
+from wandb_mcp_server.wandb_report_writer import (
+    WandBReportWriteError,
+    save_report_bounded,
+)
+
+_API_KEY = "test-api-key-that-must-not-escape"
+_INTERNAL_URL = "http://wandb-api.test.svc:8081"
+_PUBLIC_URL = "https://customer.wandb.io"
+
+
+def test_supported_sdk_and_workspaces_report_write_contract_is_available() -> None:
+    assert callable(Api.project)
+    assert callable(Api.create_project)
+    assert callable(wr_interface.execute_graphql)
+    assert callable(wr_interface.internal._generate_name)
+    assert "mutation upsertView" in wr_interface.gql.upsert_view
+
+
+class _FakeServiceApi:
+    def __init__(self, *, result=None, error: Exception | None = None) -> None:
+        self.app_url = _INTERNAL_URL
+        self.calls: list[tuple[str, dict]] = []
+        self._result = result or {"upsertView": {"view": {"id": "report-id"}}}
+        self._error = error
+
+    def execute_graphql(self, query, variables=None):
+        self.calls.append((query, dict(variables or {})))
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class _FakeApi:
+    def __init__(
+        self,
+        *,
+        result=None,
+        error: Exception | None = None,
+        project_error: Exception | None = None,
+    ) -> None:
+        self._service_api = _FakeServiceApi(result=result, error=error)
+        self.project_calls: list[tuple[str, str]] = []
+        self.create_project_calls: list[tuple[str, str]] = []
+        self._project_error = project_error
+
+    def project(self, name: str, entity: str):
+        self.project_calls.append((name, entity))
+        if self._project_error is None:
+            return SimpleNamespace(id="project-id")
+
+        error = self._project_error
+
+        class _MissingOrFailedProject:
+            @property
+            def id(self):
+                raise error
+
+        return _MissingOrFailedProject()
+
+    def create_project(self, name: str, entity: str) -> None:
+        self.create_project_calls.append((name, entity))
+
+    def projects(self, entity: str):
+        raise AssertionError(f"unbounded projects enumeration for {entity}")
+
+
+class _ProjectLookupService:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute_graphql(self, query, variables=None):
+        self.calls.append((query, dict(variables or {})))
+        if self.error is not None:
+            raise self.error
+        return {"project": None}
+
+
+class _PublicProjectLookupApi(_FakeApi):
+    """Fake API using W&B 0.28's real lazy public Project object."""
+
+    def __init__(self, *, lookup_error: Exception | None = None) -> None:
+        super().__init__()
+        self._lookup_service = _ProjectLookupService(error=lookup_error)
+
+    def project(self, name: str, entity: str):
+        self.project_calls.append((name, entity))
+        return Project(self._lookup_service, entity, name, {})
+
+
+def test_existing_project_uses_point_lookup_and_one_fixed_report_upsert(monkeypatch) -> None:
+    api = _FakeApi()
+    report = wr.Report(
+        entity="test-entity",
+        project="test-project",
+        title="Bounded Report",
+        description="description",
+        blocks=[wr.P("body")],
+    )
+    monkeypatch.setattr(wr_interface.internal, "_generate_name", lambda: "generated-name")
+
+    saved = save_report_bounded(report, api)
+
+    assert saved is report
+    assert report.id == "report-id"
+    assert api.project_calls == [("test-project", "test-entity")]
+    assert api.create_project_calls == []
+    assert len(api._service_api.calls) == 1
+    document, variables = api._service_api.calls[0]
+    assert document == wr_interface.gql.upsert_view
+    assert "mutation upsertView" in document
+    assert variables["id"] is None
+    assert variables["name"] == "generated-name"
+    assert variables["entityName"] == "test-entity"
+    assert variables["projectName"] == "test-project"
+    assert variables["displayName"] == "Bounded Report"
+    assert variables["description"] == "description"
+    assert variables["type"] == "runs"
+    assert '"blocks"' in variables["spec"]
+
+
+def test_missing_project_is_created_after_bounded_point_lookup() -> None:
+    api = _PublicProjectLookupApi()
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    save_report_bounded(report, api)
+
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == [("project", "entity")]
+    assert len(api._service_api.calls) == 1
+
+
+def test_project_lookup_failure_does_not_attempt_project_creation() -> None:
+    api = _PublicProjectLookupApi(
+        lookup_error=WandbApiFailedError("permission denied"),
+    )
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    with pytest.raises(ValueError, match="Unable to fetch project ID"):
+        save_report_bounded(report, api)
+
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert api._service_api.calls == []
+    assert len(api._lookup_service.calls) == 1
+
+
+def test_upsert_failure_is_not_retried() -> None:
+    upstream_error = RuntimeError("upstream failed")
+    api = _FakeApi(error=upstream_error)
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    with pytest.raises(RuntimeError, match="upstream failed"):
+        save_report_bounded(report, api)
+
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert len(api._service_api.calls) == 1
+
+
+def test_upsert_timeout_has_unknown_outcome_and_is_not_retried() -> None:
+    api = _FakeApi(error=TimeoutError("read timed out after dispatch"))
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    with pytest.raises(WandBWriteOutcomeUnknown):
+        save_report_bounded(report, api)
+
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert len(api._service_api.calls) == 1
+
+
+def test_project_lookup_timeout_is_not_a_write_outcome_unknown() -> None:
+    api = _FakeApi(project_error=TimeoutError("project lookup timed out"))
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    with pytest.raises(TimeoutError, match="project lookup timed out"):
+        save_report_bounded(report, api)
+
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert api._service_api.calls == []
+
+
+def test_concurrent_reports_keep_api_and_target_state_isolated() -> None:
+    api_a = _FakeApi(result={"upsertView": {"view": {"id": "report-a"}}})
+    api_b = _FakeApi(result={"upsertView": {"view": {"id": "report-b"}}})
+    report_a = wr.Report(entity="entity-a", project="project-a", title="Report A")
+    report_b = wr.Report(entity="entity-b", project="project-b", title="Report B")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(save_report_bounded, report_a, api_a)
+        future_b = executor.submit(save_report_bounded, report_b, api_b)
+        assert future_a.result() is report_a
+        assert future_b.result() is report_b
+
+    assert report_a.id == "report-a"
+    assert report_b.id == "report-b"
+    assert api_a.project_calls == [("project-a", "entity-a")]
+    assert api_b.project_calls == [("project-b", "entity-b")]
+    assert api_a._service_api.calls[0][1]["entityName"] == "entity-a"
+    assert api_a._service_api.calls[0][1]["projectName"] == "project-a"
+    assert api_b._service_api.calls[0][1]["entityName"] == "entity-b"
+    assert api_b._service_api.calls[0][1]["projectName"] == "project-b"
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        {},
+        {"upsertView": None},
+        {"upsertView": {"view": {}}},
+        {"upsertView": {"view": {"id": ""}}},
+    ],
+)
+def test_bounded_save_rejects_invalid_upstream_response_without_echoing_it(result) -> None:
+    api = _FakeApi(result=result)
+    # Preserve an explicit false-y response in the fake.
+    api._service_api._result = result
+    report = wr.Report(entity="entity", project="project", title="Report")
+
+    with pytest.raises(
+        WandBReportWriteError,
+        match="W&B returned an invalid report upsert response",
+    ) as exc_info:
+        save_report_bounded(report, api)
+
+    assert repr(result) not in str(exc_info.value)
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert len(api._service_api.calls) == 1
+
+
+def test_create_report_returns_public_url_and_never_enumerates_projects(monkeypatch) -> None:
+    api = _FakeApi()
+    monkeypatch.setattr(wandb_urls, "WANDB_API_BASE_URL", _INTERNAL_URL)
+    monkeypatch.setattr(wandb_urls, "WANDB_BASE_URL", _PUBLIC_URL)
+
+    with (
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api_key",
+            return_value=_API_KEY,
+        ),
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api",
+            return_value=api,
+        ) as get_api,
+    ):
+        result = create_report(
+            entity_name="entity",
+            project_name="project",
+            title="Customer Report",
+            markdown_report_text="# Customer Report\n\nSafe body.",
+        )
+
+    assert result == {"url": "https://customer.wandb.io/entity/project/reports/Customer-Report--report-id"}
+    assert api.project_calls == [("project", "entity")]
+    assert api.create_project_calls == []
+    assert len(api._service_api.calls) == 1
+    assert get_api.call_count == 2
+    assert get_api.call_args_list[0].args == (_API_KEY,)
+    assert get_api.call_args_list[1].args == ()
+
+
+@pytest.mark.asyncio
+async def test_public_boundary_maps_upsert_timeout_to_non_retryable_unknown(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    api = _FakeApi(error=TimeoutError("upsert response timed out"))
+    server = InstrumentedFastMCP("report-write-outcome-test")
+
+    @server.tool(name="create_wandb_report_tool")
+    def create_timed_out_report() -> dict[str, str]:
+        return create_report("entity", "project", "Report")
+
+    with (
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api_key",
+            return_value=_API_KEY,
+        ),
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api",
+            return_value=api,
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await server.call_tool("create_wandb_report_tool", {})
+
+    rendered = str(exc_info.value)
+    assert '"error": "outcome_unknown"' in rendered
+    assert '"retryable": false' in rendered
+    assert "retry_after" not in rendered
+    assert len(api._service_api.calls) == 1
+
+
+def test_create_report_sanitizes_upstream_failures(monkeypatch) -> None:
+    upstream_error = RuntimeError(f"POST {_INTERNAL_URL}/graphql failed: Authorization=Bearer {_API_KEY}")
+    api = _FakeApi(error=upstream_error)
+    monkeypatch.setenv("WANDB_INTERNAL_BASE_URL", _INTERNAL_URL)
+
+    with (
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api_key",
+            return_value=_API_KEY,
+        ),
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api",
+            return_value=api,
+        ),
+        patch.object(create_report_module.logger, "error") as error_log,
+        pytest.raises(WandBReportCreationFailed) as exc_info,
+    ):
+        create_report("entity", "project", "Report")
+
+    external_error = str(exc_info.value)
+    assert _API_KEY not in external_error
+    assert _INTERNAL_URL not in external_error
+    assert "wandb-api.test.svc" not in external_error
+    assert external_error == "The W&B report could not be created."
+    error_log.assert_called_once()
+    log_template, logged_error = error_log.call_args.args
+    assert log_template == "Report creation failed after a bounded W&B write: %s"
+    assert _API_KEY not in logged_error
+    assert _INTERNAL_URL not in logged_error
+    assert "wandb-api.test.svc" not in logged_error
+    assert "<redacted>" in logged_error
+    assert "<internal W&B API>" in logged_error
+    assert len(api._service_api.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_public_boundary_maps_report_failure_to_stable_bounded_error(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    upstream_error = RuntimeError(f"POST {_INTERNAL_URL}/graphql failed with token={_API_KEY}")
+    api = _FakeApi(error=upstream_error)
+    server = InstrumentedFastMCP("report-write-failure-test")
+
+    @server.tool(name="create_wandb_report_tool")
+    def create_failed_report() -> dict[str, str]:
+        return create_report("entity", "project", "Report")
+
+    with (
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api_key",
+            return_value=_API_KEY,
+        ),
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api",
+            return_value=api,
+        ),
+        pytest.raises(ToolError) as exc_info,
+    ):
+        await server.call_tool("create_wandb_report_tool", {})
+
+    rendered = str(exc_info.value)
+    assert '"error": "report_creation_failed"' in rendered
+    assert '"retryable": false' in rendered
+    assert _API_KEY not in rendered
+    assert _INTERNAL_URL not in rendered
+    assert len(rendered) < 300
+    assert len(api._service_api.calls) == 1
+
+
+def test_create_report_preserves_retryable_backpressure() -> None:
+    overload = RuntimeError("HTTP 429: too many requests")
+    overload.response = SimpleNamespace(
+        status_code=429,
+        headers={"Retry-After": "2"},
+        reason="Too Many Requests",
+        text="",
+    )
+    api = _FakeApi(error=overload)
+
+    with (
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api_key",
+            return_value=_API_KEY,
+        ),
+        patch(
+            "wandb_mcp_server.api_client.WandBApiManager.get_api",
+            return_value=api,
+        ),
+        pytest.raises(WandBServerBusy) as exc_info,
+    ):
+        create_report("entity", "project", "Report")
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.retry_after_ms == 2_000

--- a/tests/test_wandb_graphql_read_only.py
+++ b/tests/test_wandb_graphql_read_only.py
@@ -125,6 +125,7 @@ def test_application_graphql_transport_is_confined_to_approved_modules():
     package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server"
     approved = {
         package_root / "wandb_graphql.py",
+        package_root / "wandb_report_writer.py",
         package_root / "wandb_selective_reads.py",
         package_root / "mcp_tools" / "query_wandb_gql.py",
     }


### PR DESCRIPTION
## Summary

Fix the live v0.4 staging timeout in `create_wandb_report_tool` without changing the tool signature or success response.

- Replace `wandb_workspaces.Report.save()`, which enumerates every project in an entity, with bounded point operations.
- Resolve the target with public `wandb.Api.project(...).id`; call `create_project` only on an exact not-found, so existing-project writes do not require project-update permission.
- Persist the report with Workspaces' fixed `upsertView` document. Caller-supplied GraphQL is not accepted.
- Reuse the request-scoped `WandBApiManager` client, preserving per-request credentials, internal API routing, timeout configuration, and concurrent actor isolation.
- Return stable, bounded `report_creation_failed` errors. A timeout or connection loss after the report write is dispatched returns non-retryable `outcome_unknown`, preventing automatic duplicate writes.

## Root cause

`Report.save()` performs `Api.projects(entity)` and walks the collection before upserting a report. For entities with many projects, that unbounded preflight exceeded the 30-second MCP tool deadline in Cloud Run staging. The report upsert itself was never the expensive operation.

## Request bounds

- Existing project: one point lookup plus one report upsert.
- Missing project: one point lookup, one idempotent project create, and one report upsert.
- No project collection enumeration and no automatic write retry.

## Validation

- Ruff check and format check: pass.
- Full Python 3.12 non-integration suite: **1,112 passed, 10 deselected**.
- Python 3.11 focused report/routing/admission suite: **75 passed**.
- Focused report tests cover existing, missing, unauthorized, and timed-out project lookups; fixed upsert request count; malformed responses; public/internal URL handling; secret sanitization; non-retry behavior; outcome-unknown mapping; and concurrent actor/target isolation.
- `uv lock --check`: pass.
- Wheel and sdist build: pass.
- Fresh-wheel server construction smoke test: pass.
- W&B-latest CI now includes the report writer compatibility contract.

This PR should be merged into `staging/0.4.0`, followed by a new exact-SHA Cloud Run staging deployment and live report create/read/delete acceptance run.