### PR TITLE
fix: make registry reads actor-safe and bounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
             tests/test_diagnose_run.py \
             tests/test_query_artifacts.py \
             tests/test_query_registry.py \
+            tests/test_registry_read_correctness.py \
             tests/test_summarize_evaluation.py \
             tests/test_infer_schema.py \
             tests/test_tool_registration.py \

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Recommended deployment presets:
 
 | Deployment | Settings |
 |---|---|
-| W&B-hosted | W&B-managed feature profile; caller-supplied raw GraphQL remains disabled. Weave Agent and ARIA tools are enabled only where W&B has validated their service paths. |
+| W&B-hosted | Weave Agent tools enabled; ARIA and caller-supplied raw GraphQL disabled by default. ARIA is available only through a separately validated W&B-managed profile. |
 | Strict customer read-only | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false`, `WANDB_MCP_ENABLE_ARIA_TOOLS=false` |
 | Trusted read-only compatibility | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=true`, `WANDB_MCP_ENABLE_ARIA_TOOLS=false`, `MCP_MAX_GQL_ITEMS=50`, `MCP_MAX_GQL_ITEMS_PER_PAGE=20` |
 
@@ -174,6 +174,14 @@ These tools are disabled by default. Enable them with `WANDB_MCP_ENABLE_WEAVE_AG
 **ARIA tools are opt-in:** Set `WANDB_MCP_ENABLE_ARIA_TOOLS=true` only when the deployment has an approved HTTPS path to the hosted W&B Agent service. The default is `false`, including Dedicated/Self-Managed deployments, so customer credentials are never forwarded to the public ARIA service implicitly. `WANDB_MCP_READ_ONLY=true` additionally omits `aria_send_message` while retaining polling when the ARIA group is explicitly enabled.
 
 **ARIA polling:** ARIA calls are asynchronous. `aria_send_message` returns a turn handle, and `aria_get_turn` polls one turn for up to 30 seconds. Use `aria_get_turns` for several outstanding turns so they are fetched concurrently within one shared polling window. Poll results are compact by default; pass `include_turn=true` only when a bounded raw service snapshot is needed.
+
+**Registry organization resolution:** Registry tools use the authenticated
+request's W&B client when `organization` is omitted. A single accessible
+organization is selected automatically; callers with access to multiple
+organizations receive `organization_required` with a bounded candidate list.
+Collection listings intentionally return `aliases: null` and
+`aliases_loaded: false` instead of loading every collection's version aliases.
+Use `list_artifact_versions_tool` when aliases are needed.
 
 </details>
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -48,6 +48,15 @@ History reads support bounded range scans, custom axes, and target-value
 verification. Analysis tools use selective server-side fields instead of
 materializing complete run objects whenever the W&B API supports projection.
 
+Registry organization inference now stays on the authenticated,
+request-scoped W&B client. Explicit organization input wins; otherwise one
+accessible organization is selected automatically, while ambiguous accounts
+receive a bounded `organization_required` response instead of a Python
+exception. Registry, collection, and registry-version reads share that result.
+Collection listings no longer trigger one lazy alias request per collection;
+they return `aliases: null` and `aliases_loaded: false`, and callers use
+`list_artifact_versions_tool` for actual version aliases.
+
 ### Correct multi-key history
 
 For explicit multi-key default-history sampled and ranged collection reads,
@@ -219,7 +228,7 @@ Use these reviewed presets:
 
 | Deployment | Settings |
 |---|---|
-| W&B-hosted | W&B-managed feature profile; caller-supplied raw GraphQL remains disabled. Weave Agent and ARIA tools are enabled only where W&B has validated their service paths. |
+| W&B-hosted | Weave Agent tools enabled; ARIA and caller-supplied raw GraphQL disabled by default. ARIA is available only through a separately validated W&B-managed profile. |
 | Strict customer read-only | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=false`, `WANDB_MCP_ENABLE_ARIA_TOOLS=false` |
 | Trusted read-only compatibility | `WANDB_MCP_READ_ONLY=true`, `WANDB_MCP_ENABLE_RAW_GRAPHQL=true`, `WANDB_MCP_ENABLE_ARIA_TOOLS=false`, `MCP_MAX_GQL_ITEMS=50`, `MCP_MAX_GQL_ITEMS_PER_PAGE=20` |
 

--- a/src/wandb_mcp_server/api_client.py
+++ b/src/wandb_mcp_server/api_client.py
@@ -80,6 +80,26 @@ def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
                 pending.append(nested)
 
 
+def _http_status(value: object) -> int | None:
+    """Read status codes from requests/httpx and W&B service responses."""
+    for attr in ("status_code", "status", "http_status", "http_status_code"):
+        candidate = getattr(value, attr, None)
+        if isinstance(candidate, int) and not isinstance(candidate, bool) and candidate > 0:
+            return candidate
+    return None
+
+
+def wandb_http_status_from_exception(exc: BaseException) -> int | None:
+    """Return the first HTTP status carried anywhere in a W&B exception chain."""
+    for current in _exception_chain(exc):
+        if status := _http_status(current):
+            return status
+        response = getattr(current, "response", None)
+        if response is not None and (status := _http_status(response)):
+            return status
+    return None
+
+
 def wandb_write_outcome_unknown_from_exception(exc: BaseException) -> bool:
     """Return whether an exception chain contains an unconfirmed W&B write."""
     return any(isinstance(current, WandBWriteOutcomeUnknown) for current in _exception_chain(exc))
@@ -120,13 +140,13 @@ def wandb_server_busy_from_exception(exc: BaseException) -> WandBServerBusy | No
             return current
         messages.append(str(current))
         response = getattr(current, "response", None)
-        candidate = getattr(response, "status_code", None)
+        candidate = _http_status(current) or (_http_status(response) if response is not None else None)
         if candidate in {429, 503}:
             status_code = int(candidate)
             headers = getattr(response, "headers", None)
             if isinstance(headers, Mapping):
                 retry_after = headers.get("Retry-After") or headers.get("retry-after")
-            for attr in ("reason", "text"):
+            for attr in ("reason", "text", "message"):
                 response_text = getattr(response, attr, None)
                 if response_text:
                     messages.append(str(response_text))

