### PR TITLE
fix: bind v0.4 query cursors to request scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           uv run --no-sync pytest \
             tests/test_query_wandb_sdk.py \
+            tests/test_query_wandb_hardening.py \
             tests/test_probe_project.py \
             tests/test_wandb_selective_reads.py \
             tests/test_run_history.py \
@@ -109,6 +110,7 @@ jobs:
             tests/test_report_writer.py \
             tests/test_wandb_graphql.py \
             tests/test_wandb_graphql_read_only.py \
+            tests/test_raw_graphql_hardening.py \
             tests/test_hosted_gql_guardrails.py \
             tests/test_hosted_gql_production_errors.py \
             -k "not locked_wandb_versions_are_installed" \

--- a/docs/query-capabilities.md
+++ b/docs/query-capabilities.md
@@ -19,10 +19,10 @@ change only the page `limit` when continuing; mismatched reuse returns
 | Former example | v0.4 route | Structured request |
 |---|---|---|
 | `MinimalRunIdVsDisplayName` | `query_wandb_tool` | Use `resource="run", run_id=...` for a short ID, or `resource="runs", filters={"displayName": {"$eq": ...}}` for a display name |
-| `GetProjectInfo` | `query_wandb_tool` | `resource="project"` |
+| `GetProjectInfo` | `query_wandb_tool` | `resource="project"` returns stable project metadata including `description` and `run_count` |
 | `GetSortedRuns` | `query_wandb_tool` | `resource="runs", order=...` with optional `summary_keys` |
-| `GetFilteredRuns` | `query_wandb_tool` | `resource="runs", filters=..., order=..., cursor=...` |
-| `GetRunByDisplayName` | `query_wandb_tool` | `resource="runs", filters={"displayName": {"$eq": ...}}` |
+| `GetFilteredRuns` | `query_wandb_tool` | `resource="runs", filters=..., order=..., summary_keys=[...], cursor=...` |
+| `GetRunByDisplayName` | `query_wandb_tool` | `resource="runs", filters={"displayName": {"$eq": ...}}, summary_keys=[...]` |
 
 | Read requirement | Preferred MCP tool | Raw GraphQL needed? |
 |---|---|---|

--- a/docs/query-capabilities.md
+++ b/docs/query-capabilities.md
@@ -5,6 +5,25 @@ typed read tools below. An administrator can enable
 `WANDB_MCP_ENABLE_RAW_GRAPHQL=true` only for read shapes the typed tools cannot
 represent.
 
+## v0.3 GraphQL example migration
+
+Every named GraphQL example previously documented on `query_wandb_tool` has a
+typed v0.4 route. These calls no longer require callers to construct a GraphQL
+document or JSON-encode filter variables.
+
+Collection `next_cursor` values are opaque and bound to the original resource,
+entity/project, filters, ordering, selector, and field projection. Clients may
+change only the page `limit` when continuing; mismatched reuse returns
+`invalid_cursor` without contacting W&B.
+
+| Former example | v0.4 route | Structured request |
+|---|---|---|
+| `MinimalRunIdVsDisplayName` | `query_wandb_tool` | Use `resource="run", run_id=...` for a short ID, or `resource="runs", filters={"displayName": {"$eq": ...}}` for a display name |
+| `GetProjectInfo` | `query_wandb_tool` | `resource="project"` |
+| `GetSortedRuns` | `query_wandb_tool` | `resource="runs", order=...` with optional `summary_keys` |
+| `GetFilteredRuns` | `query_wandb_tool` | `resource="runs", filters=..., order=..., cursor=...` |
+| `GetRunByDisplayName` | `query_wandb_tool` | `resource="runs", filters={"displayName": {"$eq": ...}}` |
+
 | Read requirement | Preferred MCP tool | Raw GraphQL needed? |
 |---|---|---|
 | Entity and project discovery | `list_entities_tool`, `query_wandb_entity_projects` | No |
@@ -17,8 +36,8 @@ represent.
 | Sweep lookup/list/config | `query_wandb_tool(resource="sweep"|"sweeps")` | No |
 | Report lookup/list/spec | `query_wandb_tool(resource="reports", report_name=...)`; `report_name` accepts an exact internal name or display title | No |
 | Run metric history | `get_run_history_tool` | No |
