### PR TITLE
feat: attribute ARIA calls to MCP

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -115,7 +115,10 @@ exclusively for MCP JSON-RPC messages.
 Deployments with an approved hosted W&B Agent endpoint can set
 `WANDB_MCP_ENABLE_ARIA_TOOLS=true` to add three asynchronous tools for starting,
 polling, and batch-polling ARIA turns. The group is disabled by default and
-remains disabled in Dedicated/Self-Managed deployments unless their network,
+every opt-in ARIA request identifies its client as `wandb-mcp-server/<version>`
+for server-derived product analytics attribution. This header is not used for
+authentication, authorization, routing, quotas, or billing.
+ARIA remains disabled in Dedicated/Self-Managed deployments unless their network,
 credential, and data-residency path has been explicitly approved.
 
 Submission is treated as a non-idempotent write and is never automatically

--- a/src/wandb_mcp_server/mcp_tools/aria.py
+++ b/src/wandb_mcp_server/mcp_tools/aria.py
@@ -12,6 +12,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 from weakref import WeakKeyDictionary
@@ -47,6 +48,13 @@ MAX_RETRY_AFTER_MS = 30_000
 _OVERLOAD_ERROR_TYPES = frozenset({"rate_limited", "service_unavailable"})
 _OUTBOUND_LIMITERS: WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore] = WeakKeyDictionary()
 _OUTBOUND_LIMITERS_LOCK = threading.Lock()
+
+try:
+    _INSTALLED_VERSION = distribution_version("wandb-mcp-server")
+except PackageNotFoundError:  # pragma: no cover - source-only developer fallback
+    from wandb_mcp_server import __version__ as _INSTALLED_VERSION
+
+ARIA_CLIENT_IDENTITY = f"wandb-mcp-server/{_INSTALLED_VERSION}"
 
 
 def _outbound_limiter() -> asyncio.Semaphore:
@@ -687,7 +695,14 @@ async def _perform_bounded_request(
             method,
             path,
             json=payload,
-            headers={"Accept-Encoding": "identity"},
+            headers={
+                "Accept-Encoding": "identity",
+                # This is cooperative product attribution only. ARIA must not
+                # use it for authentication, authorization, routing, quotas,
+                # or billing. Supplying it per request also covers injected
+                # request-scoped clients used by hosted deployments.
+                "X-Wandb-Client": ARIA_CLIENT_IDENTITY,
+            },
         ) as streamed:
             body = await _read_bounded_response(streamed)
             # `aiter_bytes()` yields decoded bytes. Reusing compression or transfer

--- a/tests/test_aria.py
+++ b/tests/test_aria.py
@@ -42,6 +42,7 @@ def test_send_root_turn_uses_bearer_auth_and_openapi_payload(monkeypatch) -> Non
         captured["method"] = request.method
         captured["path"] = request.url.path
         captured["authorization"] = request.headers["Authorization"]
+        captured["wandb_client"] = request.headers["X-Wandb-Client"]
         captured["body"] = json.loads(request.content)
         return httpx.Response(202, json=_turn(), request=request)
 
@@ -67,6 +68,7 @@ def test_send_root_turn_uses_bearer_auth_and_openapi_payload(monkeypatch) -> Non
         "method": "POST",
         "path": "/api/v1/turns",
         "authorization": "Bearer user-wandb-token",
+        "wandb_client": aria.ARIA_CLIENT_IDENTITY,
         "body": {
             "user_prompt": "Compare the latest eval runs",
             "entity": "team",
@@ -105,6 +107,31 @@ def test_send_reuses_request_scoped_wandb_token(monkeypatch) -> None:
 
     assert result["ok"] is True
     assert captured["authorization"] == "Bearer context-wandb-token-123"
+
+
+def test_every_aria_request_overrides_client_attribution_header() -> None:
+    captured: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append((request.method, request.headers["X-Wandb-Client"]))
+        return httpx.Response(200, json=_turn("completed"), request=request)
+
+    async def run() -> None:
+        async with httpx.AsyncClient(
+            base_url="https://wb-agent.example",
+            headers={"X-Wandb-Client": "caller-controlled"},
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await aria._request_turn(client, "POST", "/api/v1/turns", payload={"user_prompt": "safe"})
+            await aria._request_turn(client, "GET", "/api/v1/turns/turn-1")
+
+    asyncio.run(run())
+
+    assert captured == [
+        ("POST", aria.ARIA_CLIENT_IDENTITY),
+        ("GET", aria.ARIA_CLIENT_IDENTITY),
+    ]
+    assert aria.ARIA_CLIENT_IDENTITY == "wandb-mcp-server/0.4.0"
 
 
 def test_concurrent_callers_keep_request_scoped_tokens_isolated(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add a versioned `X-Wandb-Client: wandb-mcp-server/<version>` identity to every ARIA submission and polling request
- keep ARIA opt-in and preserve request bodies, authentication, retries, routing, quotas, and tool schemas
- document that the header is cooperative analytics attribution only

## Safety

- the header is injected at the shared bounded HTTP boundary, including when hosted code supplies a request-scoped client
- caller-provided values cannot override the server-derived identity
- no prompt, scope, turn identifier, credential, or response data is added to the header
- the default 30-tool MT SaaS release does not depend on the separate Core attribution rollout

## Validation

- 71 ARIA tests passed
- 218 combined ARIA, registration, tool-description, and documentation tests passed
- Ruff check and format check passed

## Stack

This is intentionally stacked on #143 so its diff contains only ARIA attribution. After #143 merges, this PR should be retargeted to `staging/0.4.0` and revalidated before merge.

Related Core attribution implementation: wandb/core#50572.
