### PR TITLE
fix: read reports by display title

### DIFF
--- a/docs/query-capabilities.md
+++ b/docs/query-capabilities.md
@@ -15,7 +15,7 @@ represent.
 | Selected or bounded full summary/config | `query_wandb_tool` with `summary_keys`, `config_keys`, or `include` | No |
 | Run count | `query_wandb_tool(resource="runs", response_mode="count")` | No |
 | Sweep lookup/list/config | `query_wandb_tool(resource="sweep"|"sweeps")` | No |
-| Report lookup/list/spec | `query_wandb_tool(resource="reports")` | No |
+| Report lookup/list/spec | `query_wandb_tool(resource="reports", report_name=...)`; `report_name` accepts an exact internal name or display title | No |
 | Run metric history | `get_run_history_tool` | No |
 | Artifacts and registries | Artifact and registry tools | No |
 | Automations and integrations | Automation and integration tools | No |

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -203,6 +203,9 @@ query_wandb_tool(
 )
 ```
 
+For `resource="reports"`, `report_name` accepts either an exact internal report
+name or the exact user-visible report title.
+
 Use the existing specialized tools for entity/project discovery, run history,
 artifacts, registries, automations, and integrations. If a required response
 shape has no SDK equivalent, an administrator may enable the query-only raw

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -29,11 +29,14 @@ from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.trace_utils import count_tokens_conservative
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_selective_reads import (
+    ProjectedReportCursorError,
     SelectiveReadUnavailable,
     fetch_projected_reports,
     fetch_projected_run,
     fetch_projected_runs,
     fetch_projected_sweeps,
+    is_projected_report_cursor,
+    validate_projected_report_cursor,
 )
 from wandb_mcp_server.wandb_urls import public_wandb_url, publicize_wandb_url
 
@@ -77,7 +80,8 @@ run_id : str, optional
 sweep_id : str, optional
     Required only for resource="sweep".
 report_name : str, optional
-    Optional report-name filter for resource="reports".
+    Optional exact report filter for resource="reports". Accepts either the
+    internal report name or its user-visible display title.
 filters : dict, optional
     W&B SDK Mongo-style run filters for resource="runs". Supported fields include
     createdAt, displayName, duration, group, host, jobType, name, state, tags,
@@ -947,6 +951,21 @@ def query_wandb(
             config_keys=config_keys,
         )
         sdk_fallback_offset = _decode_sdk_cursor(cursor, resource, sdk_cursor_fingerprint)
+        if cursor is not None and is_projected_report_cursor(cursor) and (resource != "reports" or report_name is None):
+            raise WandBQueryValidationError(
+                "filtered report cursor requires resource='reports' and the original report_name"
+            )
+        if cursor is not None and resource == "reports" and report_name is not None and sdk_fallback_offset is None:
+            try:
+                validate_projected_report_cursor(
+                    cursor,
+                    entity=entity_name,
+                    project=project_name,
+                    report_name=report_name,
+                    include_spec="spec" in include_fields,
+                )
+            except ProjectedReportCursorError as exc:
+                raise WandBQueryValidationError(str(exc)) from None
     except WandBQueryValidationError as exc:
         safe_resource = resource if isinstance(resource, str) and resource in _INCLUDE_FIELDS else "unknown"
         return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=safe_resource)

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
+import hashlib
 import json
 import math
 from typing import Any, Mapping, NoReturn, Sequence
@@ -356,7 +358,91 @@ class SelectiveReadUnavailable(RuntimeError):
     """Raised when a backend cannot serve an application-owned read shape."""
 
 
+class ProjectedReportCursorError(ValueError):
+    """Raised before transport when a filtered report cursor is invalid."""
+
+
 _MAX_PROJECTED_PAGE_REQUESTS = 10
+_PROJECTED_REPORT_CURSOR_PREFIX = "mcp-report-v1:"
+
+
+def is_projected_report_cursor(cursor: str) -> bool:
+    """Return whether a cursor belongs to a filtered projected report read."""
+    return cursor.startswith(_PROJECTED_REPORT_CURSOR_PREFIX)
+
+
+def _projected_report_cursor_fingerprint(
+    *,
+    entity: str,
+    project: str,
+    report_name: str,
+    include_spec: bool,
+) -> str:
+    """Bind a filtered continuation to the report query that created it."""
+    payload = json.dumps(
+        {
+            "entity": entity,
+            "project": project,
+            "report_name": report_name,
+            "include_spec": include_spec,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:24]
+
+
+def _encode_projected_report_cursor(*, mode: str, after: str, fingerprint: str) -> str:
+    """Wrap a backend cursor with its filtered report connection mode."""
+    payload = json.dumps(
+        {"after": after, "mode": mode, "query": fingerprint},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    return _PROJECTED_REPORT_CURSOR_PREFIX + encoded
+
+
+def _decode_projected_report_cursor(cursor: str, *, fingerprint: str) -> tuple[str, str]:
+    """Decode and validate one mode-bound filtered report cursor."""
+    if not is_projected_report_cursor(cursor):
+        raise ProjectedReportCursorError("cursor is not a valid filtered report continuation")
+    encoded = cursor.removeprefix(_PROJECTED_REPORT_CURSOR_PREFIX)
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        raw = base64.b64decode((encoded + padding).encode("ascii"), altchars=b"-_", validate=True)
+        payload = json.loads(raw)
+    except (UnicodeEncodeError, ValueError, json.JSONDecodeError):
+        raise ProjectedReportCursorError("cursor is not a valid filtered report continuation") from None
+    if not isinstance(payload, Mapping) or set(payload) != {"after", "mode", "query"}:
+        raise ProjectedReportCursorError("cursor is not a valid filtered report continuation")
+    mode = payload.get("mode")
+    after = payload.get("after")
+    query = payload.get("query")
+    if mode not in {"internal", "display"} or not isinstance(after, str) or not after:
+        raise ProjectedReportCursorError("cursor is not a valid filtered report continuation")
+    if query != fingerprint:
+        raise ProjectedReportCursorError("cursor does not match this filtered report query")
+    return mode, after
+
+
+def validate_projected_report_cursor(
+    cursor: str,
+    *,
+    entity: str,
+    project: str,
+    report_name: str,
+    include_spec: bool,
+) -> None:
+    """Validate a filtered report cursor without constructing a W&B client."""
+    fingerprint = _projected_report_cursor_fingerprint(
+        entity=entity,
+        project=project,
+        report_name=report_name,
+        include_spec=include_spec,
+    )
+    _decode_projected_report_cursor(cursor, fingerprint=fingerprint)
 
 
 def _projected_page_request_limit(target: int, page_size: int) -> int:
@@ -791,8 +877,28 @@ def fetch_projected_reports(
     include_spec: bool = False,
     cursor: str | None = None,
 ) -> ProjectedResourcePage:
-    """Fetch report metadata without downloading report specs by default."""
+    """Fetch report metadata without downloading report specs by default.
+
+    W&B's ``viewName`` argument addresses the report's generated internal
+    name, while users normally know its display title. A filtered first page
+    therefore tries the internal name and, only when that lookup is empty,
+    scans one bounded metadata page for an exact display-title match.
+    Mode-bound cursors keep each continuation on the connection that produced
+    it, including when multiple reports share an internal name.
+    """
     target = max(1, limit)
+    if report_name is not None:
+        return _fetch_projected_reports_by_name(
+            api,
+            entity=entity,
+            project=project,
+            report_name=report_name,
+            target=target,
+            page_size=page_size,
+            include_spec=include_spec,
+            cursor=cursor,
+        )
+
     items: list[dict[str, Any]] = []
     page_cursor = cursor
     requests = 0
@@ -808,7 +914,7 @@ def fetch_projected_reports(
                 {
                     "entity": entity,
                     "project": project,
-                    "name": report_name,
+                    "name": None,
                     "first": min(max(1, page_size), target - len(items)),
                     "after": page_cursor,
                     "includeSpec": include_spec,
@@ -829,21 +935,7 @@ def fetch_projected_reports(
         for edge in edges:
             if len(items) >= target:
                 break
-            node = edge.get("node")
-            if not isinstance(node, Mapping):
-                raise SelectiveReadUnavailable("projected report query returned an invalid report edge")
-            item = {
-                "id": node.get("id"),
-                "name": node.get("name"),
-                "display_name": node.get("displayName"),
-                "description": node.get("description"),
-                "user": node.get("user"),
-                "created_at": node.get("createdAt"),
-                "updated_at": node.get("updatedAt"),
-            }
-            if include_spec:
-                item["spec"] = _parse_json_mapping(node.get("spec"))
-            items.append(item)
+            items.append(_projected_report_item(edge, include_spec=include_spec))
             retained_edge = edge
             consumed_edges += 1
         cut_mid_page = consumed_edges < len(edges)
@@ -872,6 +964,192 @@ def fetch_projected_reports(
         total_count=total_count,
         has_more=has_more,
         next_cursor=page_cursor if has_more else None,
+        requests=requests,
+    )
+
+
+def _fetch_projected_report_page(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    internal_name: str | None,
+    first: int,
+    cursor: str | None,
+    include_spec: bool,
+) -> tuple[list[Mapping[str, Any]], Mapping[str, Any], bool]:
+    """Fetch and validate one bounded report connection page."""
+    raise_if_tool_deadline_exceeded()
+    try:
+        data = execute_graphql(
+            api,
+            PROJECTED_REPORTS_QUERY,
+            {
+                "entity": entity,
+                "project": project,
+                "name": internal_name,
+                "first": max(1, first),
+                "after": cursor,
+                "includeSpec": include_spec,
+            },
+        )
+    except Exception as exc:
+        _raise_selective_failure("projected report query unavailable", exc)
+    connection = _project_payload(data).get("allViews")
+    if not isinstance(connection, Mapping):
+        raise SelectiveReadUnavailable("projected report query returned no report connection")
+    return _projected_connection_page(connection, context="projected report query")
+
+
+def _projected_report_item(edge: Mapping[str, Any], *, include_spec: bool) -> dict[str, Any]:
+    """Convert one validated report edge without hydrating omitted specs."""
+    node = edge.get("node")
+    if not isinstance(node, Mapping):
+        raise SelectiveReadUnavailable("projected report query returned an invalid report edge")
+    item = {
+        "id": node.get("id"),
+        "name": node.get("name"),
+        "display_name": node.get("displayName"),
+        "description": node.get("description"),
+        "user": node.get("user"),
+        "created_at": node.get("createdAt"),
+        "updated_at": node.get("updatedAt"),
+    }
+    if include_spec:
+        item["spec"] = _parse_json_mapping(node.get("spec"))
+    return item
+
+
+def _fetch_projected_reports_by_name(
+    api: Any,
+    *,
+    entity: str,
+    project: str,
+    report_name: str,
+    target: int,
+    page_size: int,
+    include_spec: bool,
+    cursor: str | None,
+) -> ProjectedResourcePage:
+    """Resolve an exact internal report name or exact display title."""
+    requests = 0
+    request_size = min(max(1, page_size), target)
+    fingerprint = _projected_report_cursor_fingerprint(
+        entity=entity,
+        project=project,
+        report_name=report_name,
+        include_spec=include_spec,
+    )
+    mode: str | None = None
+    backend_cursor: str | None = None
+    if cursor is not None:
+        mode, backend_cursor = _decode_projected_report_cursor(cursor, fingerprint=fingerprint)
+
+    if mode in {None, "internal"}:
+        edges, page_info, backend_has_next = _fetch_projected_report_page(
+            api,
+            entity=entity,
+            project=project,
+            internal_name=report_name,
+            first=request_size,
+            cursor=backend_cursor,
+            include_spec=include_spec,
+        )
+        requests += 1
+        if edges or mode == "internal":
+            retained_edges = edges[:target]
+            items = [_projected_report_item(edge, include_spec=include_spec) for edge in retained_edges]
+            cut_mid_page = len(retained_edges) < len(edges)
+            has_more = backend_has_next or cut_mid_page
+            next_backend_cursor = None
+            if has_more:
+                seen_cursors = {backend_cursor} if backend_cursor else set()
+                if cut_mid_page:
+                    next_backend_cursor = _retained_projected_cursor(
+                        retained_edges[-1],
+                        context="projected report query",
+                        current=backend_cursor,
+                        seen=seen_cursors,
+                    )
+                else:
+                    next_backend_cursor = _next_projected_cursor(
+                        context="projected report query",
+                        current=backend_cursor,
+                        candidate=page_info.get("endCursor"),
+                        seen=seen_cursors,
+                    )
+            return ProjectedResourcePage(
+                items=items,
+                total_count=len(items) if cursor is None and not has_more else None,
+                has_more=has_more,
+                next_cursor=(
+                    _encode_projected_report_cursor(
+                        mode="internal",
+                        after=next_backend_cursor,
+                        fingerprint=fingerprint,
+                    )
+                    if next_backend_cursor is not None
+                    else None
+                ),
+                requests=requests,
+            )
+
+    edges, page_info, backend_has_next = _fetch_projected_report_page(
+        api,
+        entity=entity,
+        project=project,
+        internal_name=None,
+        first=request_size,
+        cursor=backend_cursor,
+        include_spec=include_spec,
+    )
+    requests += 1
+
+    items: list[dict[str, Any]] = []
+    last_scanned_edge: Mapping[str, Any] | None = None
+    scanned_edges = 0
+    for edge in edges:
+        if len(items) >= target:
+            break
+        item = _projected_report_item(edge, include_spec=include_spec)
+        last_scanned_edge = edge
+        scanned_edges += 1
+        if item.get("display_name") == report_name:
+            items.append(item)
+
+    cut_mid_page = scanned_edges < len(edges)
+    has_more = backend_has_next or cut_mid_page
+    next_backend_cursor = None
+    if has_more:
+        seen_cursors = {backend_cursor} if backend_cursor else set()
+        if cut_mid_page:
+            assert last_scanned_edge is not None
+            next_backend_cursor = _retained_projected_cursor(
+                last_scanned_edge,
+                context="projected report display-title scan",
+                current=backend_cursor,
+                seen=seen_cursors,
+            )
+        else:
+            next_backend_cursor = _next_projected_cursor(
+                context="projected report display-title scan",
+                current=backend_cursor,
+                candidate=page_info.get("endCursor"),
+                seen=seen_cursors,
+            )
+    return ProjectedResourcePage(
+        items=items,
+        total_count=len(items) if cursor is None and not has_more else None,
+        has_more=has_more,
+        next_cursor=(
+            _encode_projected_report_cursor(
+                mode="display",
+                after=next_backend_cursor,
+                fingerprint=fingerprint,
+            )
+            if next_backend_cursor is not None
+            else None
+        ),
         requests=requests,
     )
 
@@ -1143,6 +1421,7 @@ __all__ = [
     "ProjectedRunPage",
     "ProjectedResourcePage",
     "ArtifactVersionPage",
+    "ProjectedReportCursorError",
     "SelectiveReadUnavailable",
     "fetch_artifact_inventory",
     "fetch_metric_value_steps",
@@ -1153,4 +1432,6 @@ __all__ = [
     "fetch_projected_runs",
     "fetch_projected_sweeps",
     "fetch_projected_reports",
+    "is_projected_report_cursor",
+    "validate_projected_report_cursor",
 ]

--- a/tests/test_query_wandb_hardening.py
+++ b/tests/test_query_wandb_hardening.py
@@ -627,3 +627,80 @@ def test_sdk_fallback_cursor_is_bound_to_original_query(monkeypatch):
 
     assert result["error"] == "invalid_request"
     assert "does not match" in result["message"]
+
+
+def test_filtered_report_cursor_is_validated_before_api_construction(monkeypatch):
+    def handler(query, variables):
+        if variables["name"] is not None:
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [],
+                        "pageInfo": {"endCursor": None, "hasNextPage": False},
+                    }
+                }
+            }
+        return {
+            "project": {
+                "allViews": {
+                    "edges": [],
+                    "pageInfo": {"endCursor": "display-page-1", "hasNextPage": True},
+                }
+            }
+        }
+
+    api = SelectiveApi(handler)
+    _install_api(monkeypatch, api)
+    first = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="reports",
+        report_name="Release report",
+        limit=1,
+    )
+    assert first["next_cursor"].startswith("mcp-report-v1:")
+
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for an invalid filtered report cursor"),
+    )
+    mismatch = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="reports",
+        report_name="Different report",
+        limit=1,
+        cursor=first["next_cursor"],
+    )
+    malformed = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="reports",
+        report_name="Release report",
+        limit=1,
+        cursor="display-page-1",
+    )
+    missing_report_name = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="reports",
+        limit=1,
+        cursor=first["next_cursor"],
+    )
+    cross_resource = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="runs",
+        limit=1,
+        cursor=first["next_cursor"],
+    )
+
+    assert mismatch["error"] == "invalid_request"
+    assert "does not match" in mismatch["message"]
+    assert malformed["error"] == "invalid_request"
+    assert "not a valid" in malformed["message"]
+    assert missing_report_name["error"] == "invalid_request"
+    assert "original report_name" in missing_report_name["message"]
+    assert cross_resource["error"] == "invalid_request"
+    assert "resource='reports'" in cross_resource["message"]

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -474,11 +474,19 @@ def test_explicit_report_spec_sdk_fallback_cursor_continues(fake_api, monkeypatc
         lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
     )
 
-    first = sdk_query.query_wandb("entity", "project", "reports", limit=1, include=["spec"])
+    first = sdk_query.query_wandb(
+        "entity",
+        "project",
+        "reports",
+        report_name="Quarterly Review",
+        limit=1,
+        include=["spec"],
+    )
     second = sdk_query.query_wandb(
         "entity",
         "project",
         "reports",
+        report_name="Quarterly Review",
         limit=1,
         include=["spec"],
         cursor=first["next_cursor"],
@@ -490,6 +498,10 @@ def test_explicit_report_spec_sdk_fallback_cursor_continues(fake_api, monkeypatc
     assert second["total_count"] == 2
     assert second["has_more"] is False
     assert second["next_cursor"] is None
+    assert fake_api.calls == [
+        ("reports", "entity/project", {"name": "Quarterly Review", "per_page": 2}),
+        ("reports", "entity/project", {"name": "Quarterly Review", "per_page": 2}),
+    ]
 
 
 def test_reports_use_sdk_name_filter_and_optional_spec(fake_api):

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 
 import pytest
@@ -17,6 +18,7 @@ from wandb_mcp_server.wandb_selective_reads import (
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
     REGISTRY_ARTIFACT_VERSIONS_QUERY,
+    ProjectedReportCursorError,
     SelectiveReadUnavailable,
     fetch_registry_artifact_versions,
     fetch_project_counts,
@@ -231,6 +233,365 @@ def test_projected_collection_fetches_only_requested_fields_in_one_request():
     assert variables["summaryKeys"] == ["accuracy", "loss"]
     assert variables["configKeys"] == ["learning_rate"]
     assert json.loads(variables["filters"]) == {"state": "finished"}
+
+
+def test_report_filter_prefers_exact_internal_name_without_spec_overfetch():
+    class InternalNameServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            variables = dict(variables or {})
+            self.calls.append((query, variables))
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [
+                            {
+                                "cursor": "internal-cursor",
+                                "node": {
+                                    "id": "report-id",
+                                    "name": "internal-report-name",
+                                    "displayName": "Customer-visible title",
+                                    "spec": '{"should_not": "be retained"}',
+                                },
+                            }
+                        ],
+                        "pageInfo": {"endCursor": "internal-cursor", "hasNextPage": False},
+                    }
+                }
+            }
+
+    api = type("Api", (), {"_service_api": InternalNameServiceApi()})()
+
+    result = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="internal-report-name",
+        limit=5,
+        page_size=20,
+    )
+
+    assert result.requests == 1
+    assert result.items == [
+        {
+            "id": "report-id",
+            "name": "internal-report-name",
+            "display_name": "Customer-visible title",
+            "description": None,
+            "user": None,
+            "created_at": None,
+            "updated_at": None,
+        }
+    ]
+    assert result.has_more is False
+    assert result.next_cursor is None
+    variables = api._service_api.calls[0][1]
+    assert variables["name"] == "internal-report-name"
+    assert variables["includeSpec"] is False
+
+
+def test_report_internal_name_continuation_preserves_the_filtered_connection():
+    class DuplicateInternalNameServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            variables = dict(variables or {})
+            self.calls.append((query, variables))
+            after = variables["after"]
+            index = 1 if after is None else 2
+            if after is not None:
+                assert after == "internal-page-1"
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [
+                            {
+                                "cursor": f"internal-page-{index}",
+                                "node": {
+                                    "id": f"report-{index}",
+                                    "name": "duplicate-internal-name",
+                                    "displayName": f"Report {index}",
+                                },
+                            }
+                        ],
+                        "pageInfo": {
+                            "endCursor": f"internal-page-{index}",
+                            "hasNextPage": index == 1,
+                        },
+                    }
+                }
+            }
+
+    api = type("Api", (), {"_service_api": DuplicateInternalNameServiceApi()})()
+
+    first = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="duplicate-internal-name",
+        limit=1,
+        page_size=1,
+    )
+    assert [item["id"] for item in first.items] == ["report-1"]
+    assert first.requests == 1
+    assert first.has_more is True
+    assert first.next_cursor.startswith("mcp-report-v1:")
+
+    second = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="duplicate-internal-name",
+        limit=1,
+        page_size=1,
+        cursor=first.next_cursor,
+    )
+    assert [item["id"] for item in second.items] == ["report-2"]
+    assert second.requests == 1
+    assert second.has_more is False
+    assert second.next_cursor is None
+    assert len(api._service_api.calls) == 2
+    continuation_variables = api._service_api.calls[1][1]
+    assert continuation_variables["name"] == "duplicate-internal-name"
+    assert continuation_variables["after"] == "internal-page-1"
+
+
+def test_report_filter_falls_back_to_exact_display_title_in_two_bounded_requests():
+    class DisplayTitleServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            variables = dict(variables or {})
+            self.calls.append((query, variables))
+            if variables["name"] is not None:
+                return {
+                    "project": {
+                        "allViews": {
+                            "edges": [],
+                            "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        }
+                    }
+                }
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [
+                            {
+                                "cursor": "contains-1",
+                                "node": {
+                                    "id": "near-match",
+                                    "name": "generated-near-match",
+                                    "displayName": "Release report (copy)",
+                                },
+                            },
+                            {
+                                "cursor": "contains-2",
+                                "node": {
+                                    "id": "exact-match",
+                                    "name": "generated-exact-match",
+                                    "displayName": "Release report",
+                                    "spec": '{"should_not": "be retained"}',
+                                },
+                            },
+                        ],
+                        "pageInfo": {"endCursor": "contains-2", "hasNextPage": False},
+                    }
+                }
+            }
+
+    api = type("Api", (), {"_service_api": DisplayTitleServiceApi()})()
+
+    result = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="Release report",
+        limit=5,
+        page_size=20,
+    )
+
+    assert result.requests == 2
+    assert [item["id"] for item in result.items] == ["exact-match"]
+    assert "spec" not in result.items[0]
+    assert result.total_count == 1
+    assert result.has_more is False
+    assert len(api._service_api.calls) == 2
+    internal_variables = api._service_api.calls[0][1]
+    fallback_variables = api._service_api.calls[1][1]
+    assert internal_variables["name"] == "Release report"
+    assert fallback_variables["name"] is None
+    assert fallback_variables["first"] == 5
+    assert fallback_variables["includeSpec"] is False
+    assert "displayNameContains" not in PROJECTED_REPORTS_QUERY
+
+
+def test_report_display_title_filter_excludes_nonexact_matches_and_continues_from_backend_cursor():
+    class PaginatedDisplayTitleServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            variables = dict(variables or {})
+            self.calls.append((query, variables))
+            if variables["name"] is not None:
+                return {
+                    "project": {
+                        "allViews": {
+                            "edges": [],
+                            "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        }
+                    }
+                }
+            if variables["after"] is None:
+                return {
+                    "project": {
+                        "allViews": {
+                            "edges": [
+                                {
+                                    "cursor": "display-page-1",
+                                    "node": {
+                                        "id": "near-match",
+                                        "name": "generated-near-match",
+                                        "displayName": "Release report (copy)",
+                                    },
+                                }
+                            ],
+                            "pageInfo": {"endCursor": "display-page-1", "hasNextPage": True},
+                        }
+                    }
+                }
+            assert variables["after"] == "display-page-1"
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [
+                            {
+                                "cursor": "display-page-2",
+                                "node": {
+                                    "id": "exact-match",
+                                    "name": "generated-exact-match",
+                                    "displayName": "Release report",
+                                },
+                            }
+                        ],
+                        "pageInfo": {"endCursor": "display-page-2", "hasNextPage": False},
+                    }
+                }
+            }
+
+    api = type("Api", (), {"_service_api": PaginatedDisplayTitleServiceApi()})()
+
+    first = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="Release report",
+        limit=1,
+        page_size=1,
+    )
+    assert first.items == []
+    assert first.requests == 2
+    assert first.has_more is True
+    assert first.next_cursor.startswith("mcp-report-v1:")
+    assert len(api._service_api.calls) == 2
+
+    second = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="Release report",
+        limit=1,
+        page_size=1,
+        cursor=first.next_cursor,
+    )
+    assert [item["id"] for item in second.items] == ["exact-match"]
+    assert second.requests == 1
+    assert second.has_more is False
+    assert second.next_cursor is None
+    assert len(api._service_api.calls) == 3
+    continuation_variables = api._service_api.calls[2][1]
+    assert continuation_variables["name"] is None
+    assert continuation_variables["after"] == "display-page-1"
+
+
+def test_filtered_report_cursor_rejects_malformed_or_mismatched_queries_without_transport():
+    class CursorServiceApi:
+        def __init__(self):
+            self.calls = []
+
+        def execute_graphql(self, query, variables=None):
+            variables = dict(variables or {})
+            self.calls.append((query, variables))
+            if variables["name"] is not None:
+                return {
+                    "project": {
+                        "allViews": {
+                            "edges": [],
+                            "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        }
+                    }
+                }
+            return {
+                "project": {
+                    "allViews": {
+                        "edges": [],
+                        "pageInfo": {"endCursor": "display-page-1", "hasNextPage": True},
+                    }
+                }
+            }
+
+    api = type("Api", (), {"_service_api": CursorServiceApi()})()
+    first = fetch_projected_reports(
+        api,
+        entity="entity",
+        project="project",
+        report_name="Release report",
+        limit=1,
+        page_size=1,
+    )
+    assert first.next_cursor.startswith("mcp-report-v1:")
+    calls_before_rejection = len(api._service_api.calls)
+
+    with pytest.raises(ProjectedReportCursorError, match="does not match"):
+        fetch_projected_reports(
+            api,
+            entity="entity",
+            project="project",
+            report_name="Different report",
+            limit=1,
+            page_size=1,
+            cursor=first.next_cursor,
+        )
+    with pytest.raises(ProjectedReportCursorError, match="not a valid"):
+        fetch_projected_reports(
+            api,
+            entity="entity",
+            project="project",
+            report_name="Release report",
+            limit=1,
+            page_size=1,
+            cursor="display-page-1",
+        )
+    malformed_mode_payload = (
+        base64.urlsafe_b64encode(json.dumps({"after": "display-page-1", "mode": "other", "query": "invalid"}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    with pytest.raises(ProjectedReportCursorError, match="not a valid"):
+        fetch_projected_reports(
+            api,
+            entity="entity",
+            project="project",
+            report_name="Release report",
+            limit=1,
+            page_size=1,
+            cursor=f"mcp-report-v1:{malformed_mode_payload}",
+        )
+    assert len(api._service_api.calls) == calls_before_rejection
 
 
 @pytest.mark.parametrize("kind", ["runs", "sweeps", "reports"])


### PR DESCRIPTION
## Summary

Fix the v0.4 staging release blocker where a newly created report could not be read back through `query_wandb_tool(resource="reports", report_name=<title>)`.

## Root cause

W&B Workspaces stores the user-visible title in `displayName` and generates a separate internal report `name`. The typed query treated `report_name` only as the internal name, so a natural title lookup returned no results. This was reproduced by staging run 30575347316 after report creation succeeded.

## Changes

- Preserve the exact internal-name lookup first.
- If it is empty, scan one bounded, metadata-only report page and exact-match the visible title.
- Keep the existing Core-compatible GraphQL document unchanged; no dependency on the recently added `displayNameContains` schema argument.
- Add mode-bound, query-fingerprinted continuation cursors so internal-name and display-title pagination cannot cross result sets.
- Reject malformed, mismatched, missing-name, and cross-resource cursors before constructing a W&B client.
- Preserve existing SDK fallback cursors and unfiltered report cursors.
- Keep report specs opt-in.

## Impact

`query_wandb_tool` now accepts either an exact internal report name or an exact user-visible report title. There are no tool, authentication, configuration, dependency, or response-shape changes.

## Validation

- 186 focused query, cursor, SDK-fallback, and tool-description tests passed.
- Full suite passed during independent review: 1,133 passed, 1 skipped.
- Ruff check and format check passed.
- `uv lock --check` and `git diff --check` passed.
- Independent staff review found no remaining release blockers.

After merge, the exact combined staging SHA will be rebuilt and the live create/read/delete acceptance, telemetry gate, same-key backpressure, and normal-load workflows will be rerun.