-| Artifacts and registries | Artifact and registry tools | No |
-| Automations and integrations | Automation and integration tools | No |
+| Artifacts and registries | `list_artifact_versions_tool`, `get_artifact_details_tool`, `list_registries_tool`, and `list_registry_collections_tool` | No |
+| Automations and integrations | `list_wandb_automations_tool` and `list_wandb_integrations_tool` | No |
 | Schema introspection or unmodeled/custom fields | `query_wandb_graphql_tool` | Yes |
 | Aliases or exact GraphQL response shape | `query_wandb_graphql_tool` | Yes |
 | Cross-resource/compound nesting | `query_wandb_graphql_tool` | Yes |

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -32,6 +32,7 @@ from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_selective_reads import (
     ProjectedReportCursorError,
     SelectiveReadUnavailable,
+    fetch_project_metadata,
     fetch_projected_reports,
     fetch_projected_run,
     fetch_projected_runs,
@@ -857,6 +858,15 @@ def _decorate_projected_run(item: Dict[str, Any]) -> Dict[str, Any]:
     return _json_safe(item)
 
 
+def _decorate_projected_project(
+    item: Dict[str, Any],
+    entity_name: str,
+    project_name: str,
+) -> Dict[str, Any]:
+    item["url"] = public_wandb_url(entity_name, project_name)
+    return _json_safe(item)
+
+
 def _decorate_projected_sweep(item: Dict[str, Any]) -> Dict[str, Any]:
     sweep_id = item.get("id")
     if sweep_id:
@@ -1042,8 +1052,48 @@ def query_wandb(
         try:
             api = WandBApiManager.get_api()
             if resource == "project":
-                project = api.project(project_name, entity=entity_name)
-                return _single_envelope(resource, entity_name, project_name, _serialize_project(project))
+                try:
+                    item = fetch_project_metadata(
+                        api,
+                        entity=entity_name,
+                        project=project_name,
+                    )
+                except SelectiveReadUnavailable as exc:
+                    project = api.project(project_name, entity=entity_name)
+                    with _SDK_RUN_CACHE_LOCK:
+                        flush = getattr(api, "flush", None)
+                        if callable(flush):
+                            flush()
+                        runs = api.runs(
+                            path,
+                            per_page=1,
+                            include_sweeps=False,
+                            lazy=True,
+                        )
+                    item = _serialize_project(project)
+                    item["run_count"] = _collection_total_count(runs)
+                    count_caveat = (
+                        "the exact run count came from the bounded public-SDK count path"
+                        if item["run_count"] is not None
+                        else "the public-SDK fallback could not expose an exact run count"
+                    )
+                    return _single_envelope(
+                        resource,
+                        entity_name,
+                        project_name,
+                        item,
+                        compatibility_caveat=(
+                            f"{exc}; used bounded public-SDK project metadata; {count_caveat}; "
+                            "description may be unavailable because the public SDK does not expose it"
+                        ),
+                    )
+                return _single_envelope(
+                    resource,
+                    entity_name,
+                    project_name,
+                    _decorate_projected_project(item, entity_name, project_name),
+                    source="wandb_selective_read",
+                )
 
             if resource == "run":
                 use_projection = bool(summary_keys or config_keys) and not (

--- a/src/wandb_mcp_server/mcp_tools/query_wandb.py
+++ b/src/wandb_mcp_server/mcp_tools/query_wandb.py
@@ -8,6 +8,7 @@ import json
 import math
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 from itertools import islice
@@ -106,7 +107,9 @@ response_mode : "items" | "count", optional
     "items" returns bounded resources. "count" is supported for resource="runs"
     and returns only the exact server-side matching count.
 cursor : str, optional
-    Opaque continuation cursor returned by a previous collection response.
+    Opaque continuation cursor returned by a previous collection response. Reuse
+    it only with the same resource, scope, filters, ordering, selector, and field
+    projection. The next page may request a different limit.
 
 Returns
 -------
@@ -133,7 +136,7 @@ _JSON_MAX_MAPPING_KEYS = 500
 _JSON_MAX_LIST_ITEMS = 500
 _JSON_MAX_STRING_CHARS = 16_000
 _SDK_RUN_CACHE_LOCK = threading.Lock()
-_SDK_CURSOR_PREFIX = "mcp-sdk-v1:"
+_QUERY_CURSOR_PREFIX = "mcp-query-v1:"
 _MAX_SDK_FALLBACK_REQUESTS = 10
 _MAX_TYPED_INPUT_BYTES = 64 * 1024
 _MAX_CURSOR_BYTES = 4 * 1024
@@ -146,7 +149,19 @@ class WandBQueryValidationError(ValueError):
     """Raised before any W&B client is obtained for an invalid request."""
 
 
-def _sdk_cursor_fingerprint(
+class WandBCursorValidationError(WandBQueryValidationError):
+    """Raised before client construction for an invalid typed continuation."""
+
+
+@dataclass(frozen=True)
+class _QueryCursor:
+    """Decoded position from an opaque, query-bound continuation token."""
+
+    kind: Literal["projected", "sdk_offset"]
+    position: str | int
+
+
+def _collection_cursor_fingerprint(
     *,
     entity_name: str,
     project_name: str,
@@ -158,7 +173,7 @@ def _sdk_cursor_fingerprint(
     summary_keys: Optional[List[str]],
     config_keys: Optional[List[str]],
 ) -> str:
-    """Bind compatibility offsets to the collection query that created them."""
+    """Bind every collection position to the query that created it."""
     canonical = json.dumps(
         {
             "entity": entity_name,
@@ -168,8 +183,8 @@ def _sdk_cursor_fingerprint(
             "order": order,
             "report_name": report_name,
             "include": sorted(include),
-            "summary_keys": sorted(summary_keys or ()),
-            "config_keys": sorted(config_keys or ()),
+            "summary_keys": summary_keys,
+            "config_keys": config_keys,
         },
         ensure_ascii=False,
         allow_nan=False,
@@ -179,32 +194,44 @@ def _sdk_cursor_fingerprint(
     return hashlib.sha256(canonical).hexdigest()[:24]
 
 
-def _encode_sdk_cursor(resource: str, offset: int, fingerprint: str) -> str:
+def _encode_query_cursor(*, kind: Literal["projected", "sdk_offset"], position: str | int, fingerprint: str) -> str:
+    """Encode a backend cursor or compatibility offset without exposing it."""
     payload = json.dumps(
-        {"resource": resource, "offset": offset, "query": fingerprint},
+        {"kind": kind, "position": position, "query": fingerprint},
         separators=(",", ":"),
         sort_keys=True,
-    ).encode()
-    return _SDK_CURSOR_PREFIX + base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    ).encode("utf-8")
+    return _QUERY_CURSOR_PREFIX + base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
 
 
-def _decode_sdk_cursor(cursor: Optional[str], resource: str, fingerprint: str) -> Optional[int]:
-    if cursor is None or not cursor.startswith(_SDK_CURSOR_PREFIX):
+def _decode_query_cursor(cursor: Optional[str], fingerprint: str) -> Optional[_QueryCursor]:
+    """Decode and validate a continuation before constructing a W&B client."""
+    if cursor is None:
         return None
-    encoded = cursor.removeprefix(_SDK_CURSOR_PREFIX)
+    if not cursor.startswith(_QUERY_CURSOR_PREFIX):
+        raise WandBCursorValidationError("cursor is not a valid typed W&B continuation")
+    encoded = cursor.removeprefix(_QUERY_CURSOR_PREFIX)
     try:
         padding = "=" * (-len(encoded) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(encoded + padding))
-        offset = payload["offset"]
-        cursor_resource = payload["resource"]
-        cursor_fingerprint = payload["query"]
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        raise WandBQueryValidationError("cursor is not a valid MCP SDK continuation") from None
-    if cursor_resource != resource or isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
-        raise WandBQueryValidationError("cursor is not valid for this collection resource")
-    if cursor_fingerprint != fingerprint:
-        raise WandBQueryValidationError("cursor does not match this collection query")
-    return offset
+        raw = base64.b64decode((encoded + padding).encode("ascii"), altchars=b"-_", validate=True)
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, UnicodeEncodeError, ValueError, json.JSONDecodeError):
+        raise WandBCursorValidationError("cursor is not a valid typed W&B continuation") from None
+    if not isinstance(payload, Mapping) or set(payload) != {"kind", "position", "query"}:
+        raise WandBCursorValidationError("cursor is not a valid typed W&B continuation")
+    kind = payload.get("kind")
+    position = payload.get("position")
+    if kind == "projected":
+        if not isinstance(position, str) or not position:
+            raise WandBCursorValidationError("cursor contains an invalid projected position")
+    elif kind == "sdk_offset":
+        if isinstance(position, bool) or not isinstance(position, int) or position < 0:
+            raise WandBCursorValidationError("cursor contains an invalid SDK offset")
+    else:
+        raise WandBCursorValidationError("cursor contains an unsupported continuation kind")
+    if payload.get("query") != fingerprint:
+        raise WandBCursorValidationError("cursor does not match this collection query")
+    return _QueryCursor(kind=kind, position=position)
 
 
 def _validate_text_bound(name: str, value: str, maximum_bytes: int) -> None:
@@ -248,7 +275,7 @@ def _validate_sdk_fallback_window(offset: int, applied_limit: int) -> None:
     page_size = min(applied_limit, MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE)
     requests = math.ceil((offset + applied_limit + 1) / max(1, page_size))
     if requests > _MAX_SDK_FALLBACK_REQUESTS:
-        raise WandBQueryValidationError(
+        raise WandBCursorValidationError(
             "cursor exceeds the bounded SDK compatibility window; restart the query "
             "or use a backend that supports projected continuation"
         )
@@ -677,13 +704,14 @@ def _validate_request(
     if response_mode == "count" and resource != "runs":
         raise WandBQueryValidationError("response_mode='count' is supported only for resource='runs'")
     if cursor is not None and (not isinstance(cursor, str) or not cursor.strip()):
-        raise WandBQueryValidationError("cursor must be a non-empty string")
+        raise WandBCursorValidationError("cursor must be a non-empty string")
     if cursor is not None:
-        _validate_text_bound("cursor", cursor, _MAX_CURSOR_BYTES)
+        if len(cursor.encode("utf-8")) > _MAX_CURSOR_BYTES:
+            raise WandBCursorValidationError(f"cursor exceeds the {_MAX_CURSOR_BYTES}-byte limit")
     if cursor is not None and resource not in {"runs", "sweeps", "reports"}:
-        raise WandBQueryValidationError("cursor is supported only for collection resources")
+        raise WandBCursorValidationError("cursor is supported only for collection resources")
     if cursor is not None and response_mode != "items":
-        raise WandBQueryValidationError("cursor is not supported with response_mode='count'")
+        raise WandBCursorValidationError("cursor is not supported with response_mode='count'")
     if include is not None and (
         not isinstance(include, list)
         or len(include) > 20
@@ -939,7 +967,7 @@ def query_wandb(
             response_mode,
             cursor,
         )
-        sdk_cursor_fingerprint = _sdk_cursor_fingerprint(
+        cursor_fingerprint = _collection_cursor_fingerprint(
             entity_name=entity_name,
             project_name=project_name,
             resource=resource,
@@ -950,22 +978,39 @@ def query_wandb(
             summary_keys=summary_keys,
             config_keys=config_keys,
         )
-        sdk_fallback_offset = _decode_sdk_cursor(cursor, resource, sdk_cursor_fingerprint)
-        if cursor is not None and is_projected_report_cursor(cursor) and (resource != "reports" or report_name is None):
-            raise WandBQueryValidationError(
+        continuation = _decode_query_cursor(cursor, cursor_fingerprint)
+        projected_cursor = (
+            str(continuation.position) if continuation is not None and continuation.kind == "projected" else None
+        )
+        sdk_fallback_offset = (
+            int(continuation.position) if continuation is not None and continuation.kind == "sdk_offset" else None
+        )
+        if (
+            projected_cursor is not None
+            and is_projected_report_cursor(projected_cursor)
+            and (resource != "reports" or report_name is None)
+        ):
+            raise WandBCursorValidationError(
                 "filtered report cursor requires resource='reports' and the original report_name"
             )
-        if cursor is not None and resource == "reports" and report_name is not None and sdk_fallback_offset is None:
+        if projected_cursor is not None and resource == "reports" and report_name is not None:
             try:
                 validate_projected_report_cursor(
-                    cursor,
+                    projected_cursor,
                     entity=entity_name,
                     project=project_name,
                     report_name=report_name,
                     include_spec="spec" in include_fields,
                 )
             except ProjectedReportCursorError as exc:
-                raise WandBQueryValidationError(str(exc)) from None
+                raise WandBCursorValidationError(str(exc)) from None
+        if sdk_fallback_offset is not None and (
+            resource == "sweeps" or (resource == "reports" and "spec" not in include_fields)
+        ):
+            raise WandBCursorValidationError("cursor continuation kind is not supported for this collection query")
+    except WandBCursorValidationError as exc:
+        safe_resource = resource if isinstance(resource, str) and resource in _INCLUDE_FIELDS else "unknown"
+        return structured_error("invalid_cursor", str(exc), source="wandb_sdk", resource=safe_resource)
     except WandBQueryValidationError as exc:
         safe_resource = resource if isinstance(resource, str) and resource in _INCLUDE_FIELDS else "unknown"
         return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=safe_resource)
@@ -974,13 +1019,9 @@ def query_wandb(
     applied_limit = min(limit, MCP_MAX_WANDB_QUERY_ITEMS)
     try:
         if sdk_fallback_offset is not None:
-            if resource == "sweeps" or (resource == "reports" and "spec" not in include_fields):
-                raise WandBQueryValidationError(
-                    "this collection does not support SDK fallback cursors; restart with no cursor"
-                )
             _validate_sdk_fallback_window(sdk_fallback_offset, applied_limit)
-    except WandBQueryValidationError as exc:
-        return structured_error("invalid_request", str(exc), source="wandb_sdk", resource=resource)
+    except WandBCursorValidationError as exc:
+        return structured_error("invalid_cursor", str(exc), source="wandb_sdk", resource=resource)
     path = f"{entity_name}/{project_name}"
 
     with track_tool_execution(
@@ -1100,7 +1141,7 @@ def query_wandb(
                             include_config="config" in include_fields,
                             include_sweep="sweep" in include_fields,
                             include_system_metrics="system_metrics" in include_fields,
-                            cursor=cursor,
+                            cursor=projected_cursor,
                         )
                     except SelectiveReadUnavailable as exc:
                         if cursor is not None:
@@ -1142,7 +1183,15 @@ def query_wandb(
                             projected.has_more,
                             projected.total_count,
                             cursor=cursor,
-                            next_cursor=projected.next_cursor,
+                            next_cursor=(
+                                _encode_query_cursor(
+                                    kind="projected",
+                                    position=projected.next_cursor,
+                                    fingerprint=cursor_fingerprint,
+                                )
+                                if projected.next_cursor is not None
+                                else None
+                            ),
                             source="wandb_selective_read",
                         )
                 else:
@@ -1198,7 +1247,13 @@ def query_wandb(
                     total_count,
                     cursor=cursor,
                     next_cursor=(
-                        _encode_sdk_cursor(resource, offset + len(items), sdk_cursor_fingerprint) if has_more else None
+                        _encode_query_cursor(
+                            kind="sdk_offset",
+                            position=offset + len(items),
+                            fingerprint=cursor_fingerprint,
+                        )
+                        if has_more
+                        else None
                     ),
                     compatibility_caveat=compatibility_caveat,
                 )
@@ -1216,7 +1271,7 @@ def query_wandb(
                         limit=applied_limit,
                         page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
                         include_config="config" in include_fields,
-                        cursor=cursor,
+                        cursor=projected_cursor,
                     )
                 except SelectiveReadUnavailable as exc:
                     return structured_error(
@@ -1235,7 +1290,15 @@ def query_wandb(
                     sweeps.has_more,
                     sweeps.total_count,
                     cursor=cursor,
-                    next_cursor=sweeps.next_cursor,
+                    next_cursor=(
+                        _encode_query_cursor(
+                            kind="projected",
+                            position=sweeps.next_cursor,
+                            fingerprint=cursor_fingerprint,
+                        )
+                        if sweeps.next_cursor is not None
+                        else None
+                    ),
                     source="wandb_selective_read",
                 )
 
@@ -1250,7 +1313,7 @@ def query_wandb(
                     limit=applied_limit,
                     page_size=MCP_MAX_WANDB_QUERY_ITEMS_PER_PAGE,
                     include_spec="spec" in include_fields,
-                    cursor=cursor,
+                    cursor=projected_cursor,
                 )
             except SelectiveReadUnavailable as exc:
                 if "spec" not in include_fields:
@@ -1294,7 +1357,13 @@ def query_wandb(
                     None if has_more else offset + len(items),
                     cursor=cursor,
                     next_cursor=(
-                        _encode_sdk_cursor(resource, offset + len(items), sdk_cursor_fingerprint) if has_more else None
+                        _encode_query_cursor(
+                            kind="sdk_offset",
+                            position=offset + len(items),
+                            fingerprint=cursor_fingerprint,
+                        )
+                        if has_more
+                        else None
                     ),
                     compatibility_caveat=f"{exc}; used a small bounded SDK fallback",
                 )
@@ -1308,7 +1377,15 @@ def query_wandb(
                 reports.has_more,
                 reports.total_count,
                 cursor=cursor,
-                next_cursor=reports.next_cursor,
+                next_cursor=(
+                    _encode_query_cursor(
+                        kind="projected",
+                        position=reports.next_cursor,
+                        fingerprint=cursor_fingerprint,
+                    )
+                    if reports.next_cursor is not None
+                    else None
+                ),
                 source="wandb_selective_read",
             )
         except Exception as exc:

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -98,6 +98,18 @@ query MCPProjectedRun(
 }
 """
 
+PROJECT_METADATA_QUERY = """
+query MCPProjectMetadata($entity: String!, $project: String!) {
+  project(name: $project, entityName: $entity) {
+    id
+    name
+    entityName
+    description
+    runCount
+  }
+}
+"""
+
 PROJECTED_SWEEPS_QUERY = """
 query MCPProjectedSweeps(
   $entity: String!
@@ -615,6 +627,38 @@ def _project_payload(data: Mapping[str, Any]) -> Mapping[str, Any]:
     if not isinstance(project, Mapping):
         raise ValueError("W&B project was not found or is not accessible")
     return project
+
+
+def fetch_project_metadata(api: Any, *, entity: str, project: str) -> dict[str, Any]:
+    """Fetch stable project metadata in one fixed, query-only request."""
+    raise_if_tool_deadline_exceeded()
+    try:
+        data = execute_graphql(
+            api,
+            PROJECT_METADATA_QUERY,
+            {"entity": entity, "project": project},
+        )
+    except Exception as exc:
+        _raise_selective_failure("project metadata query unavailable", exc)
+
+    project_payload = _project_payload(data)
+    project_id = project_payload.get("id")
+    project_name = project_payload.get("name")
+    run_count = project_payload.get("runCount")
+    if not isinstance(project_id, str) or not project_id:
+        raise SelectiveReadUnavailable("project metadata query returned no project id")
+    if not isinstance(project_name, str) or not project_name:
+        raise SelectiveReadUnavailable("project metadata query returned no project name")
+    if isinstance(run_count, bool) or not isinstance(run_count, int) or run_count < 0:
+        raise SelectiveReadUnavailable("project metadata query returned an invalid run count")
+
+    return {
+        "id": project_id,
+        "name": project_name,
+        "entity": project_payload.get("entityName") or entity,
+        "description": project_payload.get("description"),
+        "run_count": run_count,
+    }
 
 
 def fetch_projected_runs(
@@ -1411,6 +1455,7 @@ __all__ = [
     "ARTIFACT_INVENTORY_QUERY",
     "REGISTRY_ARTIFACT_VERSIONS_QUERY",
     "METRIC_VALUE_STEPS_QUERY",
+    "PROJECT_METADATA_QUERY",
     "PROJECTED_RUNS_QUERY",
     "PROJECTED_RUN_QUERY",
     "PROJECTED_SWEEPS_QUERY",
@@ -1427,6 +1472,7 @@ __all__ = [
     "fetch_metric_value_steps",
     "fetch_registry_artifact_versions",
     "fetch_project_counts",
+    "fetch_project_metadata",
     "fetch_project_fields",
     "fetch_projected_run",
     "fetch_projected_runs",

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -16,6 +16,7 @@ from wandb_mcp_server.server import register_tools
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 README = REPOSITORY_ROOT / "README.md"
+QUERY_CAPABILITIES = REPOSITORY_ROOT / "docs" / "query-capabilities.md"
 FEATURE_FLAGS = (
     "WANDB_MCP_ENABLE_RAW_GRAPHQL",
     "WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS",
@@ -76,3 +77,50 @@ def test_relative_documentation_links_resolve():
                 broken.append(f"{path.relative_to(REPOSITORY_ROOT)} -> {target}")
 
     assert not broken, "Broken relative documentation links:\n" + "\n".join(broken)
+
+
+def test_every_former_named_graphql_example_has_a_typed_v040_route():
+    text = QUERY_CAPABILITIES.read_text()
+    route_rows = dict(
+        re.findall(
+            r"^\| `([^`]+)` \| `([^`]+)` \|",
+            text,
+            flags=re.MULTILINE,
+        )
+    )
+
+    assert route_rows == {
+        "MinimalRunIdVsDisplayName": "query_wandb_tool",
+        "GetProjectInfo": "query_wandb_tool",
+        "GetSortedRuns": "query_wandb_tool",
+        "GetFilteredRuns": "query_wandb_tool",
+        "GetRunByDisplayName": "query_wandb_tool",
+    }
+
+
+def test_query_capability_matrix_routes_typed_specialized_and_raw_reads():
+    text = QUERY_CAPABILITIES.read_text()
+
+    for typed_route in (
+        'query_wandb_tool(resource="project")',
+        'query_wandb_tool(resource="run", run_id=...)',
+        'query_wandb_tool(resource="runs", filters=..., order=...)',
+        'query_wandb_tool(resource="sweep"|"sweeps")',
+        'query_wandb_tool(resource="reports", report_name=...)',
+    ):
+        assert f"`{typed_route}`" in text
+
+    for specialized_tool in (
+        "get_run_history_tool",
+        "list_artifact_versions_tool",
+        "get_artifact_details_tool",
+        "list_registries_tool",
+        "list_registry_collections_tool",
+        "list_wandb_automations_tool",
+        "list_wandb_integrations_tool",
+    ):
+        assert f"`{specialized_tool}`" in text
+
+    raw_rows = [line for line in text.splitlines() if line.startswith("|") and "query_wandb_graphql_tool" in line]
+    assert len(raw_rows) == 4
+    assert all(line.rstrip().endswith("| Yes |") for line in raw_rows)

--- a/tests/test_query_wandb_hardening.py
+++ b/tests/test_query_wandb_hardening.py
@@ -72,6 +72,27 @@ def _install_api(monkeypatch, api):
     monkeypatch.setattr(query_module, "track_tool_execution", _tracking)
 
 
+def _projected_cursor_for(**overrides):
+    query = {
+        "entity_name": "entity",
+        "project_name": "project",
+        "resource": "runs",
+        "filters": {"state": "finished"},
+        "order": "-created_at",
+        "report_name": None,
+        "include": frozenset({"summary", "config"}),
+        "summary_keys": ["accuracy"],
+        "config_keys": ["learning_rate"],
+    }
+    query.update(overrides)
+    fingerprint = query_module._collection_cursor_fingerprint(**query)
+    return query_module._encode_query_cursor(
+        kind="projected",
+        position="private-backend-position",
+        fingerprint=fingerprint,
+    )
+
+
 def test_real_wandb_028_runs_paginator_is_bounded_to_one_page(monkeypatch):
     def handler(query, variables):
         assert variables["perPage"] == 50
@@ -149,7 +170,7 @@ def test_config_only_single_projection_preserves_default_summary_and_nulls(monke
     assert "graphql_id" not in result["item"]
 
 
-def test_projected_run_cursor_and_lightweight_sweep_have_no_n_plus_one(monkeypatch):
+def test_projected_run_cursor_allows_changed_limit_and_lightweight_sweep_has_no_n_plus_one(monkeypatch):
     def handler(query, variables):
         assert query == PROJECTED_RUNS_QUERY
         assert variables["includeSweep"] is True
@@ -184,12 +205,13 @@ def test_projected_run_cursor_and_lightweight_sweep_have_no_n_plus_one(monkeypat
         "entity",
         "project",
         "runs",
-        limit=2,
+        limit=1,
         include=["sweep"],
         cursor=first["next_cursor"],
     )
 
-    assert first["next_cursor"] == "cursor-2"
+    assert first["next_cursor"].startswith("mcp-query-v1:")
+    assert "cursor-2" not in first["next_cursor"]
     assert first["truncation"]["applied"] is True
     assert second["has_more"] is False
     assert second["next_cursor"] is None
@@ -278,7 +300,8 @@ def test_report_total_count_is_unknown_when_more_pages_exist(monkeypatch):
     result = query_module.query_wandb("entity", "project", "reports", limit=1)
 
     assert result["total_count"] is None
-    assert result["next_cursor"] == "r-1"
+    assert result["next_cursor"].startswith("mcp-query-v1:")
+    assert "r-1" not in result["next_cursor"]
 
 
 def test_clamped_limit_does_not_claim_more_when_backend_is_exhausted(monkeypatch):
@@ -447,7 +470,7 @@ def test_partial_sdk_projection_fallback_cursor_continues_without_skipping(monke
     )
 
     assert first["items"][0]["id"] == "run-1"
-    assert first["next_cursor"].startswith("mcp-sdk-v1:")
+    assert first["next_cursor"].startswith("mcp-query-v1:")
     assert second["items"][0]["id"] == "run-2"
     assert second["has_more"] is False
     assert second["next_cursor"] is None
@@ -520,7 +543,8 @@ def test_oversized_or_nonfinite_typed_inputs_fail_before_api(monkeypatch, kwargs
         **kwargs,
     )
 
-    assert result["error"] == "invalid_request"
+    expected_error = "invalid_cursor" if "cursor" in kwargs else "invalid_request"
+    assert result["error"] == expected_error
 
 
 @pytest.mark.parametrize(
@@ -568,7 +592,7 @@ def test_deep_mongo_filter_fails_before_api(monkeypatch):
 
 
 def test_sdk_fallback_cursor_request_ceiling_is_checked_before_api(monkeypatch):
-    fingerprint = query_module._sdk_cursor_fingerprint(
+    fingerprint = query_module._collection_cursor_fingerprint(
         entity_name="entity",
         project_name="project",
         resource="runs",
@@ -579,7 +603,7 @@ def test_sdk_fallback_cursor_request_ceiling_is_checked_before_api(monkeypatch):
         summary_keys=None,
         config_keys=None,
     )
-    cursor = query_module._encode_sdk_cursor("runs", 500, fingerprint)
+    cursor = query_module._encode_query_cursor(kind="sdk_offset", position=500, fingerprint=fingerprint)
     monkeypatch.setattr(
         query_module.WandBApiManager,
         "get_api",
@@ -594,12 +618,12 @@ def test_sdk_fallback_cursor_request_ceiling_is_checked_before_api(monkeypatch):
         cursor=cursor,
     )
 
-    assert result["error"] == "invalid_request"
+    assert result["error"] == "invalid_cursor"
     assert "compatibility window" in result["message"]
 
 
 def test_sdk_fallback_cursor_is_bound_to_original_query(monkeypatch):
-    fingerprint = query_module._sdk_cursor_fingerprint(
+    fingerprint = query_module._collection_cursor_fingerprint(
         entity_name="entity",
         project_name="project",
         resource="runs",
@@ -610,7 +634,7 @@ def test_sdk_fallback_cursor_is_bound_to_original_query(monkeypatch):
         summary_keys=None,
         config_keys=None,
     )
-    cursor = query_module._encode_sdk_cursor("runs", 1, fingerprint)
+    cursor = query_module._encode_query_cursor(kind="sdk_offset", position=1, fingerprint=fingerprint)
     monkeypatch.setattr(
         query_module.WandBApiManager,
         "get_api",
@@ -625,8 +649,119 @@ def test_sdk_fallback_cursor_is_bound_to_original_query(monkeypatch):
         cursor=cursor,
     )
 
-    assert result["error"] == "invalid_request"
+    assert result["error"] == "invalid_cursor"
     assert "does not match" in result["message"]
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"entity_name": "other-entity"},
+        {"project_name": "other-project"},
+        {"filters": {"state": "running"}},
+        {"order": "+created_at"},
+        {"include": ["summary", "config", "system_metrics"]},
+        {"summary_keys": ["loss"]},
+        {"config_keys": ["batch_size"]},
+    ],
+    ids=["entity", "project", "filters", "order", "include", "summary-keys", "config-keys"],
+)
+def test_projected_cursor_is_query_bound_before_api_construction(monkeypatch, changed):
+    cursor = _projected_cursor_for()
+    request = {
+        "entity_name": "entity",
+        "project_name": "project",
+        "resource": "runs",
+        "filters": {"state": "finished"},
+        "order": "-created_at",
+        "include": ["summary", "config"],
+        "summary_keys": ["accuracy"],
+        "config_keys": ["learning_rate"],
+        "limit": 1,
+        "cursor": cursor,
+    }
+    request.update(changed)
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for a mismatched continuation"),
+    )
+
+    result = query_module.query_wandb(**request)
+
+    assert result["error"] == "invalid_cursor"
+    assert "does not match" in result["message"]
+
+
+def test_projected_cursor_is_bound_to_resource_and_report_selector_before_api(monkeypatch):
+    collection_cursor = query_module._encode_query_cursor(
+        kind="projected",
+        position="private-backend-position",
+        fingerprint=query_module._collection_cursor_fingerprint(
+            entity_name="entity",
+            project_name="project",
+            resource="runs",
+            filters=None,
+            order="-created_at",
+            report_name=None,
+            include=frozenset(),
+            summary_keys=None,
+            config_keys=None,
+        ),
+    )
+    report_cursor = _projected_cursor_for(
+        resource="reports",
+        filters=None,
+        report_name="Quarterly report",
+        include=frozenset(),
+        summary_keys=None,
+        config_keys=None,
+    )
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for a mismatched continuation"),
+    )
+
+    cross_resource = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="sweeps",
+        cursor=collection_cursor,
+    )
+    changed_selector = query_module.query_wandb(
+        entity_name="entity",
+        project_name="project",
+        resource="reports",
+        report_name="Different report",
+        cursor=report_cursor,
+    )
+
+    assert cross_resource["error"] == "invalid_cursor"
+    assert changed_selector["error"] == "invalid_cursor"
+    assert "does not match" in cross_resource["message"]
+    assert "does not match" in changed_selector["message"]
+
+
+@pytest.mark.parametrize(
+    "cursor",
+    [
+        "private-backend-position",
+        "mcp-query-v1:not-base64!",
+        query_module._encode_query_cursor(kind="projected", position="position", fingerprint="wrong-query"),
+    ],
+    ids=["raw-backend", "malformed-envelope", "wrong-fingerprint"],
+)
+def test_malformed_or_unbound_typed_cursors_fail_before_api(monkeypatch, cursor):
+    monkeypatch.setattr(
+        query_module.WandBApiManager,
+        "get_api",
+        lambda: pytest.fail("API must not be created for an invalid continuation"),
+    )
+
+    result = query_module.query_wandb("entity", "project", "runs", cursor=cursor)
+
+    assert result["error"] == "invalid_cursor"
 
 
 def test_filtered_report_cursor_is_validated_before_api_construction(monkeypatch):
@@ -658,7 +793,7 @@ def test_filtered_report_cursor_is_validated_before_api_construction(monkeypatch
         report_name="Release report",
         limit=1,
     )
-    assert first["next_cursor"].startswith("mcp-report-v1:")
+    assert first["next_cursor"].startswith("mcp-query-v1:")
 
     monkeypatch.setattr(
         query_module.WandBApiManager,
@@ -696,11 +831,11 @@ def test_filtered_report_cursor_is_validated_before_api_construction(monkeypatch
         cursor=first["next_cursor"],
     )
 
-    assert mismatch["error"] == "invalid_request"
+    assert mismatch["error"] == "invalid_cursor"
     assert "does not match" in mismatch["message"]
-    assert malformed["error"] == "invalid_request"
+    assert malformed["error"] == "invalid_cursor"
     assert "not a valid" in malformed["message"]
-    assert missing_report_name["error"] == "invalid_request"
-    assert "original report_name" in missing_report_name["message"]
-    assert cross_resource["error"] == "invalid_request"
-    assert "resource='reports'" in cross_resource["message"]
+    assert missing_report_name["error"] == "invalid_cursor"
+    assert "does not match" in missing_report_name["message"]
+    assert cross_resource["error"] == "invalid_cursor"
+    assert "does not match" in cross_resource["message"]

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -165,7 +165,8 @@ def test_invalid_requests_do_not_create_api(monkeypatch, kwargs, message):
 
     result = sdk_query.query_wandb(**kwargs)
 
-    assert result["error"] == "invalid_request"
+    expected_error = "invalid_cursor" if "cursor" in kwargs else "invalid_request"
+    assert result["error"] == expected_error
     assert message in result["message"]
 
 
@@ -302,6 +303,91 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
     )
 
     assert fake_api.calls[0][0:2] == ("runs", "entity/project")
+
+
+@pytest.mark.parametrize(
+    ("example_name", "arguments", "expected_call", "expected_shape"),
+    [
+        (
+            "MinimalRunIdVsDisplayName-run-id",
+            {"resource": "run", "run_id": "run-1"},
+            ("run", "entity/project/run-1"),
+            "item",
+        ),
+        (
+            "MinimalRunIdVsDisplayName-display-name",
+            {"resource": "runs", "filters": {"displayName": {"$eq": "display-run-1"}}, "limit": 1},
+            ("runs", "entity/project"),
+            "items",
+        ),
+        (
+            "GetProjectInfo",
+            {"resource": "project"},
+            ("project", "project", "entity"),
+            "item",
+        ),
+        (
+            "GetSortedRuns",
+            {
+                "resource": "runs",
+                "order": "+summary_metrics.accuracy",
+                "summary_keys": ["accuracy"],
+                "limit": 1,
+            },
+            ("runs", "entity/project"),
+            "items",
+        ),
+        (
+            "GetFilteredRuns",
+            {
+                "resource": "runs",
+                "filters": {"state": "finished", "summary_metrics.accuracy": {"$gt": 0.8}},
+                "order": "-summary_metrics.accuracy",
+                "limit": 1,
+            },
+            ("runs", "entity/project"),
+            "items",
+        ),
+        (
+            "GetRunByDisplayName",
+            {"resource": "runs", "filters": {"displayName": {"$eq": "display-run-1"}}, "limit": 1},
+            ("runs", "entity/project"),
+            "items",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_former_graphql_examples_succeed_through_public_mcp_boundary(
+    fake_api,
+    monkeypatch,
+    example_name,
+    arguments,
+    expected_call,
+    expected_shape,
+):
+    """Keep every former named GraphQL example working through typed MCP input."""
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    server = create_mcp_server("stdio")
+    result = await server.call_tool(
+        "query_wandb_tool",
+        {"entity_name": "entity", "project_name": "project", **arguments},
+    )
+
+    assert isinstance(result, tuple), example_name
+    payload = result[1]["result"]
+    assert payload["resource"] == arguments["resource"]
+    assert payload["source"] in {"wandb_sdk", "wandb_selective_read"}
+    assert expected_shape in payload
+    if expected_shape == "item":
+        assert payload["item"]["id"] in {"project-id", "run-1"}
+    else:
+        assert payload["items"][0]["id"] == "run-1"
+
+    call = fake_api.calls[-1]
+    assert call[: len(expected_call)] == expected_call
+    if arguments["resource"] == "runs":
+        assert call[2]["filters"] == arguments.get("filters")
+        assert call[2]["order"] == arguments.get("order", "-created_at")
 
 
 def test_count_mode_uses_public_sdk_without_iterating(fake_api):
@@ -493,7 +579,7 @@ def test_explicit_report_spec_sdk_fallback_cursor_continues(fake_api, monkeypatc
     )
 
     assert first["items"][0]["id"] == "report-1"
-    assert first["next_cursor"].startswith("mcp-sdk-v1:")
+    assert first["next_cursor"].startswith("mcp-query-v1:")
     assert second["items"][0]["id"] == "report-2"
     assert second["total_count"] == 2
     assert second["has_more"] is False

--- a/tests/test_query_wandb_sdk.py
+++ b/tests/test_query_wandb_sdk.py
@@ -170,14 +170,82 @@ def test_invalid_requests_do_not_create_api(monkeypatch, kwargs, message):
     assert message in result["message"]
 
 
-def test_project_uses_public_sdk_and_stable_single_envelope(fake_api):
+def test_project_uses_fixed_projection_and_stable_single_envelope(fake_api, monkeypatch):
+    projection_calls = []
+
+    def projected(api, *, entity, project):
+        projection_calls.append((api, entity, project))
+        return {
+            "id": "project-id",
+            "name": project,
+            "entity": entity,
+            "description": "Project description",
+            "run_count": 41,
+        }
+
+    monkeypatch.setattr(sdk_query, "fetch_project_metadata", projected)
+
     result = sdk_query.query_wandb("entity", "project", "project")
 
-    assert fake_api.calls == [("project", "project", "entity")]
-    assert result["source"] == "wandb_sdk"
+    assert projection_calls == [(fake_api, "entity", "project")]
+    assert fake_api.calls == []
+    assert result["source"] == "wandb_selective_read"
     assert result["resource"] == "project"
     assert result["item"]["id"] == "project-id"
+    assert result["item"]["description"] == "Project description"
+    assert result["item"]["run_count"] == 41
+    assert result["item"]["url"] == "https://wandb.ai/entity/project"
     assert result["truncation"] == {"applied": False}
+
+
+def test_project_projection_falls_back_to_two_bounded_public_sdk_reads(fake_api, monkeypatch):
+    monkeypatch.setattr(
+        sdk_query,
+        "fetch_project_metadata",
+        lambda *args, **kwargs: (_ for _ in ()).throw(SelectiveReadUnavailable("projection unavailable")),
+    )
+    fake_api.project_result.description = None
+
+    class CountedRuns:
+        def __len__(self):
+            return 3
+
+    def counted_runs(path, **kwargs):
+        fake_api.calls.append(("runs", path, kwargs))
+        return CountedRuns()
+
+    fake_api.runs = counted_runs
+
+    result = sdk_query.query_wandb("entity", "project", "project")
+
+    assert fake_api.calls == [
+        ("project", "project", "entity"),
+        (
+            "runs",
+            "entity/project",
+            {"per_page": 1, "include_sweeps": False, "lazy": True},
+        ),
+    ]
+    assert result["source"] == "wandb_sdk"
+    assert result["item"]["description"] is None
+    assert result["item"]["run_count"] == 3
+    assert "description may be unavailable" in result["compatibility_caveat"]
+
+
+def test_project_projection_preserves_actionable_upstream_errors_without_sdk_fallback(fake_api, monkeypatch):
+    class UnauthorizedError(RuntimeError):
+        status_code = 401
+
+    def unauthorized(*args, **kwargs):
+        raise UnauthorizedError("secret upstream response")
+
+    monkeypatch.setattr(sdk_query, "fetch_project_metadata", unauthorized)
+
+    result = sdk_query.query_wandb("entity", "project", "project")
+
+    assert result["error"] == "authentication_failed"
+    assert result["message"] == "W&B authentication failed"
+    assert fake_api.calls == []
 
 
 def test_run_includes_summary_by_default_and_requested_details(fake_api):
@@ -323,7 +391,7 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
         (
             "GetProjectInfo",
             {"resource": "project"},
-            ("project", "project", "entity"),
+            None,
             "item",
         ),
         (
@@ -343,6 +411,7 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
                 "resource": "runs",
                 "filters": {"state": "finished", "summary_metrics.accuracy": {"$gt": 0.8}},
                 "order": "-summary_metrics.accuracy",
+                "summary_keys": ["accuracy"],
                 "limit": 1,
             },
             ("runs", "entity/project"),
@@ -350,7 +419,12 @@ async def test_public_mcp_schema_dispatches_targeted_summary_keys(fake_api, monk
         ),
         (
             "GetRunByDisplayName",
-            {"resource": "runs", "filters": {"displayName": {"$eq": "display-run-1"}}, "limit": 1},
+            {
+                "resource": "runs",
+                "filters": {"displayName": {"$eq": "display-run-1"}},
+                "summary_keys": ["accuracy"],
+                "limit": 1,
+            },
             ("runs", "entity/project"),
             "items",
         ),
@@ -367,6 +441,20 @@ async def test_former_graphql_examples_succeed_through_public_mcp_boundary(
 ):
     """Keep every former named GraphQL example working through typed MCP input."""
     monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+    project_projection_calls = []
+    if arguments["resource"] == "project":
+
+        def projected(api, *, entity, project):
+            project_projection_calls.append((api, entity, project))
+            return {
+                "id": "project-id",
+                "name": project,
+                "entity": entity,
+                "description": "Project description",
+                "run_count": 41,
+            }
+
+        monkeypatch.setattr(sdk_query, "fetch_project_metadata", projected)
     server = create_mcp_server("stdio")
     result = await server.call_tool(
         "query_wandb_tool",
@@ -382,9 +470,16 @@ async def test_former_graphql_examples_succeed_through_public_mcp_boundary(
         assert payload["item"]["id"] in {"project-id", "run-1"}
     else:
         assert payload["items"][0]["id"] == "run-1"
+    if example_name == "GetProjectInfo":
+        assert payload["item"]["description"] == "Project description"
+        assert payload["item"]["run_count"] == 41
+        assert project_projection_calls == [(fake_api, "entity", "project")]
+    if arguments.get("summary_keys"):
+        assert payload["items"][0]["summary"] == {"accuracy": 0.9}
 
-    call = fake_api.calls[-1]
-    assert call[: len(expected_call)] == expected_call
+    if expected_call is not None:
+        call = fake_api.calls[-1]
+        assert call[: len(expected_call)] == expected_call
     if arguments["resource"] == "runs":
         assert call[2]["filters"] == arguments.get("filters")
         assert call[2]["order"] == arguments.get("order", "-created_at")

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -17,12 +17,14 @@ from wandb_mcp_server.wandb_selective_reads import (
     PROJECTED_SWEEPS_QUERY,
     PROJECT_COUNTS_QUERY,
     PROJECT_FIELDS_QUERY,
+    PROJECT_METADATA_QUERY,
     REGISTRY_ARTIFACT_VERSIONS_QUERY,
     ProjectedReportCursorError,
     SelectiveReadUnavailable,
     fetch_registry_artifact_versions,
     fetch_project_counts,
     fetch_project_fields,
+    fetch_project_metadata,
     fetch_metric_value_steps,
     fetch_projected_reports,
     fetch_projected_run,
@@ -38,6 +40,16 @@ class FakeServiceApi:
     def execute_graphql(self, query, variables=None):
         variables = variables or {}
         self.calls.append((query, variables))
+        if "MCPProjectMetadata" in query:
+            return {
+                "project": {
+                    "id": "project-id",
+                    "name": variables["project"],
+                    "entityName": variables["entity"],
+                    "description": "Customer project",
+                    "runCount": 41,
+                }
+            }
         if "MCPProjectedRuns" in query:
             summary = {key: 0.9 if key == "accuracy" else 0.2 for key in variables["summaryKeys"]}
             config = {key: {"value": 0.01} for key in variables["configKeys"]}
@@ -202,11 +214,45 @@ def test_every_application_owned_document_is_query_only():
         PROJECTED_SWEEPS_QUERY,
         PROJECT_COUNTS_QUERY,
         PROJECT_FIELDS_QUERY,
+        PROJECT_METADATA_QUERY,
         ARTIFACT_INVENTORY_QUERY,
         METRIC_VALUE_STEPS_QUERY,
         REGISTRY_ARTIFACT_VERSIONS_QUERY,
     ):
         validate_read_only_graphql(document)
+
+
+def test_project_metadata_is_one_fixed_query_only_request():
+    api = FakeApi()
+
+    result = fetch_project_metadata(api, entity="entity", project="project")
+
+    assert result == {
+        "id": "project-id",
+        "name": "project",
+        "entity": "entity",
+        "description": "Customer project",
+        "run_count": 41,
+    }
+    assert api._service_api.calls == [(PROJECT_METADATA_QUERY, {"entity": "entity", "project": "project"})]
+
+
+def test_project_metadata_wraps_transport_incompatibility_for_sdk_fallback():
+    class IncompatibleServiceApi:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            raise RuntimeError("field unavailable")
+
+    api = FakeApi()
+    api._service_api = IncompatibleServiceApi()
+
+    with pytest.raises(SelectiveReadUnavailable, match="project metadata query unavailable: RuntimeError"):
+        fetch_project_metadata(api, entity="entity", project="project")
+
+    assert api._service_api.calls == 1
 
 
 def test_projected_collection_fetches_only_requested_fields_in_one_request():


### PR DESCRIPTION
## Summary

- wrap every typed collection continuation in an opaque envelope bound to its resource, entity, project, filters, ordering, selector, and requested projection
- reject malformed or mismatched cursors as `invalid_cursor` before constructing a W&B client; callers may still change only the page limit between requests
- verify every formerly documented GraphQL example through the public MCP `query_wandb_tool` boundary and document the typed/specialized/raw capability routes
- preserve `GetProjectInfo` parity through one fixed query-only project projection returning `description` and exact `run_count`, with a bounded public-SDK fallback
- preserve targeted summary values in filtered and display-name run migrations
- run typed-query and raw query-only hardening under the unpinned-latest W&B compatibility job

## Why

Projected collection cursors previously exposed raw backend positions. A caller could accidentally reuse one with a different project, filter, ordering, report selector, or field projection. That could return an incorrect continuation page. This change binds both projected cursors and bounded SDK fallback offsets to the originating query.

The W&B 0.28 public `Project` object does not expose project description or run count. A fixed application-owned `MCPProjectMetadata` query restores those stable fields without accepting caller-supplied GraphQL. It is a single query-only request; transport compatibility failures use two bounded public-SDK paths and carry an explicit caveat.

Raw GraphQL remains disabled by default and available only through the existing opt-in, query-only `query_wandb_graphql_tool` escape hatch. This PR adds no tools and changes no deployment flags.

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- focused query/read-only suite: 125 passed
- full Python 3.12 non-integration suite: 1,149 passed, 10 deselected
- W&B 0.28.1 / Workspaces 0.4.4 compatibility suite: 349 passed, 1 deselected

## Release integration

- Base: `staging/0.4.0`
- This is the public MCP portion of the final v0.4 release gate.
- Leave draft until CI and release review are complete.
