### PR TITLE
fix: preserve Uvicorn access logs during sanitization

### DIFF
--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -4,6 +4,7 @@ import json as _json
 import logging
 import netrc
 import os
+import re
 import subprocess
 import sys
 import traceback
@@ -82,15 +83,80 @@ class _JsonLogFormatter(logging.Formatter):
         return _json.dumps(payload, default=str)
 
 
+def _sanitize_rendered_log_message(record: logging.LogRecord, message: object) -> str:
+    """Sanitize a rendered message without changing its logging arguments."""
+    exception_text = getattr(record, "_wandb_mcp_sanitized_message_suffix", "")
+    if exception_text:
+        message = f"{message}\n{exception_text}"
+    return sanitize_sensitive_text(
+        message,
+        max_chars=MAX_EXTERNAL_ERROR_CHARS,
+    )
+
+
+_LOG_PERCENT_TOKEN_RE = re.compile(r"%(?:\([^)]+\))?[#0\- +]?(?:\d+|\*)?(?:\.(?:\d+|\*))?[hlL]?[diouxXeEfFgGcrsa%]")
+
+
+def _sanitize_log_message_template(message: str) -> str:
+    """Redact literal values without consuming printf-style placeholders."""
+    tokens: list[str] = []
+
+    def _protect_token(match: re.Match[str]) -> str:
+        tokens.append(match.group(0))
+        # A leading comma keeps key/value redaction from interpreting the
+        # sentinel as the value in templates such as ``api_key=%s``.
+        return f",<wandb-mcp-log-token-{len(tokens) - 1}>,"
+
+    sanitized = sanitize_sensitive_text(_LOG_PERCENT_TOKEN_RE.sub(_protect_token, message))
+    for index, token in enumerate(tokens):
+        sanitized = sanitized.replace(f",<wandb-mcp-log-token-{index}>,", token)
+    return sanitized
+
+
+class _SensitiveLogRecord(logging.LogRecord):
+    """A pickle-safe LogRecord that sanitizes only its rendered message."""
+
+    __slots__ = ()
+    _wandb_mcp_sensitive_get_message = True
+
+    def getMessage(self) -> str:
+        return _sanitize_rendered_log_message(self, super().getMessage())
+
+
+def _install_sensitive_get_message(record: logging.LogRecord) -> None:
+    """Make ``getMessage`` safe without replacing ``msg`` or clearing ``args``."""
+    if getattr(type(record), "_wandb_mcp_sensitive_get_message", False) or getattr(
+        record, "_wandb_mcp_sensitive_get_message", False
+    ):
+        return
+
+    if type(record) is logging.LogRecord:
+        record.__class__ = _SensitiveLogRecord
+    elif not record.args:
+        # Preserve custom record classes and any formatter-specific behavior.
+        # Argument-bearing records are still protected by shape-preserving
+        # argument sanitization in the filter.
+        record.msg = sanitize_sensitive_text(
+            record.msg,
+            max_chars=MAX_EXTERNAL_ERROR_CHARS,
+        )
+
+
 class _SensitiveDataFilter(logging.Filter):