--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -10,10 +10,18 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
 from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS, MCP_WORKLOAD_PROFILE
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.registry_support import (
+    bounded_sdk_page,
+    fit_registry_response,
+    nullable_string,
+    registry_error_result,
+    require_registry,
+    resolve_registry_organization,
+    validate_optional_identifier,
+)
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.wandb_selective_reads import (
     SelectiveReadUnavailable,
@@ -122,15 +130,15 @@ def list_artifact_versions(
         "list_artifact_versions",
         None,
         {
-            "collection_name": collection_name,
-            "entity_name": entity_name,
-            "project_name": project_name,
-            "registry_name": registry_name,
-            "type_name": type_name,
             "source": source,
             "max_items": max_items,
             "order": order,
             "tag_count": len(tags or []),
+            "has_entity": entity_name is not None,
+            "has_project": project_name is not None,
+            "has_registry": registry_name is not None,
+            "has_type": type_name is not None,
+            "has_organization": organization is not None,
             "has_created_after": created_after is not None,
             "has_created_before": created_before is not None,
         },
@@ -149,6 +157,13 @@ def list_artifact_versions(
             )
             if validation_error:
                 return json.dumps({"error": "invalid_input", "message": validation_error})
+            if source == "registry":
+                try:
+                    validate_optional_identifier("collection_name", collection_name)
+                    validate_optional_identifier("registry_name", registry_name)
+                    validate_optional_identifier("organization", organization)
+                except ValueError as exc:
+                    return json.dumps(registry_error_result(exc))
 
             max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
             order_value = _normalize_order(order)
@@ -161,13 +176,13 @@ def list_artifact_versions(
             exact_total: int | None = None
 
             if source == "registry":
-                reg_kwargs: Dict[str, Any] = {}
-                if organization is not None:
-                    reg_kwargs["organization"] = organization
-                registry = api.registry(registry_name, **reg_kwargs)
-                resolved_organization = organization or getattr(registry, "organization", None)
-                if not isinstance(resolved_organization, str) or not resolved_organization:
-                    raise ValueError("Unable to resolve the registry organization")
+                resolved_organization = resolve_registry_organization(api, organization)
+                registry_search = api.registries(
+                    organization=resolved_organization,
+                    filter={"name": registry_name},
+                    per_page=1,
+                )
+                require_registry(registry_search)
                 try:
                     page = fetch_registry_artifact_versions(
                         api,
@@ -181,11 +196,11 @@ def list_artifact_versions(
                     upstream_has_more = page.has_more
                 except SelectiveReadUnavailable as exc:
                     raise_for_wandb_server_busy(exc)
-                    versions_iter = registry.collections(
+                    versions_iter = registry_search.collections(
                         filter={"name": collection_name},
                         per_page=min(scan_limit, 100),
                     ).versions(per_page=min(scan_limit, 100))
-                    raw_versions, upstream_has_more = _bounded_iterable(versions_iter, scan_limit)
+                    raw_versions, upstream_has_more = bounded_sdk_page(versions_iter, scan_limit)
                     compatibility_caveat = (
                         "This Dedicated backend lacks ordered registry-version projection; "
                         "a bounded SDK page was returned in backend order."
@@ -206,7 +221,7 @@ def list_artifact_versions(
                         exact_total = len(versions_iter)
                     except (TypeError, NotImplementedError):
                         exact_total = None
-                raw_versions, upstream_has_more = _bounded_iterable(versions_iter, scan_limit)
+                raw_versions, upstream_has_more = bounded_sdk_page(versions_iter, scan_limit)
 
             matching = [
                 _serialize_artifact_summary(artifact)
@@ -246,9 +261,19 @@ def list_artifact_versions(
             }
             if compatibility_caveat:
                 result["compatibility_caveat"] = compatibility_caveat
-            return json.dumps(result)
+            if source == "registry":
+                result = fit_registry_response(
+                    result,
+                    aliases=("versions",),
+                    optional_fields=("description", "tags", "aliases", "digest"),
+                )
+            return json.dumps(result, allow_nan=False)
 
         except Exception as e:
+            if source == "registry":
+                logger.error("Registry version listing failed (%s)", type(e).__name__)
+                ctx.mark_error(type(e).__name__)
+                return json.dumps(registry_error_result(e))
             raise_for_wandb_server_busy(e)
             logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
             ctx.mark_error(f"{type(e).__name__}: {e}")
@@ -509,7 +534,7 @@ def _serialize_artifact_summary(artifact: Any) -> Dict[str, Any]:
         "size": getattr(artifact, "size", None),
         "file_count": getattr(artifact, "file_count", None),
         "description": getattr(artifact, "description", None),
-        "created_at": str(getattr(artifact, "created_at", "")),
+        "created_at": nullable_string(getattr(artifact, "created_at", None)),
         "digest": getattr(artifact, "digest", None),
     }
 
@@ -544,10 +569,13 @@ def _validate_version_query(
         return str(exc)
     if after_dt and before_dt and after_dt > before_dt:
         return "created_after must not be later than created_before"
-    if tags is not None and (
-        not isinstance(tags, list) or any(not isinstance(tag, str) or not tag.strip() for tag in tags)
-    ):
-        return "tags must be a list of non-empty strings"
+    if tags is not None:
+        if not isinstance(tags, list) or any(not isinstance(tag, str) or not tag.strip() for tag in tags):
+            return "tags must be a list of non-empty strings"
+        if len(tags) > 100:
+            return "tags cannot contain more than 100 values"
+        if any(len(tag.encode("utf-8")) > 512 for tag in tags):
+            return "each tag must be at most 512 bytes"
     return None
 
 
@@ -609,23 +637,6 @@ def _matches_artifact_filters(
         (created_after is not None and created_at < created_after)
         or (created_before is not None and created_at > created_before)
     )
-
-
-def _bounded_iterable(values: Any, scan_limit: int) -> tuple[list[Any], bool]:
-    iterator = iter(values)
-    rows: list[Any] = []
-    for _ in range(scan_limit):
-        raise_if_tool_deadline_exceeded()
-        try:
-            rows.append(next(iterator))
-        except StopIteration:
-            return rows, False
-    raise_if_tool_deadline_exceeded()
-    try:
-        next(iterator)
-    except StopIteration:
-        return rows, False
-    return rows, True
 
 
 def _serialize_run_info(run: Any) -> Optional[Dict[str, Any]]:

--- a/src/wandb_mcp_server/mcp_tools/query_registry.py
+++ b/src/wandb_mcp_server/mcp_tools/query_registry.py
@@ -7,12 +7,24 @@ collections via the ``wandb.Api`` public interface.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
-from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
+from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.config import MCP_MAX_WANDB_QUERY_ITEMS
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.registry_support import (
+    RegistryInputError,
+    bounded_sdk_page,
+    fit_registry_response,
+    nullable_string,
+    registry_error_result,
+    require_registry,
+    resolve_registry_organization,
+    validate_optional_identifier,
+    validate_registry_filter,
+)
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -42,8 +54,9 @@ Typical workflow:
 
 <critical_info>
 Requires the user's API key to have access to the organization. If no
-organization is specified, uses the default organization for the
-authenticated user.
+organization is specified, one accessible organization is selected. Accounts
+with more than one accessible organization receive `organization_required`
+with a bounded candidate list.
 Supports MongoDB-style filters on name, description, etc.
 (e.g., {"name": {"$regex": "model.*"}}).
 </critical_info>
@@ -51,7 +64,7 @@ Supports MongoDB-style filters on name, description, etc.
 Parameters
 ----------
 organization : str, optional
-    W&B organization name. Omit to use the authenticated user's default org.
+    W&B organization name. Omit to resolve one accessible organization.
 filter : dict, optional
     MongoDB-style filter dict (e.g., {"name": {"$regex": "model.*"}}).
 max_items : int, optional
@@ -76,38 +89,52 @@ def list_registries(
     with track_tool_execution(
         "list_registries",
         None,
-        {"organization": organization, "filter": filter, "max_items": max_items},
+        {
+            "has_organization": organization is not None,
+            "has_filter": filter is not None,
+            "max_items": max_items,
+        },
     ) as ctx:
         try:
-            if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
-                return json.dumps({"error": "invalid_input", "message": "max_items must be a positive integer"})
+            _validate_request(
+                organization=organization,
+                registry_name=None,
+                filter=filter,
+                max_items=max_items,
+            )
             max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
             api = WandBApiManager.get_api()
-            kwargs: Dict[str, Any] = {"per_page": min(max_items + 1, 100)}
-            if organization is not None:
-                kwargs["organization"] = organization
+            resolved_organization = resolve_registry_organization(api, organization)
+            kwargs: Dict[str, Any] = {
+                "organization": resolved_organization,
+                "per_page": min(max_items + 1, 100),
+            }
             if filter is not None:
                 kwargs["filter"] = filter
 
-            page, has_more = _bounded_page(api.registries(**kwargs), max_items)
+            page, has_more = bounded_sdk_page(api.registries(**kwargs), max_items)
             registries: List[Dict[str, Any]] = []
             for reg in page:
+                artifact_types, artifact_types_truncated = _bounded_string_values(
+                    getattr(reg, "artifact_types", []),
+                )
                 registries.append(
                     {
-                        "name": getattr(reg, "name", None),
-                        "full_name": getattr(reg, "full_name", None),
-                        "organization": getattr(reg, "organization", None),
-                        "entity": getattr(reg, "entity", None),
-                        "description": getattr(reg, "description", None),
-                        "visibility": getattr(reg, "visibility", None),
-                        "artifact_types": list(getattr(reg, "artifact_types", [])),
-                        "created_at": str(getattr(reg, "created_at", "")),
-                        "updated_at": str(getattr(reg, "updated_at", "")),
+                        "name": _bounded_text(getattr(reg, "name", None)),
+                        "full_name": _bounded_text(getattr(reg, "full_name", None)),
+                        "organization": _bounded_text(getattr(reg, "organization", None)),
+                        "entity": _bounded_text(getattr(reg, "entity", None)),
+                        "description": _bounded_text(getattr(reg, "description", None)),
+                        "visibility": _bounded_text(getattr(reg, "visibility", None)),
+                        "artifact_types": artifact_types,
+                        "artifact_types_truncated": artifact_types_truncated,
+                        "created_at": nullable_string(getattr(reg, "created_at", None)),
+                        "updated_at": nullable_string(getattr(reg, "updated_at", None)),
                     }
                 )
 
             total_count = None if has_more else len(registries)
-            return json.dumps(
+            result = fit_registry_response(
                 {
                     "items": registries,
                     "registries": registries,
@@ -118,14 +145,15 @@ def list_registries(
                     "project_exhaustive": not has_more,
                     "count": len(registries),
                     "truncated": has_more,
-                }
+                },
+                aliases=("registries",),
             )
+            return json.dumps(result, allow_nan=False)
 
         except Exception as e:
-            raise_for_wandb_server_busy(e)
-            logger.error(f"Error in list_registries: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Registry listing failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(registry_error_result(e))
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +181,7 @@ Parameters
 registry_name : str
     The registry short name (e.g., "model", "dataset", "my-registry").
 organization : str, optional
-    W&B organization name. Omit to use default.
+    W&B organization name. Omit to resolve one accessible organization.
 filter : dict, optional
     MongoDB-style filter (e.g., {"tag": "production"}).
 max_items : int, optional
@@ -163,7 +191,9 @@ Returns
 -------
 JSON with:
   - registry: the queried registry name
-  - collections: list of collection objects with name, type, tags, aliases, etc.
+  - collections: list of collection objects with name, type, tags, and metadata.
+    Collection-wide aliases are intentionally not loaded; use
+    list_artifact_versions_tool for version aliases.
   - returned_count / total_count: returned and exact totals when known
   - has_more / project_exhaustive: explicit pagination scope
 """
@@ -181,49 +211,57 @@ def list_registry_collections(
         "list_registry_collections",
         None,
         {
-            "registry_name": registry_name,
-            "organization": organization,
-            "filter": filter,
+            "has_organization": organization is not None,
+            "has_filter": filter is not None,
             "max_items": max_items,
         },
     ) as ctx:
         try:
-            if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
-                return json.dumps({"error": "invalid_input", "message": "max_items must be a positive integer"})
+            _validate_request(
+                organization=organization,
+                registry_name=registry_name,
+                filter=filter,
+                max_items=max_items,
+            )
             max_items = min(max_items, MCP_MAX_WANDB_QUERY_ITEMS)
             api = WandBApiManager.get_api()
-            reg_kwargs: Dict[str, Any] = {}
-            if organization is not None:
-                reg_kwargs["organization"] = organization
-            registry = api.registry(registry_name, **reg_kwargs)
+            resolved_organization = resolve_registry_organization(api, organization)
+            registry_search = api.registries(
+                organization=resolved_organization,
+                filter={"name": registry_name},
+                per_page=1,
+            )
+            require_registry(registry_search)
 
             coll_kwargs: Dict[str, Any] = {"per_page": min(max_items + 1, 100)}
             if filter is not None:
                 coll_kwargs["filter"] = filter
 
-            collection_iter = registry.collections(**coll_kwargs)
-            exact_total: int | None = None
-            try:
-                exact_total = len(collection_iter)
-            except (TypeError, NotImplementedError):
-                pass
-            page, has_more = _bounded_page(collection_iter, max_items)
+            collection_iter = registry_search.collections(**coll_kwargs)
+            page, has_more = bounded_sdk_page(collection_iter, max_items)
+            last_response = getattr(collection_iter, "last_response", None)
+            exact_total = getattr(last_response, "total_count", None)
+            if not isinstance(exact_total, int) or isinstance(exact_total, bool):
+                exact_total = None
             collections: List[Dict[str, Any]] = []
             for coll in page:
+                tags, tags_truncated = _bounded_string_values(getattr(coll, "tags", []))
                 collections.append(
                     {
-                        "name": getattr(coll, "name", None),
-                        "type": getattr(coll, "type", None),
-                        "description": getattr(coll, "description", None),
-                        "tags": getattr(coll, "tags", []),
-                        "aliases": getattr(coll, "aliases", []),
-                        "created_at": str(getattr(coll, "created_at", "")),
-                        "updated_at": str(getattr(coll, "updated_at", "")),
+                        "name": _bounded_text(getattr(coll, "name", None)),
+                        "type": _bounded_text(getattr(coll, "type", None)),
+                        "description": _bounded_text(getattr(coll, "description", None)),
+                        "tags": tags,
+                        "tags_truncated": tags_truncated,
+                        "aliases": None,
+                        "aliases_loaded": False,
+                        "created_at": nullable_string(getattr(coll, "created_at", None)),
+                        "updated_at": nullable_string(getattr(coll, "updated_at", None)),
                         "is_sequence": coll.is_sequence() if hasattr(coll, "is_sequence") else None,
                     }
                 )
 
-            return json.dumps(
+            result = fit_registry_response(
                 {
                     "registry": registry_name,
                     "items": collections,
@@ -235,24 +273,52 @@ def list_registry_collections(
                     "project_exhaustive": not has_more,
                     "count": len(collections),
                     "truncated": has_more,
-                }
+                },
+                aliases=("collections",),
             )
+            return json.dumps(result, allow_nan=False)
 
         except Exception as e:
-            raise_for_wandb_server_busy(e)
-            logger.error(f"Error in list_registry_collections: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Registry collection listing failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(registry_error_result(e))
 
 
-def _bounded_page(values: Any, limit: int) -> tuple[list[Any], bool]:
-    """Consume at most limit-plus-one values from a lazy SDK collection."""
-    rows: list[Any] = []
+def _validate_request(
+    *,
+    organization: str | None,
+    registry_name: str | None,
+    filter: Mapping[str, Any] | None,
+    max_items: int,
+) -> None:
+    if isinstance(max_items, bool) or not isinstance(max_items, int) or max_items < 1:
+        raise RegistryInputError("max_items must be a positive integer")
+    validate_optional_identifier("organization", organization)
+    validate_optional_identifier("registry_name", registry_name)
+    validate_registry_filter(filter)
+
+
+def _bounded_text(value: Any, *, max_chars: int = 16_000) -> str | None:
+    rendered = nullable_string(value)
+    if rendered is None or len(rendered) <= max_chars:
+        return rendered
+    return f"{rendered[:max_chars]}…"
+
+
+def _bounded_string_values(values: Any, *, limit: int = 100) -> tuple[list[str], bool]:
+    if values is None:
+        return [], False
+    result: list[str] = []
     iterator = iter(values)
     for _ in range(limit + 1):
         raise_if_tool_deadline_exceeded()
         try:
-            rows.append(next(iterator))
+            value = next(iterator)
         except StopIteration:
-            break
-    return rows[:limit], len(rows) > limit
+            return result, False
+        if len(result) < limit:
+            name = value if isinstance(value, str) else getattr(value, "name", value)
+            rendered = _bounded_text(name, max_chars=512)
+            if rendered is not None:
+                result.append(rendered)
+    return result, True

--- a/src/wandb_mcp_server/registry_support.py
+++ b/src/wandb_mcp_server/registry_support.py
@@ -1,0 +1,471 @@
+"""Shared, bounded support for read-only W&B Registry tools."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+import math
+import threading
+from typing import Any
+
+from wandb_mcp_server.admission import raise_if_tool_deadline_exceeded
+from wandb_mcp_server.api_client import (
+    wandb_http_status_from_exception,
+    wandb_server_busy_from_exception,
+)
+from wandb_mcp_server.config import MAX_RESPONSE_TOKENS, structured_error
+from wandb_mcp_server.trace_utils import count_tokens_conservative
+from wandb_mcp_server.wandb_graphql import GraphQLResponseTooLarge
+from wandb_mcp_server.wandb_selective_reads import (
+    SelectiveReadUnavailable,
+    fetch_registry_organization_info,
+)
+
+_MAX_FILTER_DEPTH = 12
+_MAX_FILTER_BYTES = 64 * 1024
+_MAX_ORGANIZATION_CANDIDATES = 20
+_MAX_TEXT_BYTES = 512
+_MAX_PAGINATOR_REQUESTS = 8
+_CACHE_ATTRIBUTE = "_wandb_mcp_registry_organization_resolution"
+_LOCK_ATTRIBUTE = "_wandb_mcp_registry_organization_lock"
+_CACHE_GUARD = threading.Lock()
+
+
+class RegistryInputError(ValueError):
+    """Raised before constructing or calling a W&B client."""
+
+
+class OrganizationRequired(ValueError):
+    """Raised when the authenticated actor has multiple possible organizations."""
+
+    def __init__(self, candidates: tuple[str, ...], *, candidates_truncated: bool = False) -> None:
+        super().__init__("Specify organization because more than one organization is accessible.")
+        self.candidates = candidates
+        self.candidates_truncated = candidates_truncated
+
+
+class OrganizationResolutionFailed(ValueError):
+    """Raised when no organization can be resolved from a bounded response."""
+
+    def __init__(self) -> None:
+        super().__init__("Unable to resolve a W&B organization for registry access.")
+
+
+class RegistryMalformedResponse(ValueError):
+    """Raised when a registry response does not match the public SDK contract."""
+
+
+def validate_optional_identifier(name: str, value: str | None) -> None:
+    """Validate an optional, bounded non-empty registry identifier."""
+    if value is None:
+        return
+    if not isinstance(value, str) or not value.strip():
+        raise RegistryInputError(f"{name} must be a non-empty string when provided")
+    if len(value.encode("utf-8")) > _MAX_TEXT_BYTES:
+        raise RegistryInputError(f"{name} exceeds the {_MAX_TEXT_BYTES}-byte limit")
+
+
+def validate_registry_filter(value: Mapping[str, Any] | None) -> None:
+    """Apply the typed-query filter depth, type, and byte limits."""
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise RegistryInputError("filter must be an object")
+    _validate_filter_value(value)
+    try:
+        encoded = json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        raise RegistryInputError("filter must contain finite JSON-compatible values") from None
+    if len(encoded) > _MAX_FILTER_BYTES:
+        raise RegistryInputError(f"filter exceeds the {_MAX_FILTER_BYTES}-byte limit")
+
+
+def _validate_filter_value(value: Any, *, depth: int = 0) -> None:
+    if depth > _MAX_FILTER_DEPTH:
+        raise RegistryInputError(f"filter exceeds the maximum depth of {_MAX_FILTER_DEPTH}")
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise RegistryInputError("filter must use string keys")
+            _validate_filter_value(child, depth=depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        for child in value:
+            _validate_filter_value(child, depth=depth + 1)
+        return
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float) and math.isfinite(value):
+        return
+    raise RegistryInputError("filter must contain finite JSON-compatible values")
+
+
+def resolve_registry_organization(api: Any, explicit: str | None = None) -> str:
+    """Resolve a registry organization without constructing another SDK client.
+
+    Successful and ambiguous results are cached directly on the actor-isolated
+    ``wandb.Api`` instance. The manager already bounds that instance's lifetime.
+    """
+    validate_optional_identifier("organization", explicit)
+    if explicit is not None:
+        return explicit.strip()
+
+    lock = _organization_lock(api)
+    with lock:
+        cached = vars(api).get(_CACHE_ATTRIBUTE)
+        if cached is not None:
+            return _read_cached_resolution(cached)
+
+        settings = getattr(api, "settings", None)
+        configured = settings.get("organization") if isinstance(settings, Mapping) else None
+        if isinstance(configured, str) and configured.strip():
+            validate_optional_identifier("organization", configured)
+            resolution = ("resolved", configured.strip(), False)
+            setattr(api, _CACHE_ATTRIBUTE, resolution)
+            return configured.strip()
+
+        configured_entity = settings.get("entity") if isinstance(settings, Mapping) else None
+        entity = configured_entity.strip() if isinstance(configured_entity, str) and configured_entity.strip() else None
+        validate_optional_identifier("entity", entity)
+
+        try:
+            data = fetch_registry_organization_info(api, entity=entity)
+        except SelectiveReadUnavailable as exc:
+            raise RegistryMalformedResponse("organization lookup returned a malformed response") from exc
+        resolution = _parse_organization_resolution(data)
+        setattr(api, _CACHE_ATTRIBUTE, resolution)
+        return _read_cached_resolution(resolution)
+
+
+def _organization_lock(api: Any) -> threading.Lock:
+    existing = vars(api).get(_LOCK_ATTRIBUTE)
+    if isinstance(existing, type(threading.Lock())):
+        return existing
+    with _CACHE_GUARD:
+        existing = vars(api).get(_LOCK_ATTRIBUTE)
+        if isinstance(existing, type(threading.Lock())):
+            return existing
+        lock = threading.Lock()
+        setattr(api, _LOCK_ATTRIBUTE, lock)
+        return lock
+
+
+def _parse_organization_resolution(data: Any) -> tuple[str, str | tuple[str, ...], bool]:
+    if not isinstance(data, Mapping):
+        raise RegistryMalformedResponse("organization lookup returned a malformed response")
+    entity = data.get("entity")
+    if entity is None:
+        viewer = data.get("viewer")
+        if viewer is None:
+            return ("failed", (), False)
+        if not isinstance(viewer, Mapping):
+            raise RegistryMalformedResponse("organization lookup returned a malformed viewer")
+        default_entity = viewer.get("entity")
+        if default_entity is not None:
+            if not isinstance(default_entity, str) or not default_entity.strip():
+                raise RegistryMalformedResponse("organization lookup returned a malformed default entity")
+            default_entity = _bounded_upstream_identifier("default entity", default_entity)
+        organizations = viewer.get("organizations")
+        if organizations is not None and not isinstance(organizations, list):
+            raise RegistryMalformedResponse("organization lookup returned a malformed organization list")
+        if isinstance(organizations, list) and default_entity:
+            matching = [
+                item
+                for item in organizations
+                if isinstance(item, Mapping)
+                and isinstance(item.get("orgEntity"), Mapping)
+                and item["orgEntity"].get("name") == default_entity
+            ]
+            if len(matching) == 1:
+                organizations = matching
+        entity = {"organization": None, "user": {"organizations": organizations or []}}
+    if not isinstance(entity, Mapping):
+        raise RegistryMalformedResponse("organization lookup returned a malformed entity")
+
+    organization = entity.get("organization")
+    if isinstance(organization, Mapping):
+        name = organization.get("name")
+        org_entity = organization.get("orgEntity")
+        if isinstance(name, str) and name.strip() and isinstance(org_entity, Mapping):
+            entity_name = org_entity.get("name")
+            if isinstance(entity_name, str) and entity_name.strip():
+                _bounded_upstream_identifier("organization entity name", entity_name)
+                return (
+                    "resolved",
+                    _bounded_upstream_identifier("organization name", name),
+                    False,
+                )
+
+    user = entity.get("user")
+    organizations = user.get("organizations") if isinstance(user, Mapping) else None
+    if organizations is None:
+        return ("failed", (), False)
+    if not isinstance(organizations, list):
+        raise RegistryMalformedResponse("organization lookup returned a malformed organization list")
+
+    candidates: list[str] = []
+    for item in organizations:
+        if item is None:
+            continue
+        if not isinstance(item, Mapping):
+            raise RegistryMalformedResponse("organization lookup returned a malformed organization")
+        name = item.get("name")
+        org_entity = item.get("orgEntity")
+        entity_name = org_entity.get("name") if isinstance(org_entity, Mapping) else None
+        if isinstance(name, str) and name.strip() and isinstance(entity_name, str) and entity_name.strip():
+            _bounded_upstream_identifier("organization entity name", entity_name)
+            candidates.append(_bounded_upstream_identifier("organization name", name))
+    unique = tuple(sorted(set(candidates)))
+    if len(unique) == 1:
+        return ("resolved", unique[0], False)
+    if not unique:
+        return ("failed", (), False)
+    truncated = len(unique) > _MAX_ORGANIZATION_CANDIDATES
+    return ("required", unique[:_MAX_ORGANIZATION_CANDIDATES], truncated)
+
+
+def _read_cached_resolution(resolution: Any) -> str:
+    if not isinstance(resolution, tuple) or len(resolution) != 3:
+        raise OrganizationResolutionFailed()
+    kind, value, truncated = resolution
+    if kind == "resolved" and isinstance(value, str):
+        return value
+    if kind == "required" and isinstance(value, tuple):
+        raise OrganizationRequired(value, candidates_truncated=bool(truncated))
+    raise OrganizationResolutionFailed()
+
+
+def registry_error_result(exc: Exception) -> dict[str, object]:
+    """Map registry failures to stable, non-sensitive tool errors."""
+    if isinstance(exc, RegistryInputError):
+        return structured_error("invalid_input", str(exc))
+    if isinstance(exc, OrganizationRequired):
+        return structured_error(
+            "organization_required",
+            str(exc),
+            organization_candidates=list(exc.candidates),
+            candidates_truncated=exc.candidates_truncated,
+        )
+    if isinstance(exc, OrganizationResolutionFailed):
+        return structured_error("organization_resolution_failed", str(exc))
+    if isinstance(exc, GraphQLResponseTooLarge):
+        return structured_error(
+            "response_too_large",
+            "The bounded W&B registry response was too large; request fewer items",
+        )
+    if busy := wandb_server_busy_from_exception(exc):
+        return busy.as_dict()
+
+    status = wandb_http_status_from_exception(exc)
+    names, message = _exception_signals(exc)
+    if (
+        status == 401
+        or "authentication" in names
+        or "unauth" in names
+        or "invalid api key" in message
+        or "no w&b api key" in message
+    ):
+        return structured_error("authentication_failed", "W&B authentication failed")
+    if status == 403 or "permission" in message or "forbidden" in message:
+        return structured_error("permission_denied", "W&B denied registry access")
+    if status == 404 or "not found" in message or "could not find" in message:
+        return structured_error("resource_not_found", "The requested W&B registry resource was not found")
+    if "timeout" in names or "timed out" in message or "did not respond in time" in message:
+        return structured_error(
+            "upstream_timeout",
+            "The bounded W&B registry request timed out",
+            retryable=True,
+        )
+    if isinstance(exc, RegistryMalformedResponse) or "validationerror" in names:
+        return structured_error("malformed_response", "W&B returned malformed registry data")
+    return structured_error("registry_query_failed", "W&B registry query failed")
+
+
+def require_registry(registries: Any) -> Any:
+    """Read at most one exact registry match from a public SDK paginator."""
+    page, _ = bounded_sdk_page(registries, 1)
+    if not page:
+        error = LookupError("registry not found")
+        error.status_code = 404  # type: ignore[attr-defined]
+        raise error from None
+    return page[0]
+
+
+def bounded_sdk_page(values: Any, limit: int) -> tuple[list[Any], bool]:
+    """Drive real W&B paginators one backend page at a time under a hard cap.
+
+    W&B 0.28 registry paginator ``__next__`` implementations may internally
+    skip arbitrarily many empty authorization-filtered pages. Calling the SDK's
+    one-page loader directly keeps its public object conversion while letting
+    MCP enforce request and cursor-progress bounds.
+    """
+    target = max(1, limit) + 1
+    loader = getattr(values, "_load_page", None)
+    objects = getattr(values, "objects", None)
+    per_page = getattr(values, "per_page", None)
+    if not callable(loader) or not isinstance(objects, list) or not isinstance(per_page, int):
+        if type(values).__module__.startswith("wandb."):
+            raise RegistryMalformedResponse("installed W&B registry paginator is unsupported")
+        return _bounded_plain_iterable(values, limit)
+
+    rows: list[Any] = list(objects[:target])
+    seen_cursors: set[str] = set()
+    initial_cursor = getattr(values, "cursor", None)
+    if isinstance(initial_cursor, str) and initial_cursor:
+        seen_cursors.add(initial_cursor)
+    requests = 0
+    expected_requests = math.ceil(target / max(1, per_page))
+    request_limit = min(_MAX_PAGINATOR_REQUESTS, expected_requests + 2)
+
+    while len(rows) < target and bool(getattr(values, "more", False)):
+        if requests >= request_limit:
+            raise RegistryMalformedResponse("registry pagination exceeded its request limit")
+        raise_if_tool_deadline_exceeded()
+        before_count = len(objects)
+        before_cursor = getattr(values, "cursor", None)
+        loaded = loader()
+        requests += 1
+        if not isinstance(loaded, bool):
+            raise RegistryMalformedResponse("registry paginator returned an invalid page state")
+        rows.extend(objects[before_count:target])
+        more = bool(getattr(values, "more", False))
+        if not more:
+            break
+        after_cursor = getattr(values, "cursor", None)
+        if not isinstance(after_cursor, str) or not after_cursor:
+            raise RegistryMalformedResponse("registry pagination omitted its continuation cursor")
+        if after_cursor == before_cursor or after_cursor in seen_cursors:
+            raise RegistryMalformedResponse("registry pagination repeated its continuation cursor")
+        seen_cursors.add(after_cursor)
+
+    return rows[:limit], len(rows) > limit or bool(getattr(values, "more", False))
+
+
+def _bounded_plain_iterable(values: Any, limit: int) -> tuple[list[Any], bool]:
+    iterator = iter(values)
+    rows: list[Any] = []
+    for _ in range(limit + 1):
+        raise_if_tool_deadline_exceeded()
+        try:
+            rows.append(next(iterator))
+        except StopIteration:
+            break
+    return rows[:limit], len(rows) > limit
+
+
+def _bounded_upstream_identifier(label: str, value: str) -> str:
+    stripped = value.strip()
+    if len(stripped.encode("utf-8")) > _MAX_TEXT_BYTES:
+        raise RegistryMalformedResponse(f"organization lookup returned an oversized {label}")
+    return stripped
+
+
+def _exception_signals(exc: BaseException) -> tuple[str, str]:
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    names: list[str] = []
+    messages: list[str] = []
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        names.append(type(current).__name__.lower())
+        messages.append(str(current).lower())
+        response = getattr(current, "response", None)
+        response_message = getattr(response, "message", None)
+        if response_message:
+            messages.append(str(response_message).lower())
+        for nested in (getattr(current, "exc", None), getattr(current, "__cause__", None)):
+            if isinstance(nested, BaseException):
+                pending.append(nested)
+    return " ".join(names), " ".join(messages)
+
+
+def nullable_string(value: Any) -> str | None:
+    """Serialize a nullable SDK scalar without converting ``None`` to text."""
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        try:
+            return str(isoformat())
+        except (TypeError, ValueError):
+            return None
+    return str(value)
+
+
+def fit_registry_response(
+    payload: dict[str, Any],
+    *,
+    aliases: tuple[str, ...],
+    optional_fields: tuple[str, ...] = ("description", "artifact_types", "tags"),
+) -> dict[str, Any]:
+    """Trim optional metadata and tail items to the configured response budget."""
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return structured_error("malformed_response", "W&B returned malformed registry data")
+    omitted_fields: set[str] = set()
+    dropped_items = 0
+
+    if _tokens(payload) > MAX_RESPONSE_TOKENS:
+        for field in optional_fields:
+            removed = False
+            for item in items:
+                if isinstance(item, dict) and field in item:
+                    item.pop(field)
+                    removed = True
+            if removed:
+                omitted_fields.add(field)
+            if _tokens(payload) <= MAX_RESPONSE_TOKENS:
+                break
+
+    while items and _tokens(payload) > MAX_RESPONSE_TOKENS:
+        items.pop()
+        dropped_items += 1
+
+    if omitted_fields or dropped_items:
+        payload["returned_count"] = len(items)
+        payload["count"] = len(items)
+        payload["has_more"] = True
+        payload["project_exhaustive"] = False
+        payload["truncated"] = True
+        payload["truncation"] = {
+            "applied": True,
+            "reason": "response_token_budget",
+            "omitted_fields": sorted(omitted_fields),
+            "dropped_items": dropped_items,
+        }
+        for alias in aliases:
+            payload[alias] = items
+
+    if _tokens(payload) > MAX_RESPONSE_TOKENS:
+        return structured_error(
+            "response_too_large",
+            "The W&B registry metadata exceeded the configured response budget",
+        )
+    return payload
+
+
+def _tokens(payload: Mapping[str, Any]) -> int:
+    try:
+        encoded = json.dumps(payload, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        raise RegistryMalformedResponse("registry response was not JSON-compatible") from None
+    return count_tokens_conservative(encoded)
+
+
+__all__ = [
+    "OrganizationRequired",
+    "OrganizationResolutionFailed",
+    "RegistryInputError",
+    "RegistryMalformedResponse",
+    "bounded_sdk_page",
+    "fit_registry_response",
+    "nullable_string",
+    "registry_error_result",
+    "require_registry",
+    "resolve_registry_organization",
+    "validate_optional_identifier",
+    "validate_registry_filter",
+]

--- a/src/wandb_mcp_server/wandb_selective_reads.py
+++ b/src/wandb_mcp_server/wandb_selective_reads.py
@@ -15,6 +15,37 @@ from wandb_mcp_server.wandb_graphql import GraphQLResponseTooLarge, execute_grap
 MAX_SAFE_HISTORY_STEP = (1 << 63) - 2
 
 
+REGISTRY_ORGANIZATION_QUERY = """
+query MCPRegistryOrganization($entity: String!, $hasEntity: Boolean!) {
+  entity(name: $entity) @include(if: $hasEntity) {
+    organization {
+      name
+      orgEntity {
+        name
+      }
+    }
+    user {
+      organizations {
+        name
+        orgEntity {
+          name
+        }
+      }
+    }
+  }
+  viewer @skip(if: $hasEntity) {
+    entity
+    organizations {
+      name
+      orgEntity {
+        name
+      }
+    }
+  }
+}
+"""
+
+
 PROJECTED_RUNS_QUERY = """
 query MCPProjectedRuns(
   $entity: String!
@@ -1764,10 +1795,14 @@ def fetch_registry_artifact_versions(
     cursor: str | None = None
     requests = 0
     has_next_page = False
+    seen_cursors: set[str] = set()
+    request_limit = _projected_page_request_limit(target, page_size)
     registry_filter = json.dumps({"name": f"wandb-registry-{registry_name}"}, separators=(",", ":"))
     collection_filter = json.dumps({"name": collection_name}, separators=(",", ":"))
 
     while len(items) < target:
+        if requests >= request_limit:
+            raise SelectiveReadUnavailable("ordered registry artifact query exceeded its request limit")
         raise_if_tool_deadline_exceeded()
         try:
             data = execute_graphql(
@@ -1791,27 +1826,33 @@ def fetch_registry_artifact_versions(
         if not isinstance(connection, Mapping):
             raise SelectiveReadUnavailable("ordered registry artifact query returned no version connection")
 
-        for edge in connection.get("edges") or []:
-            membership = edge.get("node") if isinstance(edge, Mapping) else None
+        edges, page_info, has_next_page = _projected_connection_page(
+            connection,
+            context="ordered registry artifact query",
+        )
+        remaining = target - len(items)
+        page_overflow = len(edges) > remaining
+        for edge in edges:
+            membership = edge.get("node")
             artifact = membership.get("artifact") if isinstance(membership, Mapping) else None
             if not isinstance(membership, Mapping) or not isinstance(artifact, Mapping):
-                continue
+                raise SelectiveReadUnavailable("ordered registry artifact query returned an invalid version")
             version_index = membership.get("versionIndex")
-            collection = membership.get("artifactCollection") or {}
+            collection = membership.get("artifactCollection")
+            if not isinstance(collection, Mapping):
+                raise SelectiveReadUnavailable("ordered registry artifact query returned an invalid collection")
+            aliases = membership.get("aliases")
+            tags = artifact.get("tags")
+            if not isinstance(aliases, list) or not all(isinstance(alias, Mapping) for alias in aliases):
+                raise SelectiveReadUnavailable("ordered registry artifact query returned invalid aliases")
+            if not isinstance(tags, list) or not all(isinstance(tag, Mapping) for tag in tags):
+                raise SelectiveReadUnavailable("ordered registry artifact query returned invalid tags")
             items.append(
                 {
                     "version": f"v{version_index}" if version_index is not None else None,
                     "name": collection.get("name"),
-                    "aliases": [
-                        alias.get("alias")
-                        for alias in membership.get("aliases") or []
-                        if isinstance(alias, Mapping) and alias.get("alias")
-                    ],
-                    "tags": [
-                        tag.get("name")
-                        for tag in artifact.get("tags") or []
-                        if isinstance(tag, Mapping) and tag.get("name")
-                    ],
+                    "aliases": [alias.get("alias") for alias in aliases if alias.get("alias")],
+                    "tags": [tag.get("name") for tag in tags if tag.get("name")],
                     "state": artifact.get("state"),
                     "size": artifact.get("size"),
                     "file_count": artifact.get("fileCount"),
@@ -1823,11 +1864,15 @@ def fetch_registry_artifact_versions(
             )
             if len(items) >= target:
                 break
-        page_info = connection.get("pageInfo") or {}
-        has_next_page = bool(page_info.get("hasNextPage"))
-        cursor = page_info.get("endCursor")
-        if not has_next_page or not cursor:
+        if not has_next_page:
+            has_next_page = page_overflow
             break
+        cursor = _next_projected_cursor(
+            context="ordered registry artifact query",
+            current=cursor,
+            candidate=page_info.get("endCursor"),
+            seen=seen_cursors,
+        )
 
     return ArtifactVersionPage(
         items=items,
@@ -1836,9 +1881,23 @@ def fetch_registry_artifact_versions(
     )
 
 
+def fetch_registry_organization_info(api: Any, *, entity: str | None) -> dict[str, Any]:
+    """Resolve registry organization candidates over the request-scoped transport."""
+    raise_if_tool_deadline_exceeded()
+    data = execute_graphql(
+        api,
+        REGISTRY_ORGANIZATION_QUERY,
+        {"entity": entity or "", "hasEntity": entity is not None},
+    )
+    if not isinstance(data, dict):
+        raise SelectiveReadUnavailable("registry organization query returned malformed data")
+    return data
+
+
 __all__ = [
     "ARTIFACT_INVENTORY_QUERY",
     "REGISTRY_ARTIFACT_VERSIONS_QUERY",
+    "REGISTRY_ORGANIZATION_QUERY",
     "METRIC_VALUE_STEPS_QUERY",
     "SAMPLED_HISTORY_SERIES_QUERY",
     "PROJECT_METADATA_QUERY",
@@ -1859,6 +1918,7 @@ __all__ = [
     "fetch_metric_value_steps",
     "fetch_sampled_history_series",
     "fetch_registry_artifact_versions",
+    "fetch_registry_organization_info",
     "fetch_project_counts",
     "fetch_project_metadata",
     "fetch_project_fields",

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock
 
 import pytest
 import requests
+from wandb.proto import wandb_api_pb2
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
 
 from wandb_mcp_server import api_client
 from wandb_mcp_server.api_client import (
@@ -141,6 +143,20 @@ def test_overload_service_unavailable_maps_to_server_busy() -> None:
 
     assert busy is not None
     assert busy.status_code == 503
+    assert busy.retry_after_ms == 1_000
+
+
+@pytest.mark.parametrize("status", [429, 503])
+def test_real_wandb_service_error_shape_maps_to_server_busy(status: int) -> None:
+    response = wandb_api_pb2.ApiErrorResponse(
+        http_status=status,
+        message="Service unavailable: capacity exhausted",
+    )
+
+    busy = wandb_server_busy_from_exception(WandbApiFailedError("W&B API request failed", response))
+
+    assert busy is not None
+    assert busy.status_code == status
     assert busy.retry_after_ms == 1_000
 
 

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -103,7 +103,7 @@ class TestListArtifactVersions:
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
         mock_registry = MagicMock()
-        mock_registry.organization = "my-org"
+        mock_registry.__iter__.side_effect = lambda: iter([MagicMock()])
         mock_collections = MagicMock()
         mock_collections.versions.return_value = iter(
             [
@@ -111,10 +111,17 @@ class TestListArtifactVersions:
             ]
         )
         mock_registry.collections.return_value = mock_collections
-        mock_api.registry.return_value = mock_registry
+        mock_api.registries.return_value = mock_registry
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_artifact_versions("my-model", registry_name="model-registry", source="registry"))
+        result = json.loads(
+            list_artifact_versions(
+                "my-model",
+                registry_name="model-registry",
+                organization="my-org",
+                source="registry",
+            )
+        )
 
         assert result["count"] == 1
         assert result["source"] == "registry"
@@ -161,6 +168,27 @@ class TestListArtifactVersions:
         )
 
         assert result["error"] == "invalid_input"
+        mock_api_mgr.get_api.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_oversized_tag_filters_do_not_construct_api(self, mock_api_mgr):
+        too_many = json.loads(
+            list_artifact_versions(
+                "team/project/my-model",
+                type_name="model",
+                tags=[f"tag-{index}" for index in range(101)],
+            )
+        )
+        too_large = json.loads(
+            list_artifact_versions(
+                "team/project/my-model",
+                type_name="model",
+                tags=["x" * 513],
+            )
+        )
+
+        assert too_many["error"] == "invalid_input"
+        assert too_large["error"] == "invalid_input"
         mock_api_mgr.get_api.assert_not_called()
 
     @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")

--- a/tests/test_query_registry.py
+++ b/tests/test_query_registry.py
@@ -1,7 +1,7 @@
 """Tests for registry discovery tools (list_registries, list_registry_collections)."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from wandb_mcp_server.mcp_tools.query_registry import (
     LIST_REGISTRIES_TOOL_DESCRIPTION,
@@ -31,11 +31,17 @@ def _make_collection(name="my-model", **overrides):
     coll.type = overrides.get("type", "model")
     coll.description = overrides.get("description", "A test collection")
     coll.tags = overrides.get("tags", ["production"])
-    coll.aliases = overrides.get("aliases", ["latest"])
     coll.created_at = overrides.get("created_at", "2025-01-01T00:00:00")
     coll.updated_at = overrides.get("updated_at", "2025-06-01T00:00:00")
     coll.is_sequence.return_value = overrides.get("is_sequence", True)
     return coll
+
+
+def _make_registry_search(registries, collections=()):
+    search = MagicMock()
+    search.__iter__.side_effect = lambda: iter(registries)
+    search.collections.return_value = iter(collections)
+    return search
 
 
 class TestListRegistries:
@@ -51,7 +57,7 @@ class TestListRegistries:
         )
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registries())
+        result = json.loads(list_registries(organization="my-org"))
 
         assert result["count"] == 2
         assert result["truncated"] is False
@@ -66,7 +72,7 @@ class TestListRegistries:
         mock_api_mgr.get_api.return_value = mock_api
 
         filt = {"name": {"$regex": "model.*"}}
-        list_registries(filter=filt)
+        list_registries(organization="my-org", filter=filt)
 
         call_kwargs = mock_api.registries.call_args[1]
         assert call_kwargs["filter"] == filt
@@ -80,7 +86,7 @@ class TestListRegistries:
         mock_api.registries.return_value = iter(regs)
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registries(max_items=999))
+        result = json.loads(list_registries(organization="my-org", max_items=999))
 
         assert result["count"] == 200
         assert result["truncated"] is True
@@ -95,10 +101,10 @@ class TestListRegistries:
         mock_api.registries.side_effect = Exception("Connection refused")
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registries())
+        result = json.loads(list_registries(organization="my-org"))
 
-        assert "error" in result
-        assert "Connection refused" in result["message"]
+        assert result["error"] == "registry_query_failed"
+        assert "Connection refused" not in result["message"]
 
     @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
     def test_empty_result(self, mock_api_mgr):
@@ -107,7 +113,7 @@ class TestListRegistries:
         mock_api.registries.return_value = iter([])
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registries())
+        result = json.loads(list_registries(organization="my-org"))
 
         assert result["count"] == 0
         assert result["registries"] == []
@@ -119,17 +125,14 @@ class TestListRegistryCollections:
     def test_basic(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
-        mock_registry.collections.return_value = iter(
-            [
-                _make_collection("model-a"),
-                _make_collection("model-b"),
-            ]
+        search = _make_registry_search(
+            [_make_registry("my-registry")],
+            [_make_collection("model-a"), _make_collection("model-b")],
         )
-        mock_api.registry.return_value = mock_registry
+        mock_api.registries.return_value = search
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registry_collections("my-registry"))
+        result = json.loads(list_registry_collections("my-registry", organization="my-org"))
 
         assert result["registry"] == "my-registry"
         assert result["count"] == 2
@@ -143,12 +146,10 @@ class TestListRegistryCollections:
     def test_empty(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
-        mock_registry.collections.return_value = iter([])
-        mock_api.registry.return_value = mock_registry
+        mock_api.registries.return_value = _make_registry_search([_make_registry("my-registry")])
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registry_collections("my-registry"))
+        result = json.loads(list_registry_collections("my-registry", organization="my-org"))
 
         assert result["count"] == 0
         assert result["collections"] == []
@@ -157,30 +158,31 @@ class TestListRegistryCollections:
     def test_collection_properties(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
         coll = _make_collection("prod-model", tags=["production", "v2"], is_sequence=True)
-        mock_registry.collections.return_value = iter([coll])
-        mock_api.registry.return_value = mock_registry
+        type(coll).aliases = PropertyMock(side_effect=AssertionError("aliases must stay lazy"))
+        mock_api.registries.return_value = _make_registry_search([_make_registry("my-registry")], [coll])
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registry_collections("my-registry"))
+        result = json.loads(list_registry_collections("my-registry", organization="my-org"))
         c = result["collections"][0]
 
         assert c["name"] == "prod-model"
         assert c["tags"] == ["production", "v2"]
         assert c["is_sequence"] is True
+        assert c["aliases"] is None
+        assert c["aliases_loaded"] is False
 
     @patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager")
     def test_api_error_returns_json(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_api.registry.side_effect = Exception("Registry not found")
+        mock_api.registries.side_effect = Exception("Registry not found")
         mock_api_mgr.get_api.return_value = mock_api
 
-        result = json.loads(list_registry_collections("nonexistent"))
+        result = json.loads(list_registry_collections("nonexistent", organization="my-org"))
 
-        assert "error" in result
-        assert "Registry not found" in result["message"]
+        assert result["error"] == "resource_not_found"
+        assert "nonexistent" not in result["message"]
 
 
 class TestToolDescriptions:

--- a/tests/test_registry_read_correctness.py
+++ b/tests/test_registry_read_correctness.py
@@ -1,0 +1,718 @@
+"""Registry correctness tests using W&B 0.28 public paginator classes."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from wandb.errors import AuthenticationError, CommError
+from wandb.apis.public import Api
+from wandb.proto import wandb_api_pb2
+from wandb.sdk.lib.service.service_connection import WandbApiFailedError
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from wandb_mcp_server.mcp_tools.query_artifacts import list_artifact_versions
+from wandb_mcp_server.mcp_tools.query_registry import list_registries, list_registry_collections
+from wandb_mcp_server.api_client import WandBApiManager
+from wandb_mcp_server.registry_support import (
+    RegistryMalformedResponse,
+    registry_error_result,
+    resolve_registry_organization,
+)
+from wandb_mcp_server.wandb_selective_reads import REGISTRY_ORGANIZATION_QUERY
+from wandb_mcp_server.server import create_mcp_server
+from wandb_mcp_server.wandb_graphql import validate_read_only_graphql
+
+
+def _registry_node(name: str = "models") -> dict[str, Any]:
+    return {
+        "__typename": "Project",
+        "id": f"registry-{name}",
+        "internalId": f"registry-internal-{name}",
+        "name": f"wandb-registry-{name}",
+        "entity": {"name": "registry-entity", "organization": {"name": "Example Org"}},
+        "description": None,
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": None,
+        "access": "PRIVATE",
+        "allowAllArtifactTypes": True,
+        "artifactTypes": {"edges": []},
+    }
+
+
+def _collection_node(name: str = "my-model") -> dict[str, Any]:
+    return {
+        "__typename": "ArtifactPortfolio",
+        "id": f"collection-{name}",
+        "name": name,
+        "description": None,
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": None,
+        "project": {
+            "id": "registry-models-project",
+            "internalId": "registry-models-project-internal",
+            "name": "wandb-registry-models",
+            "entity": {"name": "registry-entity"},
+        },
+        "type": {"name": "model"},
+        "tags": {"edges": []},
+    }
+
+
+class FakeRegistryService:
+    """Small fake transport beneath the real W&B registry paginators."""
+
+    def __init__(
+        self,
+        *,
+        organization_response: dict[str, Any] | None = None,
+        registries: list[dict[str, Any]] | None = None,
+        collections: list[dict[str, Any]] | None = None,
+        versions: list[dict[str, Any]] | None = None,
+        default_entity: str | None = "team-entity",
+        registry_pages: list[tuple[list[dict[str, Any]], str | None, bool]] | None = None,
+        collection_pages: list[tuple[list[dict[str, Any]], str | None, bool]] | None = None,
+    ) -> None:
+        self.organization_response = organization_response or {
+            "entity": {
+                "organization": {
+                    "name": "Example Org",
+                    "orgEntity": {"name": "registry-entity"},
+                },
+                "user": None,
+            }
+        }
+        self.registry_nodes = [_registry_node()] if registries is None else registries
+        self.collection_nodes = [_collection_node()] if collections is None else collections
+        self.version_nodes = (
+            [
+                {
+                    "versionIndex": 0,
+                    "aliases": [{"alias": "latest"}],
+                    "artifactCollection": {"name": "my-model"},
+                    "artifact": {
+                        "id": "artifact-0",
+                        "state": "COMMITTED",
+                        "description": None,
+                        "size": 12,
+                        "fileCount": 1,
+                        "createdAt": "2025-01-01T00:00:00Z",
+                        "updatedAt": None,
+                        "digest": "digest-0",
+                        "tags": [{"name": "production"}],
+                    },
+                }
+            ]
+            if versions is None
+            else versions
+        )
+        self.default_entity = default_entity
+        self.registry_pages = registry_pages
+        self.collection_pages = collection_pages
+        self.page_indexes = {"registries": 0, "collections": 0}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def feature_enabled(self, feature: Any) -> bool:
+        return True
+
+    def execute_graphql(
+        self,
+        query: str,
+        variables: dict[str, Any] | None = None,
+        parse: Any = None,
+        **_: Any,
+    ) -> Any:
+        variables = dict(variables or {})
+        if "MCPRegistryOrganization" in query:
+            operation = "organization"
+            if variables.get("hasEntity"):
+                result = self.organization_response
+            else:
+                entity = self.organization_response.get("entity") or {}
+                user = entity.get("user") or {}
+                organization = entity.get("organization")
+                organizations = user.get("organizations")
+                if organizations is None and organization is not None:
+                    organizations = [organization]
+                result = {
+                    "entity": None,
+                    "viewer": {
+                        "entity": self.default_entity,
+                        "organizations": organizations or [],
+                    },
+                }
+        elif "GetDefaultEntity" in query:
+            operation = "default_entity"
+            result = {"viewer": {"id": "viewer-id", "entity": self.default_entity}}
+        elif "FetchRegistries" in query:
+            operation = "registries"
+            nodes, end_cursor, has_next = self._page(
+                operation,
+                self.registry_nodes,
+                self.registry_pages,
+            )
+            result = {
+                "organization": {
+                    "orgEntity": {
+                        "projects": {
+                            "pageInfo": {
+                                "__typename": "PageInfo",
+                                "endCursor": end_cursor,
+                                "hasNextPage": has_next,
+                            },
+                            "edges": [{"node": node} for node in nodes],
+                        }
+                    }
+                }
+            }
+        elif "RegistryCollections" in query:
+            operation = "collections"
+            nodes, end_cursor, has_next = self._page(
+                operation,
+                self.collection_nodes,
+                self.collection_pages,
+            )
+            result = {
+                "organization": {
+                    "orgEntity": {
+                        "name": "registry-entity",
+                        "artifactCollections": {
+                            "totalCount": len(self.collection_nodes),
+                            "pageInfo": {
+                                "__typename": "PageInfo",
+                                "endCursor": end_cursor,
+                                "hasNextPage": has_next,
+                            },
+                            "edges": [{"node": node} for node in nodes],
+                        },
+                    }
+                }
+            }
+        elif "MCPRegistryArtifactVersions" in query:
+            operation = "versions"
+            result = {
+                "organization": {
+                    "orgEntity": {
+                        "artifactMemberships": {
+                            "edges": [
+                                {"cursor": f"version-{index}", "node": node}
+                                for index, node in enumerate(self.version_nodes)
+                            ],
+                            "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        }
+                    }
+                }
+            }
+        else:  # pragma: no cover - makes an unexpected SDK query fail loudly
+            raise AssertionError("unexpected registry GraphQL operation")
+        self.calls.append((operation, variables))
+        return parse(json.dumps(result)) if callable(parse) else result
+
+    def _page(
+        self,
+        operation: str,
+        default_nodes: list[dict[str, Any]],
+        pages: list[tuple[list[dict[str, Any]], str | None, bool]] | None,
+    ) -> tuple[list[dict[str, Any]], str | None, bool]:
+        if pages is None:
+            return default_nodes, None, False
+        index = self.page_indexes[operation]
+        self.page_indexes[operation] += 1
+        if index >= len(pages):
+            raise AssertionError(f"{operation} exceeded the configured fake pages")
+        return pages[index]
+
+
+def _api(service: FakeRegistryService, *, settings: dict[str, Any] | None = None) -> Api:
+    api = object.__new__(Api)
+    api._service_api = service
+    api._default_entity = None
+    api.settings = dict({"entity": "team-entity"} if settings is None else settings)
+    return api
+
+
+def _personal_orgs(*names: str) -> dict[str, Any]:
+    return {
+        "entity": {
+            "organization": None,
+            "user": {
+                "organizations": [{"name": name, "orgEntity": {"name": f"{name.lower()}-entity"}} for name in names]
+            },
+        }
+    }
+
+
+def test_explicit_organization_wins_without_resolution_request() -> None:
+    service = FakeRegistryService(organization_response={"entity": None})
+    api = _api(service)
+
+    assert resolve_registry_organization(api, "Explicit Org") == "Explicit Org"
+    assert service.calls == []
+
+
+def test_configured_organization_wins_without_resolution_request() -> None:
+    service = FakeRegistryService(organization_response={"entity": None})
+    api = _api(service, settings={"organization": "Configured Org", "entity": "team"})
+
+    assert resolve_registry_organization(api) == "Configured Org"
+    assert service.calls == []
+
+
+def test_team_entity_resolution_uses_same_transport_and_is_cached() -> None:
+    service = FakeRegistryService()
+    api = _api(service)
+
+    assert resolve_registry_organization(api) == "Example Org"
+    assert resolve_registry_organization(api) == "Example Org"
+    assert [operation for operation, _ in service.calls] == ["organization"]
+    assert service.calls[0][1] == {"entity": "team-entity", "hasEntity": True}
+
+
+def test_team_organization_and_entity_names_are_bounded() -> None:
+    service = FakeRegistryService(
+        organization_response={
+            "entity": {
+                "organization": {
+                    "name": "x" * 513,
+                    "orgEntity": {"name": "registry-entity"},
+                },
+                "user": None,
+            }
+        }
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "malformed_response"
+
+
+def test_organization_cache_is_isolated_per_api_client() -> None:
+    first_service = FakeRegistryService(organization_response=_personal_orgs("First Org"))
+    second_service = FakeRegistryService(organization_response=_personal_orgs("Second Org"))
+
+    assert resolve_registry_organization(_api(first_service)) == "First Org"
+    assert resolve_registry_organization(_api(second_service)) == "Second Org"
+    assert [operation for operation, _ in first_service.calls] == ["organization"]
+    assert [operation for operation, _ in second_service.calls] == ["organization"]
+
+
+def test_sdk_default_entity_and_single_personal_org_are_supported() -> None:
+    service = FakeRegistryService(organization_response=_personal_orgs("Only Org"))
+    api = _api(service, settings={})
+
+    assert resolve_registry_organization(api) == "Only Org"
+    assert [operation for operation, _ in service.calls] == ["organization"]
+    assert service.calls[0][1] == {"entity": "", "hasEntity": False}
+
+
+def test_unconfigured_default_org_is_resolved_in_one_fixed_request() -> None:
+    service = FakeRegistryService(default_entity="registry-entity")
+    api = _api(service, settings={})
+
+    assert resolve_registry_organization(api) == "Example Org"
+    assert [operation for operation, _ in service.calls] == ["organization"]
+
+
+def test_multiple_personal_orgs_return_bounded_candidates() -> None:
+    service = FakeRegistryService(organization_response=_personal_orgs("Org B", "Org A"))
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result == {
+        "error": "organization_required",
+        "message": "Specify organization because more than one organization is accessible.",
+        "organization_candidates": ["Org A", "Org B"],
+        "candidates_truncated": False,
+    }
+    assert [operation for operation, _ in service.calls] == ["organization"]
+
+
+def test_many_personal_orgs_return_bounded_candidates() -> None:
+    service = FakeRegistryService(organization_response=_personal_orgs(*(f"Org {index:02d}" for index in range(25))))
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "organization_required"
+    assert len(result["organization_candidates"]) == 20
+    assert result["candidates_truncated"] is True
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"entity": None},
+        {"entity": {"organization": None, "user": None}},
+        {"entity": {"organization": None, "user": {"organizations": []}}},
+    ],
+)
+def test_null_or_missing_organization_is_stable(response: dict[str, Any]) -> None:
+    service = FakeRegistryService(organization_response=response)
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "organization_resolution_failed"
+    assert "TypeError" not in json.dumps(result)
+
+
+def test_malformed_organization_connection_is_stable() -> None:
+    service = FakeRegistryService(
+        organization_response={"entity": {"organization": None, "user": {"organizations": {"bad": "shape"}}}}
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "malformed_response"
+
+
+def test_registry_and_collection_tools_use_real_sdk_paginators_without_alias_reads() -> None:
+    service = FakeRegistryService()
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        registries = json.loads(list_registries())
+        collections = json.loads(list_registry_collections("models"))
+
+    assert registries["returned_count"] == 1
+    assert registries["items"][0]["description"] is None
+    assert registries["items"][0]["updated_at"] is None
+    assert collections["returned_count"] == 1
+    assert collections["items"][0]["description"] is None
+    assert collections["items"][0]["updated_at"] is None
+    assert collections["items"][0]["aliases"] is None
+    assert collections["items"][0]["aliases_loaded"] is False
+    operations = [operation for operation, _ in service.calls]
+    assert operations == ["organization", "registries", "registries", "collections"]
+    assert "ArtifactCollectionAliases" not in " ".join(operations)
+
+
+def test_registry_version_workflow_reuses_resolved_org_and_public_registry_search() -> None:
+    service = FakeRegistryService()
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager.get_api", return_value=api):
+        versions = json.loads(
+            list_artifact_versions(
+                "my-model",
+                registry_name="models",
+                source="registry",
+            )
+        )
+
+    assert versions["returned_count"] == 1
+    assert versions["items"][0]["aliases"] == ["latest"]
+    assert versions["items"][0]["description"] is None
+    assert versions["items"][0]["updated_at"] is None
+    assert [operation for operation, _ in service.calls] == ["organization", "registries", "versions"]
+
+
+def test_fifty_collections_use_bounded_pages_and_zero_alias_requests() -> None:
+    service = FakeRegistryService(
+        collections=[_collection_node(f"model-{index}") for index in range(50)],
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registry_collections("models", max_items=50))
+
+    assert result["returned_count"] == 50
+    assert result["total_count"] == 50
+    assert [operation for operation, _ in service.calls] == ["organization", "registries", "collections"]
+
+
+def test_registry_paginator_crosses_one_empty_page_under_a_request_cap() -> None:
+    service = FakeRegistryService(
+        registry_pages=[
+            ([], "registry-page-1", True),
+            ([_registry_node()], None, False),
+        ]
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["returned_count"] == 1
+    assert [operation for operation, _ in service.calls] == ["organization", "registries", "registries"]
+
+
+def test_registry_paginator_rejects_repeated_cursor_without_request_amplification() -> None:
+    service = FakeRegistryService(
+        registry_pages=[
+            ([], "repeated", True),
+            ([], "repeated", True),
+        ]
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "malformed_response"
+    assert [operation for operation, _ in service.calls] == ["organization", "registries", "registries"]
+
+
+def test_registry_paginator_enforces_a_hard_empty_page_request_ceiling() -> None:
+    service = FakeRegistryService(registry_pages=[([], f"page-{index}", True) for index in range(10)])
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert result["error"] == "malformed_response"
+    assert [operation for operation, _ in service.calls].count("registries") == 3
+
+
+def test_collection_paginator_crosses_one_empty_page_under_a_request_cap() -> None:
+    service = FakeRegistryService(
+        collection_pages=[
+            ([], "collection-page-1", True),
+            ([_collection_node()], None, False),
+        ]
+    )
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registry_collections("models"))
+
+    assert result["returned_count"] == 1
+    assert [operation for operation, _ in service.calls] == [
+        "organization",
+        "registries",
+        "collections",
+        "collections",
+    ]
+
+
+def test_nonexistent_registry_returns_not_found_before_collection_query() -> None:
+    service = FakeRegistryService(registries=[])
+    api = _api(service)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registry_collections("missing"))
+
+    assert result["error"] == "resource_not_found"
+    assert [operation for operation, _ in service.calls] == ["organization", "registries"]
+
+
+def test_filter_limits_fail_before_api_construction() -> None:
+    too_deep: dict[str, Any] = {}
+    cursor = too_deep
+    for _ in range(14):
+        nested: dict[str, Any] = {}
+        cursor["next"] = nested
+        cursor = nested
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api") as get_api:
+        result = json.loads(list_registries(filter=too_deep))
+
+    assert result["error"] == "invalid_input"
+    get_api.assert_not_called()
+
+
+def test_oversized_filter_fails_before_api_construction() -> None:
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api") as get_api:
+        result = json.loads(list_registries(filter={"name": "x" * (64 * 1024)}))
+
+    assert result["error"] == "invalid_input"
+    get_api.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_filter", [{"metric": math.nan}, {"metric": object()}])
+def test_non_json_filters_fail_before_api_construction(bad_filter: dict[str, Any]) -> None:
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api") as get_api:
+        result = json.loads(list_registries(filter=bad_filter))
+
+    assert result["error"] == "invalid_input"
+    get_api.assert_not_called()
+
+
+def test_registry_response_obeys_token_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = FakeRegistryService()
+    service.registry_nodes[0]["description"] = "large-value-" * 20_000
+    api = _api(service)
+    monkeypatch.setattr("wandb_mcp_server.registry_support.MAX_RESPONSE_TOKENS", 512)
+
+    with patch("wandb_mcp_server.mcp_tools.query_registry.WandBApiManager.get_api", return_value=api):
+        result = json.loads(list_registries())
+
+    assert "large-value" not in json.dumps(result)
+    assert result.get("truncated") is True or result["error"] == "response_too_large"
+
+
+@pytest.mark.parametrize(
+    ("status", "message", "expected"),
+    [
+        (401, "secret canary", "authentication_failed"),
+        (403, "secret canary", "permission_denied"),
+        (404, "secret canary", "resource_not_found"),
+        (429, "rate limited secret canary", "server_busy"),
+        (503, "service overloaded secret canary", "server_busy"),
+    ],
+)
+def test_stable_http_error_mapping_does_not_echo_upstream(
+    status: int,
+    message: str,
+    expected: str,
+) -> None:
+    class UpstreamError(RuntimeError):
+        status_code = status
+
+    result = registry_error_result(UpstreamError(message))
+
+    assert result["error"] == expected
+    assert "canary" not in json.dumps(result)
+
+
+def test_timeout_and_malformed_errors_are_stable() -> None:
+    class RequestTimeout(RuntimeError):
+        pass
+
+    timeout = registry_error_result(RequestTimeout("secret at internal.svc.cluster.local"))
+    malformed = registry_error_result(RegistryMalformedResponse("secret"))
+
+    assert timeout["error"] == "upstream_timeout"
+    assert malformed["error"] == "malformed_response"
+    assert "secret" not in json.dumps([timeout, malformed])
+
+
+@pytest.mark.parametrize(
+    ("status", "message", "expected"),
+    [
+        (401, "authentication rejected", "authentication_failed"),
+        (403, "permission rejected", "permission_denied"),
+        (404, "resource absent", "resource_not_found"),
+        (429, "too many requests", "server_busy"),
+        (503, "service unavailable: capacity exhausted", "server_busy"),
+    ],
+)
+def test_real_wandb_service_error_shapes_map_to_stable_errors(
+    status: int,
+    message: str,
+    expected: str,
+) -> None:
+    response = wandb_api_pb2.ApiErrorResponse(http_status=status, message=message)
+    result = registry_error_result(WandbApiFailedError("W&B API request failed", response))
+
+    assert result["error"] == expected
+
+
+def test_real_wandb_authentication_and_timeout_shapes_are_stable() -> None:
+    authentication = registry_error_result(AuthenticationError("API key rejected"))
+    timeout = registry_error_result(
+        CommError(
+            "The W&B service process is busy and did not respond in time.",
+            exc=TimeoutError("internal.svc secret canary"),
+        )
+    )
+
+    assert authentication["error"] == "authentication_failed"
+    assert timeout["error"] == "upstream_timeout"
+    assert "canary" not in json.dumps([authentication, timeout])
+
+
+def test_organization_projection_is_fixed_and_read_only() -> None:
+    assert REGISTRY_ORGANIZATION_QUERY.lstrip().startswith("query MCPRegistryOrganization")
+    document = validate_read_only_graphql(REGISTRY_ORGANIZATION_QUERY)
+    assert len(document.definitions) == 1
+
+
+def test_registry_tools_do_not_use_implicit_sdk_registry_resolution() -> None:
+    package_root = Path(__file__).parents[1] / "src" / "wandb_mcp_server" / "mcp_tools"
+    for filename in ("query_registry.py", "query_artifacts.py"):
+        source = (package_root / filename).read_text()
+        assert ".registry(" not in source
+
+
+@pytest.mark.asyncio
+async def test_complete_registry_workflow_through_official_mcp_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = FakeRegistryService()
+    api = _api(service)
+    artifact = type("ArtifactFixture", (), {})()
+    artifact.id = "artifact-0"
+    artifact.name = "my-model:v0"
+    artifact.type = "model"
+    artifact.version = "v0"
+    artifact.state = "COMMITTED"
+    artifact.description = None
+    artifact.size = 12
+    artifact.file_count = 1
+    artifact.tags = ["production"]
+    artifact.aliases = ["latest"]
+    artifact.metadata = {}
+    artifact.created_at = "2025-01-01T00:00:00Z"
+    artifact.digest = "digest-0"
+    artifact.commit_hash = None
+    artifact.source_qualified_name = None
+    artifact.linked_artifacts = []
+    artifact.source_artifact = artifact
+    artifact.logged_by = lambda: None
+    artifact.used_by = lambda: []
+    artifact.files = lambda: iter(())
+    api.artifact = lambda *args, **kwargs: artifact  # type: ignore[method-assign]
+    monkeypatch.setenv("MCP_ANALYTICS_DISABLED", "true")
+
+    with patch.object(WandBApiManager, "get_api", return_value=api):
+        server = create_mcp_server("stdio")
+        async with create_connected_server_and_client_session(server) as session:
+            registries = _tool_json(await session.call_tool("list_registries_tool", {}))
+            collections = _tool_json(
+                await session.call_tool(
+                    "list_registry_collections_tool",
+                    {"registry_name": registries["items"][0]["name"]},
+                )
+            )
+            versions = _tool_json(
+                await session.call_tool(
+                    "list_artifact_versions_tool",
+                    {
+                        "collection_name": collections["items"][0]["name"],
+                        "registry_name": registries["items"][0]["name"],
+                        "source": "registry",
+                    },
+                )
+            )
+            details = _tool_json(
+                await session.call_tool(
+                    "get_artifact_details_tool",
+                    {"artifact_name": "registry-entity/wandb-registry-models/my-model:v0"},
+                )
+            )
+
+    assert registries["returned_count"] == 1
+    assert collections["returned_count"] == 1
+    assert versions["returned_count"] == 1
+    assert details["artifact"]["version"] == "v0"
+    assert [operation for operation, _ in service.calls] == [
+        "organization",
+        "registries",
+        "registries",
+        "collections",
+        "registries",
+        "versions",
+    ]
+
+
+def _tool_json(result: Any) -> dict[str, Any]:
+    assert result.isError is False
+    assert result.content
+    text = getattr(result.content[0], "text", None)
+    assert isinstance(text, str)
+    parsed = json.loads(text)
+    assert isinstance(parsed, dict)
+    return parsed

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -94,11 +95,12 @@ class _ProjectLookupService:
         self.error = error
         self.calls: list[tuple[str, dict]] = []
 
-    def execute_graphql(self, query, variables=None):
+    def execute_graphql(self, query, variables=None, *, parse=None, **kwargs):
         self.calls.append((query, dict(variables or {})))
         if self.error is not None:
             raise self.error
-        return {"project": None}
+        result = {"project": None}
+        return parse(json.dumps(result)) if callable(parse) else result
 
 
 class _PublicProjectLookupApi(_FakeApi):

--- a/tests/test_tool_registration.py
+++ b/tests/test_tool_registration.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 
+import pytest
 from mcp.server.fastmcp import FastMCP
 
 from wandb_mcp_server.instrumented_server import InstrumentedFastMCP
@@ -15,13 +16,27 @@ WEAVE_TOOLS = {
     "summarize_evaluation_tool",
 }
 
-NON_WEAVE_TOOLS = {
+MODELS_TOOLS = {
     "query_wandb_tool",
     "get_run_history_tool",
     "list_artifact_versions_tool",
+    "get_artifact_details_tool",
+    "compare_artifact_versions_tool",
     "compare_runs_tool",
+    "diagnose_run_tool",
     "probe_project_tool",
+    "list_entities_tool",
+    "query_wandb_entity_projects",
+    "list_registries_tool",
+    "list_registry_collections_tool",
+    "list_wandb_automations_tool",
+    "list_wandb_integrations_tool",
+    "search_wandb_docs_tool",
+    "create_wandb_report_tool",
+    "log_analysis_to_wandb",
 }
+
+NON_WEAVE_TOOLS = MODELS_TOOLS
 
 BASE_WRITE_TOOLS = {
     "create_wandb_report_tool",
@@ -178,6 +193,69 @@ def test_agent_and_aria_tools_have_exact_full_manifest():
     assert len(names) == 33
 
 
+@pytest.mark.parametrize(
+    ("weave", "agents", "aria", "expected"),
+    [
+        (False, False, False, MODELS_TOOLS),
+        (True, False, False, MODELS_TOOLS | WEAVE_TOOLS),
+        (False, True, False, MODELS_TOOLS | AGENT_TOOLS),
+        (True, False, True, MODELS_TOOLS | WEAVE_TOOLS | ARIA_TOOLS),
+        (True, True, False, MODELS_TOOLS | WEAVE_TOOLS | AGENT_TOOLS),
+        (True, True, True, MODELS_TOOLS | WEAVE_TOOLS | AGENT_TOOLS | ARIA_TOOLS),
+    ],
+)
+def test_feature_profiles_have_exact_manifests(weave, agents, aria, expected):
+    _reset_tool_gate_env()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = str(weave).lower()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = str(agents).lower()
+    os.environ["WANDB_MCP_ENABLE_ARIA_TOOLS"] = str(aria).lower()
+    import wandb_mcp_server.config as cfg
+
+    try:
+        importlib.reload(cfg)
+        names = _registered_tool_names()
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    assert names == expected
+    assert len(names) in {17, 22, 25, 30, 33}
+
+
+@pytest.mark.parametrize(
+    ("weave", "agents", "aria"),
+    [
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    ],
+)
+def test_every_feature_profile_has_exact_read_only_variant(weave, agents, aria):
+    _reset_tool_gate_env()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_TOOLS"] = str(weave).lower()
+    os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = str(agents).lower()
+    os.environ["WANDB_MCP_ENABLE_ARIA_TOOLS"] = str(aria).lower()
+    os.environ["WANDB_MCP_READ_ONLY"] = "false"
+    import wandb_mcp_server.config as cfg
+
+    importlib.reload(cfg)
+    writable = _registered_tool_names()
+    os.environ["WANDB_MCP_READ_ONLY"] = "true"
+    try:
+        importlib.reload(cfg)
+        read_only = _registered_tool_names()
+    finally:
+        _reset_tool_gate_env()
+        importlib.reload(cfg)
+
+    expected_removed = BASE_WRITE_TOOLS | ({"aria_send_message"} if aria else set())
+    assert writable - read_only == expected_removed
+    assert read_only == writable - expected_removed
+
+
 def test_read_only_mode_removes_exactly_the_write_tools():
     _reset_tool_gate_env()
     os.environ["WANDB_MCP_ENABLE_WEAVE_AGENT_TOOLS"] = "true"
@@ -198,7 +276,7 @@ def test_read_only_mode_removes_exactly_the_write_tools():
     assert default_names - read_only_names == WRITE_TOOLS
     assert read_only_names - default_names == set()
     assert WRITE_TOOLS.isdisjoint(read_only_names)
-    assert NON_WEAVE_TOOLS.issubset(read_only_names)
+    assert (NON_WEAVE_TOOLS - BASE_WRITE_TOOLS).issubset(read_only_names)
     assert "query_wandb_tool" in read_only_names
     assert WEAVE_TOOLS.issubset(read_only_names)
     assert AGENT_TOOLS.issubset(read_only_names)
@@ -225,7 +303,7 @@ def test_read_only_mode_is_independent_of_weave_and_agent_gates():
     assert WRITE_TOOLS.isdisjoint(names)
     assert WEAVE_TOOLS.isdisjoint(names)
     assert AGENT_TOOLS.issubset(names)
-    assert NON_WEAVE_TOOLS.issubset(names)
+    assert (NON_WEAVE_TOOLS - BASE_WRITE_TOOLS).issubset(names)
     assert ARIA_TOOLS - {"aria_send_message"} <= names
     assert "query_wandb_tool" in names
 

--- a/tests/test_wandb_selective_reads.py
+++ b/tests/test_wandb_selective_reads.py
@@ -22,6 +22,7 @@ from wandb_mcp_server.wandb_selective_reads import (
     PROJECT_FIELDS_QUERY,
     PROJECT_METADATA_QUERY,
     REGISTRY_ARTIFACT_VERSIONS_QUERY,
+    REGISTRY_ORGANIZATION_QUERY,
     SAMPLED_HISTORY_SERIES_QUERY,
     ProjectedReportCursorError,
     SelectiveReadUnavailable,
@@ -226,6 +227,7 @@ def test_every_application_owned_document_is_query_only():
         METRIC_VALUE_STEPS_QUERY,
         SAMPLED_HISTORY_SERIES_QUERY,
         REGISTRY_ARTIFACT_VERSIONS_QUERY,
+        REGISTRY_ORGANIZATION_QUERY,
     ):
         validate_read_only_graphql(document)
 
@@ -1350,3 +1352,98 @@ def test_registry_artifact_versions_use_fixed_ordered_query():
     assert json.loads(variables["registryFilter"]) == {"name": "wandb-registry-models"}
     assert json.loads(variables["collectionFilter"]) == {"name": "my-model"}
     assert variables["order"] == "-createdAt"
+
+
+def _registry_version_page(*, cursor, has_next, edges=None):
+    return {
+        "organization": {
+            "orgEntity": {
+                "artifactMemberships": {
+                    "edges": [] if edges is None else edges,
+                    "pageInfo": {"endCursor": cursor, "hasNextPage": has_next},
+                }
+            }
+        }
+    }
+
+
+def test_registry_artifact_versions_reject_repeated_cursor_without_amplification():
+    class RepeatingService:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return _registry_version_page(cursor="repeated", has_next=True)
+
+    service = RepeatingService()
+    api = type("Api", (), {"_service_api": service})()
+
+    with pytest.raises(SelectiveReadUnavailable, match="repeated a continuation cursor"):
+        fetch_registry_artifact_versions(
+            api,
+            organization="my-org",
+            registry_name="models",
+            collection_name="my-model",
+            order="-createdAt",
+            scan_limit=10,
+        )
+
+    assert service.calls == 2
+
+
+def test_registry_artifact_versions_enforce_empty_page_request_ceiling():
+    class EmptyPageService:
+        def __init__(self):
+            self.calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return _registry_version_page(cursor=f"page-{self.calls}", has_next=True)
+
+    service = EmptyPageService()
+    api = type("Api", (), {"_service_api": service})()
+
+    with pytest.raises(SelectiveReadUnavailable, match="request limit"):
+        fetch_registry_artifact_versions(
+            api,
+            organization="my-org",
+            registry_name="models",
+            collection_name="my-model",
+            order="-createdAt",
+            scan_limit=10,
+        )
+
+    assert service.calls == 2
+
+
+@pytest.mark.parametrize(
+    "connection",
+    [
+        {"edges": None, "pageInfo": {"endCursor": None, "hasNextPage": False}},
+        {"edges": [], "pageInfo": {"endCursor": None, "hasNextPage": "yes"}},
+        {"edges": [], "pageInfo": {"endCursor": None, "hasNextPage": True}},
+    ],
+)
+def test_registry_artifact_versions_reject_malformed_connections(connection):
+    class MalformedService:
+        calls = 0
+
+        def execute_graphql(self, query, variables=None):
+            self.calls += 1
+            return {"organization": {"orgEntity": {"artifactMemberships": connection}}}
+
+    service = MalformedService()
+    api = type("Api", (), {"_service_api": service})()
+
+    with pytest.raises(SelectiveReadUnavailable):
+        fetch_registry_artifact_versions(
+            api,
+            organization="my-org",
+            registry_name="models",
+            collection_name="my-model",
+            order="-createdAt",
+            scan_limit=10,
+        )
+
+    assert service.calls == 1


### PR DESCRIPTION
## Summary

- resolve omitted Registry organizations with one fixed read-only request over the existing actor-scoped W&B transport
- return bounded `organization_required` / stable upstream errors instead of raw SDK exceptions
- use public registry search/collection APIs and remove per-collection alias reads
- share organization resolution with registry-backed artifact version listing
- preserve nullable fields, validate filters/identifiers, and enforce pagination and response budgets
- verify exact 17/22/25/30/33 tool profiles and keep ARIA opt-in

## Security and privacy

- no new tools or signature changes
- no new client, credential fallback, raw error, internal URL, or caller filter in telemetry
- caller-supplied raw GraphQL remains disabled by default
- fixed organization projection is query-only and compatible with Dedicated Server 0.82.2

## Validation

- Python 3.11 full non-integration: 1,433 passed
- Python 3.12 full non-integration: 1,433 passed
- W&B latest (0.28.2) compatibility: 602 passed
- focused locked registry/API suite: 165 passed
- installed-wheel STDIO: passed with MCP 1.29.0 and 1.28.1, default and 33-tool profiles
- Ruff check/format, Bandit, and lock validation: passed
- independent staff re-review: no blocking findings

This PR targets `staging/0.4.0`. It does not deploy or promote production.