### PR TITLE
fix: bound project artifact tag filtering

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -55,7 +55,10 @@ receive a bounded `organization_required` response instead of a Python
 exception. Registry, collection, and registry-version reads share that result.
 Collection listings no longer trigger one lazy alias request per collection;
 they return `aliases: null` and `aliases_loaded: false`, and callers use
-`list_artifact_versions_tool` for actual version aliases.
+`list_artifact_versions_tool` for actual version aliases. Project artifact tag
+filters are applied after a bounded SDK page scan, so a missing tag returns a
+successful, explicitly bounded empty result instead of scanning pages until a
+generic API failure.
 
 ### Correct multi-key history
 

--- a/src/wandb_mcp_server/admission.py
+++ b/src/wandb_mcp_server/admission.py
@@ -190,7 +190,7 @@ def tool_cost(name: str, arguments: Mapping[str, Any] | None = None) -> tuple[st
     if name == "get_artifact_details_tool" and arguments.get("include_files"):
         return "heavy", 4
     if name == "list_artifact_versions_tool":
-        if arguments.get("created_after") or arguments.get("created_before"):
+        if arguments.get("tags") or arguments.get("created_after") or arguments.get("created_before"):
             return "heavy", 4
         return "expensive", 2
     if name == "count_weave_traces_tool":

--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -169,7 +169,7 @@ def list_artifact_versions(
             order_value = _normalize_order(order)
             after_dt = _parse_timestamp(created_after)
             before_dt = _parse_timestamp(created_before)
-            needs_local_filter_scan = bool(created_after or created_before or (source == "registry" and tags))
+            needs_local_filter_scan = bool(created_after or created_before or tags)
             scan_limit = MCP_MAX_WANDB_QUERY_ITEMS + 1 if needs_local_filter_scan else max_items + 1
             api = WandBApiManager.get_api()
             compatibility_caveat: str | None = None
@@ -213,7 +213,13 @@ def list_artifact_versions(
                     type_name=type_name,
                     name=qualified_name,
                     order=order_value,
-                    tags=tags,
+                    # W&B 0.28 applies ``tags`` while converting each SDK
+                    # page. A missing tag can therefore make every converted
+                    # page empty and cause the paginator to scan the entire
+                    # collection before MCP can enforce its row cap. Fetch a
+                    # bounded raw page and apply the identical all-tags
+                    # predicate below instead.
+                    tags=None,
                     per_page=min(scan_limit, 100),
                 )
                 if not tags and created_after is None and created_before is None:
@@ -221,7 +227,11 @@ def list_artifact_versions(
                         exact_total = len(versions_iter)
                     except (TypeError, NotImplementedError):
                         exact_total = None
-                raw_versions, upstream_has_more = bounded_sdk_page(versions_iter, scan_limit)
+                raw_versions, upstream_has_more = bounded_sdk_page(
+                    versions_iter,
+                    scan_limit,
+                    allow_partial_on_request_limit=True,
+                )
 
             matching = [
                 _serialize_artifact_summary(artifact)

--- a/src/wandb_mcp_server/registry_support.py
+++ b/src/wandb_mcp_server/registry_support.py
@@ -291,7 +291,12 @@ def require_registry(registries: Any) -> Any:
     return page[0]
 
 
-def bounded_sdk_page(values: Any, limit: int) -> tuple[list[Any], bool]:
+def bounded_sdk_page(
+    values: Any,
+    limit: int,
+    *,
+    allow_partial_on_request_limit: bool = False,
+) -> tuple[list[Any], bool]:
     """Drive real W&B paginators one backend page at a time under a hard cap.
 
     W&B 0.28 registry paginator ``__next__`` implementations may internally
@@ -319,6 +324,8 @@ def bounded_sdk_page(values: Any, limit: int) -> tuple[list[Any], bool]:
 
     while len(rows) < target and bool(getattr(values, "more", False)):
         if requests >= request_limit:
+            if allow_partial_on_request_limit:
+                return rows[:limit], True
             raise RegistryMalformedResponse("registry pagination exceeded its request limit")
         raise_if_tool_deadline_exceeded()
         before_count = len(objects)

--- a/tests/test_admission_control.py
+++ b/tests/test_admission_control.py
@@ -140,6 +140,7 @@ def test_tool_costs_are_stable_and_unknown_is_heavy() -> None:
     assert tool_cost("get_run_history_tool", {"target_x": 100}) == ("heavy", 4)
     assert tool_cost("get_run_history_tool", {"min_step": 0, "max_step": 100}) == ("heavy", 4)
     assert tool_cost("list_artifact_versions_tool") == ("expensive", 2)
+    assert tool_cost("list_artifact_versions_tool", {"tags": ["production"]}) == ("heavy", 4)
     assert tool_cost("list_artifact_versions_tool", {"created_after": "2026-01-01"}) == ("heavy", 4)
     assert tool_cost("query_wandb_tool", {"resource": "runs", "response_mode": "count"}) == ("light", 1)
     assert tool_cost(

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from mcp.server.fastmcp import FastMCP
+from wandb.apis.public import Api
 
 from wandb_mcp_server.mcp_tools.query_artifacts import (
     COMPARE_ARTIFACT_VERSIONS_TOOL_DESCRIPTION,
@@ -66,6 +67,108 @@ def _make_file(name="model.pt", size=1000000, digest="aaa111"):
     f.size = size
     f.digest = digest
     return f
+
+
+class _RealArtifactPaginatorService:
+    """Fake transport beneath W&B's real 0.28 Artifacts paginator."""
+
+    def __init__(self, *, total=40, tags_by_index=None):
+        self.calls = 0
+        self.total = total
+        self.tags_by_index = tags_by_index or {}
+
+    def execute_graphql(self, _query, variables=None, **kwargs):
+        self.calls += 1
+        variables = variables or {}
+        page_size = variables["perPage"]
+        start = int(variables.get("cursor") or 0)
+        stop = min(start + page_size, self.total)
+        edges = [
+            {
+                "version": f"v{index}",
+                "node": {
+                    "__typename": "Artifact",
+                    "id": f"artifact-{index}",
+                    "artifactSequence": {
+                        "__typename": "ArtifactSequence",
+                        "name": "my-model",
+                        "project": {
+                            "id": "project-id",
+                            "internalId": "project-internal-id",
+                            "name": "project",
+                            "entity": {"name": "team"},
+                        },
+                    },
+                    "versionIndex": index,
+                    "artifactType": {"name": "model"},
+                    "description": None,
+                    "metadata": "{}",
+                    "ttlDurationSeconds": 0,
+                    "ttlIsInherited": False,
+                    "tags": [
+                        {
+                            "__typename": "Tag",
+                            "id": f"{tag}-tag",
+                            "name": tag,
+                        }
+                        for tag in self.tags_by_index.get(index, ["production"])
+                    ],
+                    "historyStep": None,
+                    "state": "COMMITTED",
+                    "size": 1,
+                    "digest": f"digest-{index}",
+                    "commitHash": None,
+                    "fileCount": 1,
+                    "createdAt": "2026-01-01T00:00:00Z",
+                    "updatedAt": None,
+                    "aliases": [],
+                },
+            }
+            for index in range(start, stop)
+        ]
+        has_next = stop < self.total
+        payload = {
+            "project": {
+                "artifactType": {
+                    "artifactCollection": {
+                        "__typename": "ArtifactSequence",
+                        "artifacts": {
+                            "totalCount": self.total,
+                            "pageInfo": {
+                                "__typename": "PageInfo",
+                                "endCursor": str(stop) if has_next else None,
+                                "hasNextPage": has_next,
+                            },
+                            "edges": edges,
+                        },
+                    }
+                }
+            }
+        }
+        parse = kwargs.get("parse")
+        return parse(json.dumps(payload)) if callable(parse) else payload
+
+
+class _RealArtifactPaginatorApi:
+    def __init__(self, service):
+        self.public_api = object.__new__(Api)
+        self.public_api._service_api = service
+        self.public_api.settings = {
+            "base_url": "https://api.wandb.ai",
+            "entity": "team",
+            "project": "project",
+        }
+        self.requested_tags = object()
+
+    def artifacts(self, *, type_name, name, order, tags, per_page):
+        self.requested_tags = tags
+        return self.public_api.artifacts(
+            type_name=type_name,
+            name=name,
+            order=order,
+            tags=tags,
+            per_page=per_page,
+        )
 
 
 class TestListArtifactVersions:
@@ -155,7 +258,116 @@ class TestListArtifactVersions:
         assert result["project_exhaustive"] is False
         assert result["items"][0]["version"] == "v3"
         assert mock_api.artifacts.call_args.kwargs["order"] == "+versionIndex"
-        assert mock_api.artifacts.call_args.kwargs["tags"] == ["production"]
+        # W&B 0.28 filters tags while converting paginator pages. MCP leaves
+        # that SDK filter unset and applies it locally after its bounded scan.
+        assert mock_api.artifacts.call_args.kwargs["tags"] is None
+
+    def test_missing_project_tag_uses_bounded_real_sdk_paginator(self):
+        service = _RealArtifactPaginatorService()
+        api = _RealArtifactPaginatorApi(service)
+        with (
+            patch(
+                "wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager.get_api",
+                return_value=api,
+            ),
+            patch(
+                "wandb_mcp_server.mcp_tools.query_artifacts.MCP_MAX_WANDB_QUERY_ITEMS",
+                3,
+            ),
+        ):
+            result = json.loads(
+                list_artifact_versions(
+                    "team/project/my-model",
+                    type_name="model",
+                    tags=["does-not-exist"],
+                    max_items=2,
+                )
+            )
+
+        assert "error" not in result
+        assert result["items"] == []
+        assert result["versions"] == []
+        assert result["count"] == 0
+        assert result["has_more"] is True
+        assert result["project_exhaustive"] is False
+        assert result["scan"]["rows_examined"] == 4
+        assert api.requested_tags is None
+        assert service.calls == 2
+
+    def test_missing_project_tag_returns_partial_at_sdk_request_ceiling(self):
+        service = _RealArtifactPaginatorService(total=2_000)
+        api = _RealArtifactPaginatorApi(service)
+
+        with (
+            patch(
+                "wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager.get_api",
+                return_value=api,
+            ),
+            patch(
+                "wandb_mcp_server.mcp_tools.query_artifacts.MCP_MAX_WANDB_QUERY_ITEMS",
+                1_000,
+            ),
+        ):
+            result = json.loads(
+                list_artifact_versions(
+                    "team/project/my-model",
+                    type_name="model",
+                    tags=["does-not-exist"],
+                    max_items=2,
+                )
+            )
+
+        assert "error" not in result
+        assert result["items"] == []
+        assert result["total_count"] is None
+        assert result["has_more"] is True
+        assert result["project_exhaustive"] is False
+        assert result["scan"]["rows_examined"] == 800
+        assert result["scan"]["filter_exhaustive"] is False
+        assert service.calls == 8
+
+    def test_exhausted_missing_tag_is_truthful_and_multi_tag_filter_is_and(self):
+        exhausted_service = _RealArtifactPaginatorService(total=3)
+        exhausted_api = _RealArtifactPaginatorApi(exhausted_service)
+        with patch(
+            "wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager.get_api",
+            return_value=exhausted_api,
+        ):
+            exhausted = json.loads(
+                list_artifact_versions(
+                    "team/project/my-model",
+                    type_name="model",
+                    tags=["does-not-exist"],
+                    max_items=2,
+                )
+            )
+
+        assert exhausted["items"] == []
+        assert exhausted["total_count"] == 0
+        assert exhausted["has_more"] is False
+        assert exhausted["project_exhaustive"] is True
+
+        sparse_service = _RealArtifactPaginatorService(
+            total=5,
+            tags_by_index={3: ["production", "approved"]},
+        )
+        sparse_api = _RealArtifactPaginatorApi(sparse_service)
+        with patch(
+            "wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager.get_api",
+            return_value=sparse_api,
+        ):
+            sparse = json.loads(
+                list_artifact_versions(
+                    "team/project/my-model",
+                    type_name="model",
+                    tags=["production", "approved"],
+                    max_items=2,
+                )
+            )
+
+        assert [item["version"] for item in sparse["items"]] == ["v3"]
+        assert sparse["total_count"] == 1
+        assert sparse["has_more"] is False
 
     @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
     def test_invalid_filters_do_not_construct_api(self, mock_api_mgr):


### PR DESCRIPTION
## Summary

- avoid W&B 0.28's client-side tag-filter paginator loop for project artifact versions
- scan unfiltered SDK pages under the existing profile cap and apply all-tags matching locally
- return truthful partial/exhaustion metadata at the hard eight-request ceiling instead of `api_error`
- classify tag-filtered artifact listings as heavy under admission control

## Why

The first rebuilt MT SaaS staging acceptance exposed an adjacent release blocker: the maintained missing-tag check returned `api_error` because W&B 0.28 filters tags after each page is converted. Empty converted pages advanced until MCP's request ceiling. The candidate was automatically rolled back before registry-chain acceptance.

## Validation

- reproduced the exact maintained read fixture failure locally using a read-only credential
- verified the exact fixture now returns a successful bounded empty result
- real W&B 0.28 `Api.artifacts()` paginator tests cover missing tags, sparse multi-tag AND matching, exhaustion, and >800-row request-ceiling behavior
- 147 focused artifact, registry, selective-read, and admission tests passed
- full non-integration suite: 1,432 passed; three socket-binding tests were sandbox-blocked locally and remain covered by GitHub Actions
- Ruff check/format and `git diff --check` passed

## Release scope

Targets `staging/0.4.0`. No tool signatures, tool registrations, auth behavior, version, Helm, or deployment settings change.