-    """Ensure credentials and internal service addresses never reach logs."""
+    """Ensure credentials and internal service addresses never reach logs.
+
+    Some third-party formatters, including Uvicorn's access formatter, treat
+    ``LogRecord.args`` as a structured protocol. Sanitize those values without
+    flattening the record so downstream formatters retain their expected shape.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
         try:
-            message = sanitize_sensitive_text(
-                record.getMessage(),
-                max_chars=MAX_EXTERNAL_ERROR_CHARS,
-            )
+            if record.args:
+                record.args = sanitize_sensitive_value(record.args)
+                if isinstance(record.msg, str):
+                    record.msg = _sanitize_log_message_template(record.msg)
+            _install_sensitive_get_message(record)
             if record.exc_info:
                 exception_text = sanitize_sensitive_text(
                     "".join(traceback.format_exception(*record.exc_info)),
@@ -98,11 +164,9 @@ class _SensitiveDataFilter(logging.Filter):
                 )
                 record._wandb_mcp_sanitized_exc_info = exception_text
                 if os.environ.get("MCP_LOG_FORMAT", "rich").strip().lower() != "json":
-                    message = f"{message}\n{exception_text}"
+                    record._wandb_mcp_sanitized_message_suffix = exception_text
                 record.exc_info = None
                 record.exc_text = None
-            record.msg = message
-            record.args = ()
             if hasattr(record, "json_fields"):
                 record.json_fields = sanitize_sensitive_value(record.json_fields)
         except Exception:
@@ -121,7 +185,8 @@ def _install_sensitive_record_factory() -> None:
     sanitizer = _SensitiveDataFilter()
 
     def _sanitizing_factory(*args, **kwargs):
-        record = current_factory(*args, **kwargs)
+        factory = _SensitiveLogRecord if current_factory is logging.LogRecord else current_factory
+        record = factory(*args, **kwargs)
         sanitizer.filter(record)
         return record
 

--- a/tests/test_error_sanitizer.py
+++ b/tests/test_error_sanitizer.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import base64
+import io
 import logging
+import pickle
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from mcp.server.fastmcp.exceptions import ToolError
+from uvicorn.logging import AccessFormatter
 
 from wandb_mcp_server.analytics import _prepare_event
 from wandb_mcp_server.api_client import WandBApiManager
@@ -69,6 +73,144 @@ def test_log_filter_sanitizes_message_arguments_and_exception() -> None:
     _assert_canaries_absent(record.getMessage())
     _assert_canaries_absent(record._wandb_mcp_sanitized_exc_info)
     assert record.exc_info is None
+
+
+def _uvicorn_access_record(path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        __file__,
+        1,
+        '%s - "%s %s HTTP/%s" %d',
+        ("127.0.0.1:8080", "POST", path, "1.1", 200),
+        None,
+    )
+
+
+def _uvicorn_access_formatter() -> AccessFormatter:
+    return AccessFormatter(
+        '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+        use_colors=False,
+    )
+
+
+def test_log_filter_preserves_uvicorn_access_record_contract() -> None:
+    record = _uvicorn_access_record(f"/mcp?upstream={INTERNAL_URL}&api_key={SECRET}")
+
+    assert _SensitiveDataFilter().filter(record)
+
+    assert isinstance(record.args, tuple)
+    assert len(record.args) == 5
+    rendered = _uvicorn_access_formatter().format(record)
+    _assert_canaries_absent(rendered)
+    assert "POST" in rendered
+    assert "200 OK" in rendered
+
+
+def test_sanitized_uvicorn_access_record_remains_queue_safe() -> None:
+    record = _uvicorn_access_record(f"/mcp?upstream={INTERNAL_URL}&api_key={SECRET}")
+
+    assert _SensitiveDataFilter().filter(record)
+    restored = pickle.loads(pickle.dumps(record))
+
+    rendered = _uvicorn_access_formatter().format(restored)
+    _assert_canaries_absent(rendered)
+    assert len(restored.args) == 5
+
+
+def test_uvicorn_access_logger_formats_through_process_record_factory() -> None:
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(_uvicorn_access_formatter())
+    handler.addFilter(_SensitiveDataFilter())
+    logger = logging.getLogger("uvicorn.access.sanitizer-regression")
+    original_handlers = logger.handlers[:]
+    original_level = logger.level
+    original_propagate = logger.propagate
+    try:
+        logger.handlers = [handler]
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.info(
+            '%s - "%s %s HTTP/%s" %d',
+            "127.0.0.1:8080",
+            "POST",
+            f"/mcp?upstream={INTERNAL_URL}&api_key={SECRET}",
+            "1.1",
+            200,
+        )
+    finally:
+        logger.handlers = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+    rendered = stream.getvalue()
+    _assert_canaries_absent(rendered)
+    assert "POST" in rendered
+    assert "200 OK" in rendered
+
+
+def test_log_filter_preserves_mapping_arguments_and_sanitizes_literals() -> None:
+    record = logging.LogRecord(
+        "structured.logger",
+        logging.INFO,
+        __file__,
+        1,
+        f"backend={INTERNAL_URL} request=%(path)s api_key=%(api_key)s",
+        ({"path": INTERNAL_URL, "api_key": SECRET},),
+        None,
+    )
+
+    assert _SensitiveDataFilter().filter(record)
+
+    assert isinstance(record.args, dict)
+    assert set(record.args) == {"path", "api_key"}
+    _assert_canaries_absent(record.getMessage())
+
+
+def test_custom_argument_record_sanitizes_literals_without_flattening() -> None:
+    class CustomLogRecord(logging.LogRecord):
+        pass
+
+    record = CustomLogRecord(
+        "custom.structured.logger",
+        logging.INFO,
+        __file__,
+        1,
+        f"backend={INTERNAL_URL} api_key=%s literal={SECRET} progress=100%%",
+        (SECRET,),
+        None,
+    )
+
+    assert _SensitiveDataFilter().filter(record)
+
+    assert type(record) is CustomLogRecord
+    assert isinstance(record.args, tuple)
+    assert len(record.args) == 1
+    assert "%s" in record.msg
+    assert "%%" in record.msg
+    rendered = record.getMessage()
+    _assert_canaries_absent(rendered)
+    assert "api_key=<redacted>" in rendered
+    assert "progress=100%" in rendered
+
+
+def test_log_filter_formats_uvicorn_access_records_concurrently() -> None:
+    sanitizer = _SensitiveDataFilter()
+    formatter = _uvicorn_access_formatter()
+
+    def _format(index: int) -> str:
+        record = _uvicorn_access_record(f"/mcp/{index}?upstream={INTERNAL_URL}&token={SECRET}")
+        assert sanitizer.filter(record)
+        return formatter.format(record)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        rendered = list(pool.map(_format, range(100)))
+
+    assert len(rendered) == 100
+    for message in rendered:
+        _assert_canaries_absent(message)
+        assert "200 OK" in message
 
 
 def test_analytics_preparation_sanitizes_before_forwarding() -> None:


### PR DESCRIPTION
## Summary

- Preserve structured `LogRecord.args` while sanitizing access-log fields.
- Sanitize rendered messages through a pickle-safe `LogRecord` subclass instead of flattening records early.
- Safely redact literal values in custom argument-bearing log records while preserving printf-style tokens.
- Keep exception, credential, and internal Kubernetes URL redaction intact.
- Add regression coverage using Uvicorn's real `AccessFormatter`, the process-wide log record factory, concurrent formatting, mapping and custom record arguments, and queue/pickle round trips.

## Root cause

`_SensitiveDataFilter` called `record.getMessage()`, replaced `record.msg` with the rendered text, and cleared `record.args`. Uvicorn's `AccessFormatter` treats those arguments as a five-field structured contract (`client_addr`, method, path, HTTP version, and status), so it raised `ValueError: not enough values to unpack (expected 5, got 0)`.

## Impact

HTTP access logging no longer breaks request handling or staging acceptance. Secrets and internal service addresses remain absent from rendered logs, and third-party formatters retain their structured argument shape.

## Validation

- Rebased on `staging/0.4.0` at `7d6c3d2b598253d452a18333a336940b54be2ebd`.
- Final head: `73c51980c6ec6740bb25d97a6dcade4b5886fa80`.
- Focused logging and sanitizer tests: 31 passed.
- Combined report/logging regression tests: 88 passed.
- Full final non-integration suite on Python 3.12: 1,118 passed, 10 deselected.
- Full pre-rebase suite on Python 3.11 and 3.12: 1,099 passed, 10 deselected on each runtime.
- Ruff check and format check pass.
- `uv lock --check` and `git diff --check` pass.
