### PR TITLE
perf: remove repeated W&B setup from run history

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/run_history.py
+++ b/src/wandb_mcp_server/mcp_tools/run_history.py
@@ -1,6 +1,6 @@
 """Retrieve sampled time-series metric history for a W&B run.
 
-Uses `wandb.Api().run().history()` for sampled data and a tiered
+Uses the actor-isolated W&B public API client for sampled data and a tiered
 strategy for step-range queries: scan_history (parquet-backed) first,
 history() (sampled) as last resort.
 """
@@ -8,6 +8,7 @@ history() (sampled) as last resort.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import islice
 import json
 import math
 from typing import Any, Dict, List, Literal, Optional
@@ -26,8 +27,6 @@ from wandb_mcp_server.config import (
     MCP_MAX_HISTORY_RANGE_STEPS,
     MCP_MAX_HISTORY_SAMPLES,
     MCP_WORKLOAD_PROFILE,
-    MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
-    WANDB_API_BASE_URL,
 )
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
@@ -198,11 +197,12 @@ def get_run_history(
             raise ValueError("W&B API key is required to fetch run history.")
 
         try:
-            wandb_api = wandb.Api(
-                api_key=api_key,
-                overrides={"base_url": WANDB_API_BASE_URL},
-                timeout=MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
-            )
+            # Reuse the actor-isolated public API client. Constructing a fresh
+            # ``wandb.Api`` performs credential validation and creates a new
+            # transport before every history read, adding a second upstream
+            # request and avoidable connection churn to a latency-sensitive
+            # path.
+            wandb_api = WandBApiManager.get_api(api_key)
             run_path = f"{entity_name}/{project_name}/{run_id}"
             run = wandb_api.run(run_path)
         except wandb.errors.CommError as e:
@@ -391,9 +391,7 @@ def _scan_history_rows(
     scan_kwargs["page_size"] = min(1000, max(1, scan_limit))
     scanned_rows: list[dict[str, Any]] = []
     rows_scanned = 0
-    for index, row in enumerate(run.scan_history(**scan_kwargs)):
-        if index >= scan_limit:
-            break
+    for index, row in enumerate(islice(run.scan_history(**scan_kwargs), scan_limit)):
         if index % 100 == 0:
             raise_if_tool_deadline_exceeded()
         rows_scanned += 1
@@ -457,6 +455,48 @@ def _numeric_x(row: Dict[str, Any], x_axis: str) -> float | None:
     return numeric if math.isfinite(numeric) else None
 
 
+def _scan_history_for_target(
+    run: Any,
+    *,
+    keys: list[str],
+    x_axis: str,
+    target_x: float,
+    tolerance: float | None,
+    scan_limit: int,
+) -> tuple[list[dict[str, Any]], bool, int]:
+    """Stream a bounded compatibility scan and retain at most one row.
+
+    An exact lookup can stop at the first matching row. A tolerance lookup
+    must inspect the bounded window to select the nearest value, but still
+    avoids materializing thousands of history rows in memory.
+    """
+    best_row: dict[str, Any] | None = None
+    best_distance = math.inf
+    rows_scanned = 0
+    scan_kwargs = {
+        "keys": keys,
+        "page_size": min(1000, max(1, scan_limit)),
+    }
+
+    for index, row in enumerate(islice(run.scan_history(**scan_kwargs), scan_limit)):
+        if index % 100 == 0:
+            raise_if_tool_deadline_exceeded()
+        rows_scanned += 1
+        value = _numeric_x(row, x_axis)
+        if value is None:
+            continue
+        distance = abs(value - target_x)
+        if distance <= _EXACT_EPSILON:
+            return [row], True, rows_scanned
+        if tolerance is not None and distance < best_distance:
+            best_row = row
+            best_distance = distance
+
+    if best_row is not None and best_distance <= tolerance:
+        return [best_row], False, rows_scanned
+    return [], False, rows_scanned
+
+
 def _select_target_row(
     rows: list[dict[str, Any]],
     *,
@@ -512,14 +552,14 @@ def _fetch_target_x(
         )
     except SelectiveReadUnavailable as exc:
         raise_for_wandb_server_busy(exc)
-        rows, rows_scanned = _scan_history_rows(
+        selected, exact, rows_scanned = _scan_history_for_target(
             run,
             keys=requested_keys,
-            min_step=None,
-            max_step=None,
+            x_axis=x_axis,
+            target_x=target_x,
+            tolerance=tolerance,
             scan_limit=MCP_MAX_HISTORY_RANGE_STEPS,
         )
-        selected, exact = _select_target_row(rows, x_axis=x_axis, target_x=target_x, tolerance=tolerance)
         return _HistoryFetch(
             selected,
             "sdk_bounded_compatibility_scan",

--- a/tests/test_internal_wandb_routing.py
+++ b/tests/test_internal_wandb_routing.py
@@ -134,7 +134,6 @@ def test_backend_wandb_constructors_use_only_resolved_api_url() -> None:
         package_root / "api_client.py",
         package_root / "server.py",
         package_root / "mcp_tools" / "log_analysis.py",
-        package_root / "mcp_tools" / "run_history.py",
     )
 
     for module in constructor_modules:
@@ -143,10 +142,15 @@ def test_backend_wandb_constructors_use_only_resolved_api_url() -> None:
         assert "WANDB_BASE_URL" not in source, module
 
     create_report_source = (package_root / "mcp_tools" / "create_report.py").read_text()
+    run_history_source = (package_root / "mcp_tools" / "run_history.py").read_text()
     report_writer_source = (package_root / "wandb_report_writer.py").read_text()
     assert "WandBApiManager.get_api" in create_report_source
     assert "wandb.Api(" not in create_report_source
     assert "WANDB_BASE_URL" not in create_report_source
     assert "WANDB_API_BASE_URL" not in create_report_source
+    assert "WandBApiManager.get_api" in run_history_source
+    assert "wandb.Api(" not in run_history_source
+    assert "WANDB_BASE_URL" not in run_history_source
+    assert "WANDB_API_BASE_URL" not in run_history_source
     assert "WANDB_BASE_URL" not in report_writer_source
     assert "WANDB_API_BASE_URL" not in report_writer_source

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -14,6 +14,7 @@ from wandb_mcp_server.mcp_tools.run_history import (
     get_run_history,
 )
 from wandb_mcp_server.server import register_tools
+from wandb_mcp_server.wandb_selective_reads import SelectiveReadUnavailable
 
 
 class TestRunHistoryDescription:
@@ -44,7 +45,6 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_basic_history(self, mock_wandb_mod, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -58,7 +58,7 @@ class TestGetRunHistory:
 
         mock_api = MagicMock()
         mock_api.run.return_value = mock_run
-        mock_wandb_mod.Api.return_value = mock_api
+        mock_api_mgr.get_api.return_value = mock_api
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("entity", "project", "abc12345", keys=["loss", "accuracy"]))
@@ -69,11 +69,12 @@ class TestGetRunHistory:
         assert len(result["rows"]) == 3
         assert "loss" in result["keys_returned"]
         assert "accuracy" in result["keys_returned"]
+        mock_api_mgr.get_api.assert_called_once_with("fake_key_12345678901234567890")
+        mock_wandb_mod.Api.assert_not_called()
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_filters_internal_keys(self, mock_wandb_mod, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -82,7 +83,7 @@ class TestGetRunHistory:
         mock_run.history.return_value = [
             {"_step": 0, "_wandb": {"internal": True}, "loss": 1.0},
         ]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1"))
@@ -94,7 +95,6 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_filters_nan_values(self, mock_wandb_mod, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -103,7 +103,7 @@ class TestGetRunHistory:
         mock_run.history.return_value = [
             {"_step": 0, "loss": float("nan"), "accuracy": 0.5},
         ]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1"))
@@ -114,14 +114,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_clamps_samples(self, mock_wandb_mod, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 10
         mock_run.history.return_value = []
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", samples=99999)
@@ -131,10 +130,9 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_missing_run_raises(self, mock_wandb_mod, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(side_effect=wandb.errors.CommError("Not found")))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(side_effect=wandb.errors.CommError("Not found")))
         mock_wandb_mod.errors = wandb.errors
 
         with pytest.raises(ValueError, match="Run not found"):
@@ -142,7 +140,6 @@ class TestGetRunHistory:
 
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     def test_no_api_key_raises(self, mock_api_mgr):
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = None
 
         with pytest.raises(ValueError, match="API key"):
@@ -152,7 +149,6 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_step_range_uses_scan_history(self, mock_wandb_mod, mock_api_mgr):
         """min_step/max_step must use scan_history, not history (which doesn't support them)."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -163,7 +159,7 @@ class TestGetRunHistory:
             {"_step": 100, "loss": 1.0},
             {"_step": 150, "loss": 0.7},
         ]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=50, max_step=200))
@@ -179,14 +175,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_no_step_range_uses_history(self, mock_wandb_mod, mock_api_mgr):
         """Without min_step/max_step, should use history() for sampled data."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 100
         mock_run.history.return_value = [{"_step": 0, "loss": 1.0}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", samples=100)
@@ -198,14 +193,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_scan_history_samples_large_result(self, mock_wandb_mod, mock_api_mgr):
         """scan_history results should be client-side sampled to match the samples parameter."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 10000
         mock_run.scan_history.return_value = [{"_step": i, "loss": float(i)} for i in range(5000)]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, samples=500))
@@ -216,7 +210,6 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_step_range_samples_across_full_window(self, mock_wandb_mod, mock_api_mgr):
         """Step-range sampling should cover the full requested range, not just a prefix."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -224,7 +217,7 @@ class TestGetRunHistory:
         mock_run.lastHistoryStep = 99
         rows = [{"_step": i, "loss": float(i)} for i in range(100)]
         mock_run.scan_history.return_value = rows
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, max_step=99, samples=5))
@@ -244,7 +237,6 @@ class TestGetRunHistory:
         """Reservoir sampling should draw from the entire scan window, not
         just the first N rows. Over multiple runs, the max step in the sample
         should reach into the tail of the data."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         total_rows = 10_000
@@ -252,7 +244,7 @@ class TestGetRunHistory:
         mock_run.name = "r1"
         mock_run.lastHistoryStep = total_rows - 1
         mock_run.scan_history.return_value = [{"_step": i, "loss": float(i)} for i in range(total_rows)]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         max_steps_seen = []
@@ -271,14 +263,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_scan_history_only_min_step(self, mock_wandb_mod, mock_api_mgr):
         """Setting only min_step (no max_step) should use scan_history."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 500
         mock_run.scan_history.return_value = [{"_step": 100, "loss": 1.0}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", min_step=100)
@@ -293,14 +284,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_scan_history_only_max_step(self, mock_wandb_mod, mock_api_mgr):
         """Setting only max_step (no min_step) should use scan_history."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 500
         mock_run.scan_history.return_value = [{"_step": 50, "loss": 1.0}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", max_step=200)
@@ -314,7 +304,6 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_sparse_metrics_both_keys_returned(self, mock_wandb_mod, mock_api_mgr):
         """Rows with disjoint metric sets should still report all keys."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
@@ -325,7 +314,7 @@ class TestGetRunHistory:
             {"_step": 1, "accuracy": 0.5},
             {"_step": 2, "loss": 0.5},
         ]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1"))
@@ -336,14 +325,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_response_shape(self, mock_wandb_mod, mock_api_mgr):
         """Response must always contain the documented top-level keys."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "r1"
         mock_run.lastHistoryStep = 10
         mock_run.history.return_value = [{"_step": 0, "loss": 1.0}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1"))
@@ -354,14 +342,13 @@ class TestGetRunHistory:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_empty_history(self, mock_wandb_mod, mock_api_mgr):
         """Run with no history rows should return gracefully."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "empty-run"
         mock_run.lastHistoryStep = 0
         mock_run.history.return_value = []
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1"))
@@ -377,7 +364,6 @@ class TestHistoryTruncation:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_large_response_truncated(self, mock_wandb_mod, mock_api_mgr):
         """History exceeding token budget should be downsampled."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         rows = [{"_step": i, "loss": 1.0 / (i + 1), "acc": i * 0.01, "lr": 0.001} for i in range(2000)]
@@ -385,7 +371,7 @@ class TestHistoryTruncation:
         mock_run.name = "big-run"
         mock_run.lastHistoryStep = 2000
         mock_run.history.return_value = rows
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         with patch("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 500):
@@ -398,7 +384,6 @@ class TestHistoryTruncation:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_small_response_not_truncated(self, mock_wandb_mod, mock_api_mgr):
         """History under budget passes through unchanged."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         rows = [{"_step": i, "loss": 0.5} for i in range(10)]
@@ -406,7 +391,7 @@ class TestHistoryTruncation:
         mock_run.name = "small-run"
         mock_run.lastHistoryStep = 10
         mock_run.history.return_value = rows
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", samples=10))
@@ -417,14 +402,13 @@ class TestHistoryTruncation:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_hosted_history_samples_clamped(self, mock_wandb_mod, mock_api_mgr):
         """Hosted mode clamps requested samples to the configured hosted limit."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "hosted-run"
         mock_run.lastHistoryStep = 2000
         mock_run.history.return_value = [{"_step": i, "loss": 0.5} for i in range(5)]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         with (
@@ -458,7 +442,6 @@ class TestHistoryTruncation:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_truncation_preserves_step_ordering(self, mock_wandb_mod, mock_api_mgr):
         """Truncated rows must remain sorted by _step."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         rows = [{"_step": i, "val": i * 0.1} for i in range(2000)]
@@ -466,7 +449,7 @@ class TestHistoryTruncation:
         mock_run.name = "ordered-run"
         mock_run.lastHistoryStep = 2000
         mock_run.history.return_value = rows
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         with patch("wandb_mcp_server.config.MAX_RESPONSE_TOKENS", 500):
@@ -490,7 +473,6 @@ class TestTieredStepRangeFetch:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_scan_history_tried_first(self, mock_wandb_mod, mock_api_mgr):
         """scan_history is the first strategy attempted for step-range queries."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         scan_rows = [{"_step": i, "loss": 0.5} for i in range(50)]
@@ -498,7 +480,7 @@ class TestTieredStepRangeFetch:
         mock_run.name = "scan-run"
         mock_run.lastHistoryStep = 100
         mock_run.scan_history.return_value = iter(scan_rows)
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, max_step=100))
@@ -510,7 +492,6 @@ class TestTieredStepRangeFetch:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_fallback_to_history_when_scan_empty(self, mock_wandb_mod, mock_api_mgr):
         """When scan returns empty with lastHistoryStep<=0, falls back to history()."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         history_rows = [{"_step": i, "acc": 0.9} for i in range(10)]
@@ -519,7 +500,7 @@ class TestTieredStepRangeFetch:
         mock_run.lastHistoryStep = -1
         mock_run.scan_history.return_value = iter([])
         mock_run.history.return_value = history_rows
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=0, max_step=100))
@@ -531,14 +512,13 @@ class TestTieredStepRangeFetch:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_scan_history_passes_keys_and_range(self, mock_wandb_mod, mock_api_mgr):
         """scan_history receives keys, min_step, max_step."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "params-run"
         mock_run.lastHistoryStep = 200
         mock_run.scan_history.return_value = iter([{"_step": 10, "loss": 0.5}])
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         get_run_history("e", "p", "run1", keys=["loss"], min_step=10, max_step=100)
@@ -551,14 +531,13 @@ class TestTieredStepRangeFetch:
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
     def test_no_history_fallback_when_last_step_positive(self, mock_wandb_mod, mock_api_mgr):
         """When lastHistoryStep > 0 and scan returns empty, do NOT fall back to history()."""
-        mock_api_mgr.get_api.return_value = MagicMock(viewer="test-user")
         mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
 
         mock_run = MagicMock()
         mock_run.name = "normal-run"
         mock_run.lastHistoryStep = 1000
         mock_run.scan_history.return_value = iter([])
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=mock_run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(get_run_history("e", "p", "run1", min_step=5000, max_step=6000))
@@ -567,6 +546,102 @@ class TestTieredStepRangeFetch:
 
 
 class TestCustomAxisHistory:
+    @patch(
+        "wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps",
+        side_effect=SelectiveReadUnavailable("unsupported metric"),
+    )
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_compatibility_scan_stops_at_first_exact_match(
+        self,
+        mock_wandb_mod,
+        mock_api_mgr,
+        _mock_steps,
+    ):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        rows_yielded = 0
+
+        def history_rows():
+            nonlocal rows_yielded
+            rows_yielded += 1
+            yield {"_step": 0, "validation/step": 1000.0, "validation/loss": 0.2}
+            rows_yielded += 1
+            yield {"_step": 1, "validation/step": 1001.0, "validation/loss": 0.1}
+
+        run = MagicMock()
+        run.name = "custom-axis"
+        run.lastHistoryStep = 100
+        run.scan_history.return_value = history_rows()
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        result = json.loads(
+            get_run_history(
+                "e",
+                "p",
+                "run1",
+                keys=["validation/loss"],
+                x_axis="validation/step",
+                target_x=1000,
+            )
+        )
+
+        assert result["exact"] is True
+        assert result["rows_scanned"] == 1
+        assert result["retrieval_method"] == "sdk_bounded_compatibility_scan"
+        assert rows_yielded == 1
+
+    @patch(
+        "wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps",
+        side_effect=SelectiveReadUnavailable("unsupported metric"),
+    )
+    @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
+    @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
+    def test_compatibility_tolerance_scan_is_bounded_and_selects_nearest(
+        self,
+        mock_wandb_mod,
+        mock_api_mgr,
+        _mock_steps,
+    ):
+        mock_api_mgr.get_api_key.return_value = "fake_key_12345678901234567890"
+        rows_yielded = 0
+
+        def history_rows():
+            nonlocal rows_yielded
+            for row in (
+                {"_step": 0, "validation/step": 999.6},
+                {"_step": 1, "validation/step": 1000.2},
+                {"_step": 2, "validation/step": 999.9},
+                {"_step": 3, "validation/step": 1000.01},
+            ):
+                rows_yielded += 1
+                yield row
+
+        run = MagicMock()
+        run.name = "custom-axis"
+        run.lastHistoryStep = 100
+        run.scan_history.return_value = history_rows()
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_wandb_mod.errors = wandb.errors
+
+        with patch("wandb_mcp_server.mcp_tools.run_history.MCP_MAX_HISTORY_RANGE_STEPS", 3):
+            result = json.loads(
+                get_run_history(
+                    "e",
+                    "p",
+                    "run1",
+                    keys=["validation/loss"],
+                    x_axis="validation/step",
+                    target_x=1000,
+                    tolerance=0.5,
+                )
+            )
+
+        assert result["exact"] is False
+        assert result["rows_scanned"] == 3
+        assert result["rows"] == [{"_step": 2, "validation/step": 999.9}]
+        assert rows_yielded == 3
+
     @patch("wandb_mcp_server.mcp_tools.run_history.fetch_metric_value_steps", return_value=[42])
     @patch("wandb_mcp_server.mcp_tools.run_history.WandBApiManager")
     @patch("wandb_mcp_server.mcp_tools.run_history.wandb")
@@ -581,7 +656,7 @@ class TestCustomAxisHistory:
         run.name = "custom-axis"
         run.lastHistoryStep = 100
         run.scan_history.return_value = [{"_step": 42, "validation/step": 1000.0, "validation/loss": 0.2}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(
@@ -615,7 +690,7 @@ class TestCustomAxisHistory:
         run = MagicMock()
         run.name = "custom-axis"
         run.scan_history.return_value = [{"_step": 42, "validation/step": 999.5}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(
@@ -650,7 +725,7 @@ class TestCustomAxisHistory:
             {"_step": 41, "validation/step": 999.75, "validation/loss": 0.21},
             {"_step": 42, "validation/step": 1001.0},
         ]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(
@@ -681,7 +756,7 @@ class TestCustomAxisHistory:
         run.name = "system"
         run.lastHistoryStep = 10
         run.history.return_value = [{"_timestamp": 10, "system.cpu": 40.0}]
-        mock_wandb_mod.Api.return_value = MagicMock(run=MagicMock(return_value=run))
+        mock_api_mgr.get_api.return_value = MagicMock(run=MagicMock(return_value=run))
         mock_wandb_mod.errors = wandb.errors
 
         result = json.loads(


### PR DESCRIPTION
## Summary

- reuse the existing actor-isolated `WandBApiManager` client for run-history calls
- stop exact compatibility scans at the first match and retain at most one candidate row
- preserve the existing bounded full scan for tolerance/absence cases
- make bounded iterators consume no more than their configured row limit

## Why

The exact v0.4 staging candidate failed the normal-load gate twice. Each failure occurred in `get_run_history_tool`: the implementation created a fresh `wandb.Api`, revalidated credentials, and created a new transport on every call. This duplicated upstream work despite the shared client manager already providing per-actor TTL/LRU/single-flight isolation.

Read-only timing against the staging fixture after this patch: cold sampled read 17.1s, repeated cached sampled read 0.82s, cached exact compatibility read 4.14s.

## Validation

- Ruff check and format check: pass
- `tests/test_run_history.py`: 36 passed
- full non-integration suite: 1,126 passed, 10 deselected
- no writes or response-shape/tool-signature changes

## Release gate

This targets `staging/0.4.0`. After merge, the hosted wrapper must pin the resulting staging SHA and repeat exact functional, normal-load, and same-key staging acceptance. Thresholds are unchanged.