### PR TITLE
security: harden v0.4 logs and overload handling

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -249,10 +249,18 @@ Telemetry now:
 - Uses a pseudonymous API-key-derived actor identifier.
 - Excludes API keys, raw tool arguments, prompts, queries, filters, report
   content, and customer resource identifiers.
+- Avoids recording Weave request bodies, trace identifiers, selected customer
+  fields, or upstream response bodies in application logs, including error and
+  debug paths.
 - Bounds dimensions and serialized event size.
 
 Successful HTTP request telemetry is sampled for operational cost control.
 Session and public tool events are not sampled.
+
+Agent observability reads also perform one upstream attempt. A trace-service
+rate limit or overload is returned as retryable `server_busy` with a bounded
+`retry_after_ms`, so the MCP server does not amplify upstream pressure with
+hidden retries.
 
 ### Security and CI hardening
 

--- a/src/wandb_mcp_server/analytics.py
+++ b/src/wandb_mcp_server/analytics.py
@@ -832,7 +832,7 @@ class AnalyticsTracker:
                 extra={"json_fields": event, "labels": labels},
             )
         except Exception as exc:
-            logger.debug(f"Analytics emit failed (non-fatal): {exc}")
+            logger.debug("Analytics emit failed (non-fatal; %s)", type(exc).__name__)
 
         try:
             from wandb_mcp_server.analytics_segment import get_segment_forwarder
@@ -841,7 +841,7 @@ class AnalyticsTracker:
             if forwarder.enabled:
                 forwarder.forward(event)
         except Exception as exc:
-            logger.debug(f"Segment forwarding failed (non-fatal): {exc}")
+            logger.debug("Segment forwarding failed (non-fatal; %s)", type(exc).__name__)
 
         try:
             from wandb_mcp_server.analytics_datadog import get_datadog_forwarder
@@ -850,7 +850,7 @@ class AnalyticsTracker:
             if dd_forwarder.enabled:
                 dd_forwarder.forward(event)
         except Exception as exc:
-            logger.debug(f"Datadog forwarding failed (non-fatal): {exc}")
+            logger.debug("Datadog forwarding failed (non-fatal; %s)", type(exc).__name__)
 
     @staticmethod
     def _apply_identity_privacy(
@@ -917,7 +917,7 @@ class AnalyticsTracker:
                 },
             )
         except Exception as exc:
-            logger.warning(f"Failed to track user session: {exc}")
+            logger.warning("Failed to track user session (%s)", type(exc).__name__)
 
     def track_tool_call(
         self,
@@ -964,7 +964,7 @@ class AnalyticsTracker:
                 labels,
             )
         except Exception as exc:
-            logger.warning(f"Failed to track tool call: {exc}")
+            logger.warning("Failed to track tool call (%s)", type(exc).__name__)
 
     def track_request(
         self,
@@ -1011,7 +1011,7 @@ class AnalyticsTracker:
                 },
             )
         except Exception as exc:
-            logger.warning(f"Failed to track request: {exc}")
+            logger.warning("Failed to track request (%s)", type(exc).__name__)
 
 
 # -- Singleton access -------------------------------------------------------

--- a/src/wandb_mcp_server/analytics_datadog.py
+++ b/src/wandb_mcp_server/analytics_datadog.py
@@ -313,7 +313,7 @@ def _resolve_dd_api_key() -> str:
             if key_bytes:
                 return key_bytes.decode("utf-8").strip()
     except Exception as exc:
-        logger.debug(f"SecretsResolver failed for {_DD_SECRET_NAME}: {exc}")
+        logger.debug("Datadog credential resolution failed (%s)", type(exc).__name__)
     return ""
 
 
@@ -408,9 +408,9 @@ class DatadogForwarder:
                 },
             )
             if resp.status_code not in (200, 202):
-                logger.warning(f"Datadog forward failed: {resp.status_code} {resp.text[:200]}")
+                logger.warning("Datadog forwarding returned HTTP %s", resp.status_code)
         except Exception as exc:
-            logger.warning(f"Datadog forward error (non-fatal): {exc}")
+            logger.warning("Datadog forwarding failed (non-fatal; %s)", type(exc).__name__)
 
     def get_forwarded_payloads(self) -> List[Dict[str, Any]]:
         """Return all payloads that were forwarded (for testing/inspection)."""

--- a/src/wandb_mcp_server/analytics_segment.py
+++ b/src/wandb_mcp_server/analytics_segment.py
@@ -219,10 +219,10 @@ class SegmentForwarder:
                 headers={"Content-Type": "application/json"},
             )
             if resp.status_code != 200:
-                logger.warning(f"Segment forward failed: {resp.status_code} {resp.text[:200]}")
+                logger.warning("Segment forwarding returned HTTP %s", resp.status_code)
             return payload
         except Exception as exc:
-            logger.warning(f"Segment forward error (non-fatal): {exc}")
+            logger.warning("Segment forwarding failed (non-fatal; %s)", type(exc).__name__)
             return payload
 
     def get_forwarded_payloads(self) -> List[Dict[str, Any]]:

--- a/src/wandb_mcp_server/auth.py
+++ b/src/wandb_mcp_server/auth.py
@@ -88,13 +88,13 @@ async def validate_bearer_token(credentials: Optional[HTTPAuthorizationCredentia
 
     # Basic format validation
     if not is_valid_wandb_api_key(token):
-        logger.debug(f"Rejected API key: length={len(token)}")
+        logger.debug("Rejected an invalid W&B API key format")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid W&B API key format. Get your key at: https://wandb.ai/authorize",
         )
 
-    logger.debug(f"Bearer token validated successfully (length: {len(token)})")
+    logger.debug("Bearer token format validated successfully")
     return token
 
 
@@ -143,7 +143,7 @@ async def mcp_auth_middleware(request: Request, call_next):
     except HTTPException as e:
         return JSONResponse(status_code=e.status_code, content={"error": e.detail}, headers=e.headers)
     except Exception as e:
-        logger.error(f"Authentication error: {e}")
+        logger.error("Authentication failed (%s)", type(e).__name__)
         return JSONResponse(
             status_code=status.HTTP_401_UNAUTHORIZED,
             content={"error": "Authentication failed"},
@@ -204,7 +204,7 @@ async def mcp_auth_middleware(request: Request, call_next):
         except Exception:
             logger.debug("Session creation failed on mismatch retry (non-fatal)")
     except Exception as sm_err:
-        logger.debug(f"Session manager unavailable (non-fatal): {sm_err}")
+        logger.debug("Session manager unavailable (non-fatal; %s)", type(sm_err).__name__)
 
     request.state.session_id = session_id
     session_ctx_token = current_session_id.set(session_id)
@@ -222,7 +222,7 @@ async def mcp_auth_middleware(request: Request, call_next):
                 api_key_hash=api_key_hash,
             )
         except Exception as analytics_err:
-            logger.debug(f"Analytics tracking failed (non-fatal): {analytics_err}")
+            logger.debug("Analytics tracking failed (non-fatal; %s)", type(analytics_err).__name__)
 
     # --- Execute request (errors here propagate as 500, not 401) ----------
     request_start = time.monotonic()

--- a/src/wandb_mcp_server/instrumented_server.py
+++ b/src/wandb_mcp_server/instrumented_server.py
@@ -63,6 +63,47 @@ _ARIA_TOOL_COSTS = {
     "aria_get_turn": ("light", 1),
     "aria_get_turns": ("heavy", 4),
 }
+_TELEMETRY_RESULT_ERROR_CODES = frozenset(
+    {
+        "agents_api_unavailable",
+        "agents_query_failed",
+        "api_error",
+        "artifact_inventory_unavailable",
+        "auth_required",
+        "authentication_failed",
+        "count_failed",
+        "evaluation_query_failed",
+        "history_fetch_failed",
+        "history_query_failed",
+        "invalid_cursor",
+        "invalid_input",
+        "invalid_request",
+        "log_failed",
+        "malformed_response",
+        "organization_required",
+        "organization_resolution_failed",
+        "out_of_memory",
+        "pagination_cursor_unavailable",
+        "permission_denied",
+        "project_probe_failed",
+        "project_query_failed",
+        "query_failed",
+        "query_too_large",
+        "read_only_violation",
+        "registry_query_failed",
+        "report_creation_failed",
+        "resolve_failed",
+        "resource_not_found",
+        "response_too_large",
+        "run_not_found",
+        "schema_query_failed",
+        "selective_read_unavailable",
+        "server_busy",
+        "target_not_logged",
+        "tool_timeout",
+        "upstream_error",
+    }
+)
 
 
 def _dispatch_tool_cost(name: str, arguments: dict[str, Any]) -> tuple[str, int]:
@@ -171,6 +212,72 @@ def structured_result_error(result: Any) -> str | None:
             error = structured_result_error(block)
             if error:
                 return error
+    return None
+
+
+def _error_category_from_mapping(value: dict[str, Any]) -> str | None:
+    """Return a bounded categorical error without copying customer text."""
+    error = value.get("error")
+    if not error:
+        return None
+    if isinstance(error, dict):
+        candidate = error.get("code") or error.get("type") or "tool_error"
+    else:
+        candidate = error
+    return str(candidate) if candidate in _TELEMETRY_RESULT_ERROR_CODES else "tool_error"
+
+
+def _telemetry_error(category: str) -> str:
+    """Format a low-cardinality error so Datadog retains its error kind."""
+    return f"{category}: tool failed"
+
+
+def _exception_error_category(exc: BaseException) -> str:
+    """Return a bounded exception class name without copying exception text."""
+    candidate = type(exc).__name__
+    if (
+        0 < len(candidate) <= 64
+        and candidate[0].isalpha()
+        and all(character.isalnum() or character == "_" for character in candidate)
+    ):
+        return candidate
+    return "exception"
+
+
+def _structured_result_error_category(result: Any) -> str | None:
+    """Classify a structured MCP failure for telemetry without its message."""
+    if getattr(result, "isError", False) or getattr(result, "is_error", False):
+        return "mcp_error"
+    if isinstance(result, dict):
+        category = _error_category_from_mapping(result)
+        if category:
+            return category
+        if "result" in result:
+            return _structured_result_error_category(result["result"])
+        return None
+    if isinstance(result, str):
+        try:
+            decoded = json.loads(result)
+        except (TypeError, ValueError):
+            return None
+        return _error_category_from_mapping(decoded) if isinstance(decoded, dict) else None
+    content = getattr(result, "content", None)
+    if content is not None and content is not result:
+        category = _structured_result_error_category(content)
+        if category:
+            return category
+    structured_content = getattr(result, "structuredContent", None)
+    if structured_content is None:
+        structured_content = getattr(result, "structured_content", None)
+    if structured_content is not None and structured_content is not result:
+        category = _structured_result_error_category(structured_content)
+        if category:
+            return category
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+        for block in result:
+            category = _structured_result_error_category(block)
+            if category:
+                return category
     return None
 
 
@@ -428,7 +535,7 @@ class InstrumentedFastMCP(FastMCP):
                     raise ToolError(json.dumps(busy.as_dict())) from exc
                 if success:
                     success = False
-                    error = sanitize_sensitive_text(f"{type(exc).__name__}: {str(exc)[:500]}")
+                    error = _telemetry_error(_exception_error_category(exc))
                 sanitized_message = sanitize_sensitive_text(
                     str(exc),
                     max_chars=MAX_EXTERNAL_ERROR_CHARS,
@@ -447,7 +554,7 @@ class InstrumentedFastMCP(FastMCP):
             if structured_error:
                 result = _bounded_error_result(result)
                 success = False
-                error = structured_result_error(result) or "ToolError: upstream error"
+                error = _telemetry_error(_structured_result_error_category(result) or "tool_error")
             return result
         finally:
             if deadline_token is not None:
@@ -465,9 +572,9 @@ class InstrumentedFastMCP(FastMCP):
                         await lease.release()
                     except Exception as release_error:
                         logger.error(
-                            "Tool admission release failed for %s: %s",
+                            "Tool admission release failed for %s (%s)",
                             name,
-                            release_error,
+                            type(release_error).__name__,
                         )
             duration_ms = round((time.monotonic() - started) * 1000, 2)
             try:
@@ -490,7 +597,7 @@ class InstrumentedFastMCP(FastMCP):
                     duration_ms=duration_ms,
                 )
             except Exception as analytics_error:
-                logger.debug("Tool analytics failed for %s: %s", name, analytics_error)
+                logger.debug("Tool analytics failed for %s (%s)", name, type(analytics_error).__name__)
             finally:
                 _current_sync_executor.reset(sync_executor_token)
                 _current_sync_call_state.reset(sync_state_token)
@@ -514,9 +621,9 @@ class InstrumentedFastMCP(FastMCP):
                 await lease.release()
             except Exception as release_error:
                 logger.error(
-                    "Deferred tool admission release failed for %s: %s",
+                    "Deferred tool admission release failed for %s (%s)",
                     tool_name,
-                    release_error,
+                    type(release_error).__name__,
                 )
 
         task = asyncio.create_task(_release_after_workers())

--- a/src/wandb_mcp_server/instrumented_server.py
+++ b/src/wandb_mcp_server/instrumented_server.py
@@ -275,6 +275,11 @@ def _structured_result_error_category(result: Any) -> str | None:
             return category
     if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
         for block in result:
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                category = _structured_result_error_category(text)
+                if category:
+                    return category
             category = _structured_result_error_category(block)
             if category:
                 return category

--- a/src/wandb_mcp_server/mcp_tools/agents.py
+++ b/src/wandb_mcp_server/mcp_tools/agents.py
@@ -4,8 +4,8 @@ Agent spans are ingested via OTel into a data plane separate from classic Weave
 calls, so these tools complement -- they do not duplicate -- the calls-based
 ``query_weave_traces_tool`` family. Each tool builds a request body and POSTs it
 to one ``/agents/*`` trace-server endpoint via ``_agents_request`` -- the same
-basic-auth + retry-session + ``track_tool_execution`` pattern as ``count_traces``
--- then trims the response to the token budget.
+basic-auth, no-retry, and ``track_tool_execution`` pattern as ``count_traces`` --
+then trims the response to the token budget.
 
 Request/response shapes mirror ``weave/trace_server/agents`` in github.com/wandb/weave.
 """
@@ -16,9 +16,11 @@ import base64
 import json
 from typing import Any, Dict, List, Optional
 
-from wandb_mcp_server.api_client import WandBApiManager
+import requests
+
+from wandb_mcp_server.api_client import WandBApiManager, raise_for_wandb_server_busy
 from wandb_mcp_server.config import MAX_RESPONSE_TOKENS, WF_TRACE_SERVER_URL, structured_error
-from wandb_mcp_server.mcp_tools.tools_utils import get_retry_session, track_tool_execution
+from wandb_mcp_server.mcp_tools.tools_utils import get_no_retry_session, track_tool_execution
 from wandb_mcp_server.utils import get_rich_logger
 from wandb_mcp_server.weave_api.processors import TraceProcessor
 
@@ -120,9 +122,11 @@ def _truncate_response(payload: Dict[str, Any]) -> Dict[str, Any]:
 def _agents_request(tool_name: str, path: str, body: Dict[str, Any], track_params: Dict[str, Any]) -> str:
     """POST to an ``/agents/*`` endpoint and return a JSON string.
 
-    Mirrors ``count_traces``: a basic-auth POST to the trace server via
-    ``get_retry_session``, wrapped in ``track_tool_execution`` and the standard
+    Mirrors ``count_traces``: a basic-auth POST to the trace server via a
+    no-retry session, wrapped in ``track_tool_execution`` and the standard
     ``structured_error`` envelope, with the response trimmed to the token budget.
+    Retrying a read belongs to the MCP caller; doing it here would amplify an
+    already overloaded trace service.
     """
     api_key = WandBApiManager.get_api_key()
     if not api_key:
@@ -142,28 +146,44 @@ def _agents_request(tool_name: str, path: str, body: Dict[str, Any], track_param
         # Only the HTTP round-trip can raise here, so the try wraps just that;
         # the status-code branching below is plain control flow and stays outside.
         try:
-            response = get_retry_session().post(url, headers=headers, data=data, timeout=_REQUEST_TIMEOUT_SECONDS)
+            response = get_no_retry_session().post(
+                url,
+                headers=headers,
+                data=data,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
         except Exception as e:
-            logger.error(f"Agents API request to {path} failed: {e}", exc_info=True)
-            ctx.mark_error(str(e))
-            return json.dumps(structured_error("agents_query_failed", str(e)[:500]))
+            logger.error("Agents API request failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                structured_error(
+                    "agents_query_failed",
+                    "The Agents API request failed.",
+                )
+            )
 
         if response.status_code == 404:
             ctx.mark_error("agents_api_unavailable")
             return json.dumps(
                 structured_error(
                     "agents_api_unavailable",
-                    f"The trace server at {WF_TRACE_SERVER_URL} has no {path} endpoint (404); "
+                    "The configured trace server does not expose this Agents API endpoint (404); "
                     "it may predate the Weave Agents API.",
                     status_code=404,
                 )
             )
         if response.status_code != 200:
             ctx.mark_error(f"http_{response.status_code}")
+            if response.status_code in {429, 503}:
+                overload = requests.HTTPError(
+                    f"Agents API returned HTTP {response.status_code}",
+                    response=response,
+                )
+                raise_for_wandb_server_busy(overload)
             return json.dumps(
                 structured_error(
                     "agents_query_failed",
-                    f"Agents API {path} returned {response.status_code}: {response.text[:500]}",
+                    f"The Agents API returned HTTP {response.status_code}.",
                     status_code=response.status_code,
                 )
             )
@@ -172,9 +192,14 @@ def _agents_request(tool_name: str, path: str, body: Dict[str, Any], track_param
         try:
             result = response.json()
         except Exception as e:
-            logger.error(f"Agents API {path} returned a non-JSON body: {e}", exc_info=True)
-            ctx.mark_error(str(e))
-            return json.dumps(structured_error("agents_query_failed", str(e)[:500]))
+            logger.error("Agents API response was not valid JSON")
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                structured_error(
+                    "agents_query_failed",
+                    "The Agents API returned an invalid response.",
+                )
+            )
 
     return json.dumps(_truncate_response(result), default=str)
 

--- a/src/wandb_mcp_server/mcp_tools/automations.py
+++ b/src/wandb_mcp_server/mcp_tools/automations.py
@@ -214,9 +214,14 @@ def list_automations(
 
         except Exception as e:
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in list_automations: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Automation listing failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "api_error",
+                    "message": "The W&B automation query failed.",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -333,6 +338,11 @@ def list_integrations(
 
         except Exception as e:
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in list_integrations: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Integration listing failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "api_error",
+                    "message": "The W&B integration query failed.",
+                }
+            )

--- a/src/wandb_mcp_server/mcp_tools/count_traces.py
+++ b/src/wandb_mcp_server/mcp_tools/count_traces.py
@@ -145,7 +145,6 @@ def count_traces(
 
     logger.debug("W&B API key: present")
 
-    api = WandBApiManager.get_api()
     with track_tool_execution(
         "count_traces",
         None,
@@ -245,7 +244,9 @@ def count_traces(
         # overloaded; the MCP client receives retryable backpressure instead.
         session = get_no_retry_session()
 
-        logger.debug(f"Posting to {url} with body: {json.dumps(request_body)}")
+        # The body may contain project identifiers, trace IDs, and arbitrary
+        # customer filters. Never log it, even at DEBUG.
+        logger.debug("Sending bounded request to the Weave trace-count service")
 
         try:
             response = session.post(
@@ -256,11 +257,8 @@ def count_traces(
             )
 
             if response.status_code != 200:
-                error_msg = f"Error querying Weave trace count: {response.status_code} - {response.text}"
-                logger.error(error_msg)
-                if "40 characters" in response.text:
-                    logger.error("W&B API key does not meet length requirements.")
-                logger.debug(f"Failed request body: {json.dumps(request_body)}")
+                error_msg = f"Error querying Weave trace count: {response.status_code}"
+                logger.error("Weave trace-count request failed with HTTP %s", response.status_code)
                 # Preserve status and Retry-After for the shared overload
                 # classifier at the public MCP dispatch boundary.
                 raise requests.HTTPError(error_msg, response=response)
@@ -269,11 +267,8 @@ def count_traces(
             return response_json.get("count", 0)
 
         except requests.exceptions.RequestException as e:
-            logger.error(f"HTTP Request failed for project {project_id}: {e}")
-            logger.debug(f"Failed request body during exception for {project_id}: {json.dumps(request_body)}")
-            raise Exception(f"Failed to query Weave trace count for {project_id} due to network error: {e}") from e
+            logger.error("Weave trace-count HTTP request failed (%s)", type(e).__name__)
+            raise Exception("Failed to query Weave trace count due to a network error") from e
         except json.JSONDecodeError as e:
-            logger.error(
-                f"Failed to decode JSON response for {project_id}: {e}. Response text: {response.text if 'response' in locals() else 'N/A'}"
-            )
-            raise Exception(f"Failed to parse Weave API response for {project_id}: {e}")
+            logger.error("Weave trace-count response was not valid JSON")
+            raise Exception("Failed to parse the Weave trace-count response") from e

--- a/src/wandb_mcp_server/mcp_tools/docs_search.py
+++ b/src/wandb_mcp_server/mcp_tools/docs_search.py
@@ -94,7 +94,7 @@ async def search_wandb_docs(query: str) -> str:
                 return json.dumps({"error": "No documentation results found for this query.", "query": query})
 
         except httpx.TimeoutException:
-            logger.warning(f"Docs MCP proxy timed out for query: {query}")
+            logger.warning("Docs MCP proxy timed out")
             ctx.mark_error("TimeoutException: docs search timed out")
             return json.dumps(
                 {
@@ -112,11 +112,11 @@ async def search_wandb_docs(query: str) -> str:
                 }
             )
         except Exception as e:
-            logger.warning(f"Docs MCP proxy error: {e}")
-            ctx.mark_error(f"{type(e).__name__}: {e}")
+            logger.warning("Docs MCP proxy failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
             return json.dumps(
                 {
-                    "error": f"Documentation search failed: {str(e)}",
+                    "error": "Documentation search failed.",
                     "query": query,
                 }
             )

--- a/src/wandb_mcp_server/mcp_tools/infer_schema.py
+++ b/src/wandb_mcp_server/mcp_tools/infer_schema.py
@@ -148,9 +148,14 @@ def infer_trace_schema(
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            logger.error(f"Failed to query traces for schema inference: {e}")
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": f"Failed to infer schema for {entity_name}/{project_name}: {type(e).__name__}"})
+            logger.error("Trace schema inference failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "schema_query_failed",
+                    "message": "The Weave trace schema query failed.",
+                }
+            )
 
         traces = result.traces if hasattr(result, "traces") else []
         if not traces:

--- a/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
+++ b/src/wandb_mcp_server/mcp_tools/list_wandb_entities_projects.py
@@ -96,9 +96,14 @@ def list_entity_projects(
                 entities_projects[ent] = projects_data
             except Exception as e:
                 raise_for_wandb_server_busy(e)
-                logger.warning(f"Failed to list projects for entity {ent}: {e}")
-                ctx.mark_error(f"{type(e).__name__}: {e}")
-                entities_projects[ent] = [{"error": str(e)}]
+                logger.warning("Failed to list projects for one entity (%s)", type(e).__name__)
+                ctx.mark_error(type(e).__name__)
+                entities_projects[ent] = [
+                    {
+                        "error": "project_query_failed",
+                        "message": "W&B project listing failed for this entity.",
+                    }
+                ]
 
         return json.dumps(
             {

--- a/src/wandb_mcp_server/mcp_tools/probe_project.py
+++ b/src/wandb_mcp_server/mcp_tools/probe_project.py
@@ -273,7 +273,10 @@ def probe_project(
                 )
             except SelectiveReadUnavailable as exc:
                 raise_for_wandb_server_busy(exc)
-                logger.warning("Project selective read unavailable; using bounded SDK fallback: %s", exc)
+                logger.warning(
+                    "Project selective read unavailable; using bounded SDK fallback (%s)",
+                    type(exc).__name__,
+                )
                 counts, fields, run_samples = _sdk_fallback(
                     api,
                     entity_name=entity_name,

--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -285,9 +285,14 @@ def list_artifact_versions(
                 ctx.mark_error(type(e).__name__)
                 return json.dumps(registry_error_result(e))
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Artifact version listing failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "api_error",
+                    "message": "The W&B artifact version query failed.",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -384,9 +389,14 @@ def get_artifact_details(
 
         except Exception as e:
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in get_artifact_details: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Artifact detail query failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "api_error",
+                    "message": "The W&B artifact detail query failed.",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -521,9 +531,14 @@ def compare_artifact_versions(
 
         except Exception as e:
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in compare_artifact_versions: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Artifact comparison failed (%s)", type(e).__name__)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "api_error",
+                    "message": "The W&B artifact comparison failed.",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -668,7 +683,7 @@ def _get_logged_by(artifact: Any) -> Optional[Dict[str, Any]]:
         return _serialize_run_info(run)
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("logged_by() failed", exc_info=True)
+        logger.debug("Artifact logged-by lookup failed (%s)", type(exc).__name__)
         return None
 
 
@@ -689,7 +704,7 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
                 used_by.append(_serialize_run_info(run))
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("used_by() failed", exc_info=True)
+        logger.debug("Artifact used-by lookup failed (%s)", type(exc).__name__)
 
     source_artifact = None
     try:
@@ -698,7 +713,7 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
             source_artifact = getattr(src, "source_qualified_name", None) or getattr(src, "name", None)
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("source_artifact failed", exc_info=True)
+        logger.debug("Source-artifact lookup failed (%s)", type(exc).__name__)
 
     linked: Optional[List[str]] = None
     try:
@@ -711,7 +726,7 @@ def _build_lineage(artifact: Any) -> Dict[str, Any]:
                     linked.append(name)
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("linked_artifacts failed", exc_info=True)
+        logger.debug("Linked-artifact lookup failed (%s)", type(exc).__name__)
 
     lineage: Dict[str, Any] = {
         "logged_by": logged_by,
@@ -740,7 +755,7 @@ def _list_files(artifact: Any, max_files: int) -> List[Dict[str, Any]]:
             )
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("files() failed", exc_info=True)
+        logger.debug("Artifact file listing failed (%s)", type(exc).__name__)
     return files
 
 
@@ -773,7 +788,7 @@ def _compute_file_diff(art_a: Any, art_b: Any, max_entries: int) -> Dict[str, An
             files_a[getattr(f, "name", "")] = getattr(f, "digest", "")
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("files() failed for artifact_a", exc_info=True)
+        logger.debug("First artifact file listing failed (%s)", type(exc).__name__)
 
     try:
         for f in art_b.files():
@@ -783,7 +798,7 @@ def _compute_file_diff(art_a: Any, art_b: Any, max_entries: int) -> Dict[str, An
             files_b[getattr(f, "name", "")] = getattr(f, "digest", "")
     except Exception as exc:
         raise_for_wandb_server_busy(exc)
-        logger.debug("files() failed for artifact_b", exc_info=True)
+        logger.debug("Second artifact file listing failed (%s)", type(exc).__name__)
 
     names_a, names_b = set(files_a.keys()), set(files_b.keys())
     added = sorted(names_b - names_a)

--- a/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
+++ b/src/wandb_mcp_server/mcp_tools/resolve_trace_roots.py
@@ -104,5 +104,10 @@ def resolve_trace_roots(
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "resolve_failed", "message": str(e)[:500]})
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "resolve_failed",
+                    "message": "Trace-root resolution failed.",
+                }
+            )

--- a/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
+++ b/src/wandb_mcp_server/mcp_tools/summarize_evaluation.py
@@ -288,5 +288,10 @@ def summarize_evaluation(
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "evaluation_query_failed", "message": str(e)[:500]})
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "evaluation_query_failed",
+                    "message": "The evaluation trace query failed.",
+                }
+            )

--- a/src/wandb_mcp_server/secrets_resolver.py
+++ b/src/wandb_mcp_server/secrets_resolver.py
@@ -24,7 +24,9 @@ class SecretsResolver:
         if self._provider == "gcp" and not self._project:
             raise ValueError("GCP secrets provider requires a secrets_project")
 
-        logger.info("Initialized SecretsResolver (provider=%s, project=%s)", self._provider, self._project)
+        # The cloud project is infrastructure metadata and does not belong in
+        # shared application logs.
+        logger.info("Initialized SecretsResolver (provider=%s)", self._provider)
 
     def fetch_secret(self, secret_id: str) -> bytes:
         if not secret_id:

--- a/src/wandb_mcp_server/server.py
+++ b/src/wandb_mcp_server/server.py
@@ -364,7 +364,7 @@ async def _count_traces_or_none(
         from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
         raise_for_wandb_server_busy(exc)
-        logger.info("count_traces skipped after timeout or error", exc_info=True)
+        logger.info("Trace preflight count skipped after timeout or error")
         return None
 
 
@@ -391,12 +391,11 @@ def validate_api_key(api_key: str) -> bool:
             overrides={"base_url": WANDB_API_BASE_URL},
             timeout=MCP_WANDB_REQUEST_TIMEOUT_SECONDS,
         )
-        viewer = api.viewer  # This will fail if the key is invalid
-        viewer_id = getattr(viewer, "username", None) or getattr(viewer, "entity", None) or "<unknown>"
-        logger.info(f"W&B API key validated successfully. Viewer: {viewer_id}")
+        api.viewer  # This will fail if the key is invalid
+        logger.info("W&B API key validated successfully")
         return True
     except Exception as e:
-        logger.error(f"Invalid W&B API key: {e}")
+        logger.error("W&B API key validation failed (%s)", type(e).__name__)
         return False
 
 
@@ -471,7 +470,7 @@ def configure_wandb_logging() -> None:
         )
         logger.debug("W&B configured for silent operation")
     except Exception as e:
-        logger.warning(f"Could not apply wandb.setup settings: {e}")
+        logger.warning("Could not apply W&B SDK settings (%s)", type(e).__name__)
 
     # Silence specific loggers that might interfere with MCP
     weave_logger = get_rich_logger("weave")
@@ -517,7 +516,7 @@ def initialize_weave_tracing() -> bool:
 
     try:
         weave_project = f"{entity}/{project}"
-        logger.info(f"Initializing Weave tracing for MCP operations: {weave_project}")
+        logger.info("Initializing Weave tracing for MCP operations")
 
         # Set optional MCP configuration for list operations tracing
         if os.environ.get("MCP_TRACE_LIST_OPERATIONS", "").lower() == "true":
@@ -530,7 +529,7 @@ def initialize_weave_tracing() -> bool:
         logger.info("Weave tracing initialized - FastMCP operations will be automatically traced")
         return True
     except Exception as e:
-        logger.error(f"Failed to initialize Weave tracing: {e}")
+        logger.error("Failed to initialize Weave tracing (%s)", type(e).__name__)
         return False
 
 
@@ -737,7 +736,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
                 if matching_count is not None:
                     result_model.metadata.total_matching_count = matching_count
             except Exception:
-                logger.debug("count_traces for total_matching_count failed", exc_info=True)
+                logger.debug("Trace total-count enrichment failed")
 
             # Normalize traces to plain dicts -- the processor may return
             # WeaveTrace Pydantic objects which aren't JSON-serializable by
@@ -782,7 +781,7 @@ def register_tools(mcp_instance: FastMCP) -> None:
 
             return response_json
         except MemoryError:
-            logger.error("MemoryError in query_weave_traces_tool", exc_info=True)
+            logger.error("Memory limit reached in Weave trace query")
             return json.dumps(
                 {
                     "error": "out_of_memory",
@@ -798,11 +797,11 @@ def register_tools(mcp_instance: FastMCP) -> None:
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in query_weave_traces_tool: {e}", exc_info=True)
+            logger.error("Weave trace query failed (%s)", type(e).__name__)
             return json.dumps(
                 {
                     "error": "query_failed",
-                    "message": str(e)[:500],
+                    "message": "The Weave trace query failed.",
                 }
             )
 
@@ -857,8 +856,13 @@ def register_tools(mcp_instance: FastMCP) -> None:
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in count_weave_traces_tool: {e}")
-            return json.dumps({"error": f"Error counting traces: {str(e)}"})
+            logger.error("Weave trace count failed (%s)", type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "count_failed",
+                    "message": "The Weave trace count failed.",
+                }
+            )
 
     from wandb_mcp_server.mcp_tools.resolve_trace_roots import (
         RESOLVE_TRACE_ROOTS_TOOL_DESCRIPTION,
@@ -1095,8 +1099,13 @@ def register_tools(mcp_instance: FastMCP) -> None:
             from wandb_mcp_server.api_client import raise_for_wandb_server_busy
 
             raise_for_wandb_server_busy(e)
-            logger.error(f"Error in get_run_history_tool: {e}")
-            return json.dumps({"error": str(e)})
+            logger.error("Run-history query failed (%s)", type(e).__name__)
+            return json.dumps(
+                {
+                    "error": "history_query_failed",
+                    "message": "The W&B run-history query failed.",
+                }
+            )
 
     # --- Registry & Artifact tools ---
 

--- a/src/wandb_mcp_server/session_manager.py
+++ b/src/wandb_mcp_server/session_manager.py
@@ -126,7 +126,7 @@ class MultiTenantSessionManager:
                 self._hmac_sha256_key = key_bytes
                 logger.info("HMAC-SHA256 sessions enabled")
             except Exception as e:
-                logger.error("Failed to initialize HMAC-SHA256 sessions: %s", e)
+                logger.error("Failed to initialize HMAC-SHA256 sessions (%s)", type(e).__name__)
                 raise
         else:
             logger.warning(
@@ -483,7 +483,7 @@ class MultiTenantSessionManager:
                     time.sleep(60)  # Run every minute
                     self._cleanup_expired_sessions()
                 except Exception as e:
-                    logger.error(f"Error in cleanup task: {e}")
+                    logger.error("Session cleanup task failed (%s)", type(e).__name__)
 
         import threading
 

--- a/src/wandb_mcp_server/trace_utils.py
+++ b/src/wandb_mcp_server/trace_utils.py
@@ -54,7 +54,7 @@ def truncate_value(value: Any, max_length: int = 200) -> Any:
         try:
             # Handle special case for inputs/outputs that might have complex object references
             if "__type__" in value or "_type" in value:
-                logger.info(f"Found potential complex object: {value.get('__type__') or value.get('_type')}")
+                logger.info("Found a complex object during trace truncation")
                 # For very small max_length, return empty dict to ensure proper truncation tests pass
                 if max_length < 50:
                     return {}
@@ -64,21 +64,21 @@ def truncate_value(value: Any, max_length: int = 200) -> Any:
             result = {k: truncate_value(v, max_length) for k, v in value.items()}
             return result
         except Exception as e:
-            logger.warning(f"Error truncating dict: {e}, returning empty dict")
+            logger.warning("Error truncating trace mapping (%s); returning an empty mapping", type(e).__name__)
             return {}
     elif isinstance(value, list):
         try:
             result = [truncate_value(v, max_length) for v in value]
             return result
         except Exception as e:
-            logger.warning(f"Error truncating list: {e}, returning empty list")
+            logger.warning("Error truncating trace list (%s); returning an empty list", type(e).__name__)
             return []
     # For datetime objects and other non-JSON serializable types, convert to string
     elif not isinstance(value, (int, float, bool)):
         try:
             return str(value)[:max_length] + "..." if len(str(value)) > max_length else str(value)
         except Exception as e:
-            logger.warning(f"Error converting value to string: {e}, returning None")
+            logger.warning("Error converting trace value (%s); returning null", type(e).__name__)
             return None
     return value
 
@@ -210,10 +210,6 @@ def process_traces(
         f"process_traces called with {len(traces)} traces, "
         f"detail_level={detail_level}, truncate_length={truncate_length}, return_full_data={return_full_data}"
     )
-
-    if traces:
-        trace_ids = [t.get("id") for t in traces]
-        logger.info(f"First few trace IDs: {trace_ids[:3]}")
 
     metadata = {
         "total_traces": len(traces),

--- a/src/wandb_mcp_server/utils.py
+++ b/src/wandb_mcp_server/utils.py
@@ -534,7 +534,7 @@ def get_git_commit():
         result = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
         return str(result.stdout.strip())[:8]
     except Exception as e:
-        logger.warning(f"Failed to get git commit: {e}")
+        logger.warning("Failed to resolve git commit (%s)", type(e).__name__)
         return "unknown"
 
 

--- a/src/wandb_mcp_server/weave_api/client.py
+++ b/src/wandb_mcp_server/weave_api/client.py
@@ -91,17 +91,11 @@ class WeaveApiClient:
         url = f"{self.server_url}/calls/stream_query"
         headers = self._get_auth_headers()
 
-        # Demote the raw-body log to DEBUG at standard+ privacy levels. The body
-        # is a customer-supplied Weave filter expression that may contain PII-ish
-        # run/project identifiers or inline values; product analytics receives
-        # only bounded usage dimensions from the public tool boundary.
-        from wandb_mcp_server.analytics import is_verbose_log_site_gated
-
-        if is_verbose_log_site_gated():
-            logger.debug(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
-        else:
-            logger.info(f"Sending request to Weave server:\n{json.dumps(query_params, indent=2)[:1000]}...\n")
-        logger.debug(f"Full query parameters:\n{json.dumps(query_params, indent=2)}\n")
+        # Never log the customer-supplied query. It may contain entity/project
+        # identifiers, filters, prompts, trace IDs, or other customer content.
+        # Product analytics receives only bounded allowlisted dimensions from
+        # the public MCP tool boundary.
+        logger.debug("Sending bounded request to the Weave trace service")
 
         try:
             response = self.session.post(
@@ -114,8 +108,8 @@ class WeaveApiClient:
 
             # Check for errors
             if response.status_code != 200:
-                error_msg = f"Error {response.status_code}: {response.text}"
-                logger.error(error_msg)
+                error_msg = f"Error {response.status_code}"
+                logger.error("Weave trace request failed with HTTP %s", response.status_code)
                 # Keep the response (including Retry-After) attached so the
                 # common MCP boundary can produce a stable server_busy result.
                 raise requests.HTTPError(error_msg, response=response)
@@ -127,17 +121,14 @@ class WeaveApiClient:
                 if line:
                     # Parse the JSON line
                     trace_data = json.loads(line.decode("utf-8"))
-                    logger.debug(f"Received trace data with ID: {trace_data.get('id')}")
                     yield trace_data
 
         except requests.RequestException as e:
-            logger.error(
-                f"Error executing HTTP request to Weave server: {e}. Request body snippet: {str(query_params)[:1000]}"
-            )
-            raise Exception(f"Failed to query Weave traces due to network error: {e}") from e
+            logger.error("Weave trace HTTP request failed (%s)", type(e).__name__)
+            raise Exception("Failed to query Weave traces due to a network error") from e
         except json.JSONDecodeError as e:
-            logger.error(f"Error decoding JSON from Weave server: {e}")
-            raise Exception(f"Failed to parse Weave API response: {e}")
+            logger.error("Weave trace response contained invalid JSON")
+            raise Exception("Failed to parse the Weave trace response") from e
         except Exception as e:
-            logger.error(f"Unexpected error during HTTP request to Weave server: {e}")
+            logger.error("Unexpected Weave trace request failure (%s)", type(e).__name__)
             raise

--- a/src/wandb_mcp_server/weave_api/processors.py
+++ b/src/wandb_mcp_server/weave_api/processors.py
@@ -68,7 +68,7 @@ class TraceProcessor:
             try:
                 # Handle special case for inputs/outputs that might have complex object references
                 if "__type__" in value or "_type" in value:
-                    logger.info(f"Found potential complex object: {value.get('__type__') or value.get('_type')}")
+                    logger.info("Found a complex object during trace truncation")
                     # For very small max_length, return empty dict to ensure proper truncation tests pass
                     if max_length < 50:
                         return {}
@@ -78,21 +78,21 @@ class TraceProcessor:
                 result = {k: TraceProcessor.truncate_value(v, max_length) for k, v in value.items()}
                 return result
             except Exception as e:
-                logger.warning(f"Error truncating dict: {e}, returning empty dict")
+                logger.warning("Error truncating trace mapping (%s); returning an empty mapping", type(e).__name__)
                 return {}
         elif isinstance(value, list):
             try:
                 result = [TraceProcessor.truncate_value(v, max_length) for v in value]
                 return result
             except Exception as e:
-                logger.warning(f"Error truncating list: {e}, returning empty list")
+                logger.warning("Error truncating trace list (%s); returning an empty list", type(e).__name__)
                 return []
         # For datetime objects and other non-JSON serializable types, convert to string
         elif not isinstance(value, (int, float, bool)):
             try:
                 return str(value)[:max_length] + "..." if len(str(value)) > max_length else str(value)
             except Exception as e:
-                logger.warning(f"Error converting value to string: {e}, returning None")
+                logger.warning("Error converting trace value (%s); returning null", type(e).__name__)
                 return None
         return value
 
@@ -110,7 +110,7 @@ class TraceProcessor:
             encoding = tiktoken.get_encoding("cl100k_base")  # Using OpenAI's encoding
             return len(encoding.encode(text))
         except Exception as e:
-            logger.warning(f"Error counting tokens with tiktoken: {e}, falling back to approximation")
+            logger.warning("Token counting failed (%s); using the bounded approximation", type(e).__name__)
             # Fallback to approximate token count if tiktoken fails
             return len(text.split())
 
@@ -447,16 +447,6 @@ class TraceProcessor:
             f"Processing {len(traces)} traces, truncate_length={truncate_length}, return_full_data={return_full_data}"
         )
 
-        if traces:
-            # Handle both dict traces and WeaveTrace Pydantic objects
-            trace_ids = []
-            for t in traces:
-                if hasattr(t, "id"):  # Pydantic WeaveTrace object
-                    trace_ids.append(t.id)
-                elif isinstance(t, dict) and "id" in t:  # Dictionary
-                    trace_ids.append(t.get("id"))
-            logger.debug(f"First few trace IDs: {trace_ids[:3]}")
-
         # Generate metadata
         metadata = TraceMetadata(
             total_traces=len(traces),
@@ -568,7 +558,7 @@ class TraceProcessor:
                     total += float(val)
                     found = True
             except Exception as e:
-                logger.warning(f"Error converting cost to float: {e}")
+                logger.warning("Could not convert a returned cost value (%s)", type(e).__name__)
 
         return total if found else 0.0
 

--- a/src/wandb_mcp_server/weave_api/query_builder.py
+++ b/src/wandb_mcp_server/weave_api/query_builder.py
@@ -66,7 +66,7 @@ class QueryBuilder:
             return int(calendar.timegm(dt.utctimetuple()))
         except ValueError:
             # If parsing fails, return 0 (beginning of epoch)
-            logger.warning(f"Failed to parse datetime string: {dt_str}")
+            logger.warning("Failed to parse a datetime filter value")
             return 0
 
     @classmethod
@@ -95,7 +95,7 @@ class QueryBuilder:
 
             literal_op = LiteralOperation(**{"$literal": value})
         except Exception as e:
-            logger.warning(f"Invalid value for {field_name} comparison {operator}: {value}. Error: {e}")
+            logger.warning("Invalid comparison filter value (%s)", type(e).__name__)
             return None
 
         if operator == FilterOperator.GREATER_THAN:
@@ -111,7 +111,7 @@ class QueryBuilder:
             gt_op = GtOperation(**{"$gt": (field_op, literal_op)})
             return NotOperation(**{"$not": [gt_op]})
         else:
-            logger.warning(f"Unsupported comparison operator '{operator}' for {field_name}")
+            logger.warning("Unsupported comparison operator")
             return None
 
     @classmethod
@@ -218,7 +218,7 @@ class QueryBuilder:
                 if comp_op:
                     operations.append(comp_op)
             else:
-                logger.warning(f"Invalid status filter value: {target_status}. Expected a string.")
+                logger.warning("Invalid status filter value type")
 
         # Handle time range filter (convert ISO datetime strings to Unix seconds)
         if "time_range" in filters:
@@ -264,9 +264,9 @@ class QueryBuilder:
                 if isinstance(pattern, str):
                     operations.append(cls.create_contains_operation("wb_run_id", pattern))
                 else:
-                    logger.warning(f"Invalid $contains value for wb_run_id: {pattern}. Expected string.")
+                    logger.warning("Invalid run-ID contains-filter value type")
             else:
-                logger.warning(f"Invalid wb_run_id filter value: {run_id}. Expected a string or dict with $contains.")
+                logger.warning("Invalid run-ID filter value type")
 
         # Handle latency filter based on summary.weave.latency_ms
         if "latency" in filters:
@@ -280,11 +280,9 @@ class QueryBuilder:
                     if comp_op:
                         operations.append(comp_op)
                 except (ValueError, KeyError):
-                    logger.warning(f"Invalid operator for latency filter: {op_key}")
+                    logger.warning("Invalid latency filter operator")
             else:
-                logger.warning(
-                    f"Invalid format for latency filter: {latency_filter}. Expected a dict with one operator key."
-                )
+                logger.warning("Invalid latency filter shape")
 
         # Handle attributes filter using dot notation AND supporting comparison operators
         if "attributes" in filters:
@@ -307,7 +305,7 @@ class QueryBuilder:
                             if comp_op:
                                 operations.append(comp_op)
                         except (ValueError, KeyError):
-                            logger.warning(f"Invalid operator for attribute filter: {op_key}")
+                            logger.warning("Invalid attribute filter operator")
                     elif isinstance(attr_value_or_op, dict) and "$contains" in attr_value_or_op:
                         # It's a contains operation
                         if isinstance(attr_value_or_op["$contains"], str):
@@ -315,9 +313,7 @@ class QueryBuilder:
                                 cls.create_contains_operation(full_attr_path, attr_value_or_op["$contains"])
                             )
                         else:
-                            logger.warning(
-                                f"Invalid value for $contains on {full_attr_path}: {attr_value_or_op['$contains']}. Expected string."
-                            )
+                            logger.warning("Invalid attribute contains-filter value type")
                     else:
                         # Assume literal equality
                         comp_op = cls.create_comparison_operation(
@@ -326,7 +322,7 @@ class QueryBuilder:
                         if comp_op:
                             operations.append(comp_op)
             else:
-                logger.warning(f"Invalid format for 'attributes' filter: {attributes_filters}. Expected a dictionary.")
+                logger.warning("Invalid attributes filter shape")
 
         # Handle inputs filter (substring search on trace inputs via $contains)
         if "inputs" in filters:
@@ -338,7 +334,7 @@ class QueryBuilder:
                         if isinstance(input_condition["$contains"], str):
                             operations.append(cls.create_contains_operation(full_path, input_condition["$contains"]))
                         else:
-                            logger.warning(f"Invalid $contains value for {full_path}: expected string.")
+                            logger.warning("Invalid input contains-filter value type")
                     elif isinstance(input_condition, dict):
                         for op_key, value in input_condition.items():
                             try:
@@ -347,7 +343,7 @@ class QueryBuilder:
                                 if comp_op:
                                     operations.append(comp_op)
                             except (ValueError, KeyError):
-                                logger.warning(f"Invalid operator for inputs filter: {op_key}")
+                                logger.warning("Invalid input filter operator")
                     else:
                         comp_op = cls.create_comparison_operation(full_path, FilterOperator.EQUALS, input_condition)
                         if comp_op:
@@ -368,7 +364,7 @@ class QueryBuilder:
                         if isinstance(output_condition["$contains"], str):
                             operations.append(cls.create_contains_operation(full_path, output_condition["$contains"]))
                         else:
-                            logger.warning(f"Invalid $contains value for {full_path}: expected string.")
+                            logger.warning("Invalid output contains-filter value type")
                     elif isinstance(output_condition, dict):
                         for op_key, value in output_condition.items():
                             try:
@@ -377,7 +373,7 @@ class QueryBuilder:
                                 if comp_op:
                                     operations.append(comp_op)
                             except (ValueError, KeyError):
-                                logger.warning(f"Invalid operator for output filter: {op_key}")
+                                logger.warning("Invalid output filter operator")
                     else:
                         comp_op = cls.create_comparison_operation(full_path, FilterOperator.EQUALS, output_condition)
                         if comp_op:

--- a/src/wandb_mcp_server/weave_api/service.py
+++ b/src/wandb_mcp_server/weave_api/service.py
@@ -218,15 +218,13 @@ class TraceService:
                     # Valid nested field (e.g., "summary.weave.latency_ms", "attributes.foo")
                     if col_name not in filtered_columns_for_api:
                         filtered_columns_for_api.append(col_name)
-                    logger.info(f"Nested column field '{col_name}' requested, added to API columns.")
+                    logger.info("A validated nested column was added to the API projection")
                 else:
-                    logger.warning(
-                        f"Invalid base field '{base_field}' in nested column '{col_name}'. It will be ignored."
-                    )
+                    logger.warning("An invalid nested column was ignored")
                     invalid_columns_reported.add(col_name)
             else:
                 # Neither a direct valid column, nor a recognized synthetic, nor a valid-looking nested path
-                logger.warning(f"Invalid column '{col_name}' requested. It will be ignored.")
+                logger.warning("An invalid column was ignored")
                 invalid_columns_reported.add(col_name)
 
         # Ensure filtered_columns_for_api does not have duplicates and maintains order as much as possible
@@ -305,7 +303,7 @@ class TraceService:
                     logger.debug(f"Adding synthetic 'costs' column with {len(costs_data)} providers")
                     updated_trace["costs"] = costs_data
                 else:
-                    logger.warning(f"No costs data found in trace {trace.get('id')}")
+                    logger.warning("No costs data found in a returned trace")
                     updated_trace["costs"] = {}
 
             # Add status from summary if requested
@@ -315,10 +313,10 @@ class TraceService:
                     # Extract from summary.weave.status
                     status = trace.get("summary", {}).get("weave", {}).get("status")
                     if status:
-                        logger.debug(f"Adding synthetic 'status' from summary: {status}")
+                        logger.debug("Adding synthetic status from summary")
                         updated_trace["status"] = status
                     else:
-                        logger.warning(f"No status data found in trace {trace.get('id')}")
+                        logger.warning("No status data found in a returned trace")
                         updated_trace["status"] = None
 
             # Add latency_ms from summary if requested
@@ -328,10 +326,10 @@ class TraceService:
                     # Extract from summary.weave.latency_ms
                     latency = trace.get("summary", {}).get("weave", {}).get("latency_ms")
                     if latency is not None:
-                        logger.debug(f"Adding synthetic 'latency_ms' from summary: {latency}")
+                        logger.debug("Adding synthetic latency from summary")
                         updated_trace["latency_ms"] = latency
                     else:
-                        logger.warning(f"No latency_ms data found in trace {trace.get('id')}")
+                        logger.warning("No latency data found in a returned trace")
                         updated_trace["latency_ms"] = None
 
             # Add warnings for invalid columns
@@ -399,7 +397,7 @@ class TraceService:
 
         # Handle latency field mapping
         if sort_by in self.LATENCY_FIELD_MAPPING:
-            logger.info(f"Mapping sort field '{sort_by}' to '{self.LATENCY_FIELD_MAPPING[sort_by]}'")
+            logger.info("Mapping a supported synthetic sort field to its server field")
             server_sort_by = self.LATENCY_FIELD_MAPPING[sort_by]
             server_sort_direction = sort_direction
         elif client_side_cost_sort:
@@ -407,25 +405,21 @@ class TraceService:
             server_sort_by = "started_at"
             server_sort_direction = sort_direction
         elif sort_by == "latency_ms":  # Added specific handling for latency_ms sort
-            logger.info(
-                f"Sort by 'latency_ms' requested. Will sort by server field '{self.LATENCY_FIELD_MAPPING['latency_ms']}'."
-            )
+            logger.info("Mapping the latency sort field to its server field")
             server_sort_by = self.LATENCY_FIELD_MAPPING["latency_ms"]
             server_sort_direction = sort_direction
         elif "." in sort_by:  # Handles general dot-separated paths
             base_field = sort_by.split(".")[0]
             if base_field in VALID_COLUMNS:
-                logger.info(f"Using nested sort field for server: {sort_by}")
+                logger.info("Using a validated nested server sort field")
                 server_sort_by = sort_by
                 server_sort_direction = sort_direction
             else:
-                logger.warning(
-                    f"Invalid base field '{base_field}' in sort_by '{sort_by}', falling back to 'started_at'."
-                )
+                logger.warning("Invalid nested sort field; using the default sort")
                 server_sort_by = "started_at"
                 server_sort_direction = sort_direction
         elif sort_by not in VALID_COLUMNS:
-            logger.warning(f"Invalid sort field '{sort_by}', falling back to 'started_at'.")
+            logger.warning("Invalid sort field; using the default sort")
             server_sort_by = "started_at"
             server_sort_direction = sort_direction
         else:  # sort_by is in VALID_COLUMNS and not a special case
@@ -496,7 +490,7 @@ class TraceService:
 
         # Client-side cost-based sorting if needed
         if client_side_cost_sort and all_traces:
-            logger.info(f"Performing client-side sorting by {sort_by}")
+            logger.info("Performing a bounded client-side cost sort")
             # Sort traces by cost
             all_traces.sort(
                 key=lambda t: TraceProcessor.get_cost(t, sort_by),
@@ -508,7 +502,7 @@ class TraceService:
 
         # If we need to synthesize fields, do it
         if synthetic_fields:
-            logger.info(f"Synthesizing fields: {synthetic_fields}")
+            logger.info("Synthesizing %d requested fields", len(synthetic_fields))
             all_traces = [TraceProcessor.synthesize_fields(trace, synthetic_fields) for trace in all_traces]
 
         # Process traces
@@ -625,20 +619,20 @@ class TraceService:
         effective_sort_by = "started_at"  # Default
         if sort_by == "latency_ms":
             effective_sort_by = self.LATENCY_FIELD_MAPPING["latency_ms"]
-            logger.info(f"Paginated sort by 'latency_ms', server will use '{effective_sort_by}'.")
+            logger.info("Mapping the paginated latency sort field to its server field")
         elif "." in sort_by:
             base_field = sort_by.split(".")[0]
             if base_field in VALID_COLUMNS:
                 effective_sort_by = sort_by
-                logger.info(f"Paginated sort by nested field '{sort_by}', server will use it directly.")
+                logger.info("Using a validated nested sort field for pagination")
             else:
-                logger.warning(f"Paginated sort by invalid nested field '{sort_by}', defaulting to 'started_at'.")
+                logger.warning("Invalid nested pagination sort field; using the default sort")
         elif (
             sort_by in VALID_COLUMNS and sort_by not in self.COST_FIELDS
         ):  # Exclude COST_FIELDS as they are client-sorted
             effective_sort_by = sort_by
         elif sort_by not in self.COST_FIELDS:  # If not valid and not cost, warn and default
-            logger.warning(f"Paginated sort by invalid field '{sort_by}', defaulting to 'started_at'.")
+            logger.warning("Invalid pagination sort field; using the default sort")
 
         # Validate and filter columns using CallSchema
         # Pass the original 'columns'
@@ -655,7 +649,7 @@ class TraceService:
         # filtered_api_columns = self._ensure_required_columns_for_synthetic(filtered_api_columns, rs_columns)
 
         if client_side_cost_sort:
-            logger.info(f"Cost-based sorting detected: {sort_by}")
+            logger.info("Cost-based pagination sort selected")
             all_traces = self._query_for_cost_sorting(
                 entity_name=entity_name,
                 project_name=project_name,
@@ -818,7 +812,7 @@ class TraceService:
             else [t["id"] for t in filtered_results if "id" in t]
         )
 
-        logger.info(f"After sorting by {sort_by}, selected {len(top_ids)} trace IDs")
+        logger.info("Selected %d traces after bounded cost sorting", len(top_ids))
 
         if not top_ids:
             return []

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -28,10 +28,11 @@ from wandb_mcp_server.mcp_tools.agents import (
 
 
 class _FakeResponse:
-    def __init__(self, json_data, status_code=200, text=""):
+    def __init__(self, json_data, status_code=200, text="", headers=None):
         self._json = json_data
         self.status_code = status_code
         self.text = text
+        self.headers = headers or {}
 
     def json(self):
         if self._json is None:
@@ -52,13 +53,20 @@ class _FakeSession:
 
 
 @contextmanager
-def _patched(json_data, status_code=200, text=""):
+def _patched(json_data, status_code=200, text="", headers=None):
     """Patch auth + the agents HTTP session; yield the fake session for asserts."""
-    session = _FakeSession(_FakeResponse(json_data, status_code=status_code, text=text))
+    session = _FakeSession(
+        _FakeResponse(
+            json_data,
+            status_code=status_code,
+            text=text,
+            headers=headers,
+        )
+    )
     with (
         patch.object(WandBApiManager, "get_api_key", return_value="test-key"),
         patch.object(WandBApiManager, "get_api", return_value=MagicMock(viewer=MagicMock())),
-        patch("wandb_mcp_server.mcp_tools.agents.get_retry_session", return_value=session),
+        patch("wandb_mcp_server.mcp_tools.agents.get_no_retry_session", return_value=session),
     ):
         yield session
 
@@ -216,10 +224,61 @@ class TestErrorHandling:
         data = json.loads(out)
         assert data["error"] == "agents_api_unavailable"
         assert data["status_code"] == 404
+        assert "http://" not in data["message"]
+        assert "https://" not in data["message"]
 
     def test_500_maps_to_query_failed(self):
-        with _patched(None, status_code=500, text="boom"):
+        with _patched(None, status_code=500, text="upstream-response-canary"):
             out = list_agents("e", "p")
+        data = json.loads(out)
+        assert data["error"] == "agents_query_failed"
+        assert data["status_code"] == 500
+        assert "upstream-response-canary" not in out
+
+    def test_transport_exception_does_not_expose_customer_content(self, caplog):
+        session = _FakeSession(_FakeResponse(None))
+        session.post = MagicMock(side_effect=RuntimeError("customer-secret-canary"))
+        with (
+            patch.object(WandBApiManager, "get_api_key", return_value="test-key"),
+            patch("wandb_mcp_server.mcp_tools.agents.get_no_retry_session", return_value=session),
+            caplog.at_level("DEBUG"),
+        ):
+            out = list_agents("customer-entity", "customer-project")
+
+        assert json.loads(out)["error"] == "agents_query_failed"
+        assert "customer-secret-canary" not in out
+        assert "customer-secret-canary" not in caplog.text
+        assert "customer-entity" not in caplog.text
+        assert "customer-project" not in caplog.text
+
+    @pytest.mark.parametrize(
+        ("status_code", "body"),
+        [
+            (429, "rate limited"),
+            (503, "service overloaded"),
+        ],
+    )
+    def test_overload_is_single_attempt_and_preserves_retry_after(self, status_code, body):
+        from wandb_mcp_server.api_client import WandBServerBusy
+
+        with _patched(
+            None,
+            status_code=status_code,
+            text=body,
+            headers={"Retry-After": "7"},
+        ) as session:
+            with pytest.raises(WandBServerBusy) as caught:
+                list_agents("e", "p")
+
+        assert len(session.calls) == 1
+        assert caught.value.status_code == status_code
+        assert caught.value.retry_after_ms == 7000
+
+    def test_non_overload_503_is_structured_and_not_retried(self):
+        with _patched(None, status_code=503, text="maintenance") as session:
+            out = list_agents("e", "p")
+
+        assert len(session.calls) == 1
         assert json.loads(out)["error"] == "agents_query_failed"
 
 

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from mcp.types import TextContent
 
 from wandb_mcp_server.analytics import reset_analytics_tracker
 from wandb_mcp_server.analytics_datadog import (
@@ -19,7 +20,11 @@ from wandb_mcp_server.analytics_segment import (
     reset_segment_forwarder,
 )
 from wandb_mcp_server.api_client import WandBApiManager
-from wandb_mcp_server.instrumented_server import InstrumentedFastMCP, structured_result_error
+from wandb_mcp_server.instrumented_server import (
+    InstrumentedFastMCP,
+    _structured_result_error_category,
+    structured_result_error,
+)
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
 
 
@@ -219,6 +224,22 @@ def test_mcp_is_error_result_is_failed() -> None:
         isError = True
 
     assert structured_result_error(ErrorResult()) == "ToolError: MCP result marked as an error"
+
+
+def test_text_content_error_retains_allowlisted_telemetry_category() -> None:
+    result = [
+        TextContent(
+            type="text",
+            text=json.dumps(
+                {
+                    "error": "permission_denied",
+                    "message": "private-organization-canary",
+                }
+            ),
+        )
+    ]
+
+    assert _structured_result_error_category(result) == "permission_denied"
 
 
 @pytest.mark.usefixtures("_enable_analytics")

--- a/tests/test_analytics_e2e.py
+++ b/tests/test_analytics_e2e.py
@@ -78,7 +78,16 @@ def _server() -> InstrumentedFastMCP:
 
     @server.tool(name="structured_error_tool")
     async def structured_error_tool() -> str:
-        return json.dumps({"error": "permission_denied", "message": "access denied"})
+        return json.dumps(
+            {
+                "error": "permission_denied",
+                "message": "access denied for private-organization-canary",
+            }
+        )
+
+    @server.tool(name="untrusted_error_tool")
+    async def untrusted_error_tool() -> str:
+        return json.dumps({"error": "private-organization-canary"})
 
     @server.tool(name="exception_tool")
     async def exception_tool() -> str:
@@ -164,7 +173,10 @@ async def test_exception_is_emitted_as_one_failed_public_call() -> None:
     datadog = dd_forwarder.get_forwarded_payloads()
     assert len(segment) == len(datadog) == 1
     assert segment[0]["properties"]["success"] is False
-    assert "ToolError" in segment[0]["properties"]["error"]
+    assert segment[0]["properties"]["error"] == "ToolError: tool failed"
+    assert "bad query" not in str(segment[0])
+    assert "bad query" not in str(datadog[0])
+    assert datadog[0]["attributes"]["error"]["kind"] == "ToolError"
     assert datadog[0]["status"] == "error"
 
 
@@ -179,7 +191,26 @@ async def test_structured_error_result_is_failed() -> None:
     segment = get_segment_forwarder().get_forwarded_payloads()[0]
     datadog = dd_forwarder.get_forwarded_payloads()[0]
     assert segment["properties"]["success"] is False
-    assert "access denied" in segment["properties"]["error"]
+    assert segment["properties"]["error"] == "permission_denied: tool failed"
+    assert "private-organization-canary" not in str(segment)
+    assert "private-organization-canary" not in str(datadog)
+    assert datadog["attributes"]["error"]["kind"] == "permission_denied"
+
+
+@pytest.mark.usefixtures("_enable_analytics")
+@pytest.mark.asyncio
+async def test_untrusted_error_value_is_not_used_as_telemetry_category() -> None:
+    server = _server()
+    dd_forwarder = get_datadog_forwarder()
+    with patch.object(dd_forwarder, "_post"):
+        await server.call_tool("untrusted_error_tool", {})
+
+    segment = get_segment_forwarder().get_forwarded_payloads()[0]
+    datadog = dd_forwarder.get_forwarded_payloads()[0]
+    assert segment["properties"]["error"] == "tool_error: tool failed"
+    assert datadog["attributes"]["error"]["kind"] == "tool_error"
+    assert "private-organization-canary" not in str(segment)
+    assert "private-organization-canary" not in str(datadog)
     assert datadog["status"] == "error"
 
 

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -604,13 +604,14 @@ class TestListAutomations:
         assert auto["updated_at"] is None
 
     def test_api_error_returns_error_dict(self, mock_api):
-        mock_api.automations.side_effect = RuntimeError("boom")
+        mock_api.automations.side_effect = RuntimeError("customer-automation-error-canary")
 
         from wandb_mcp_server.mcp_tools.automations import list_automations
 
         result = json.loads(list_automations())
         assert result["error"] == "api_error"
-        assert "boom" in result["message"]
+        assert result["message"] == "The W&B automation query failed."
+        assert "customer-automation-error-canary" not in json.dumps(result)
 
 
 # ---------------------------------------------------------------------------
@@ -717,13 +718,14 @@ class TestListIntegrations:
         assert result["truncated"] is True
 
     def test_api_error_returns_error_dict(self, mock_api):
-        mock_api.integrations.side_effect = RuntimeError("kapow")
+        mock_api.integrations.side_effect = RuntimeError("customer-integration-error-canary")
 
         from wandb_mcp_server.mcp_tools.automations import list_integrations
 
         result = json.loads(list_integrations())
         assert result["error"] == "api_error"
-        assert "kapow" in result["message"]
+        assert result["message"] == "The W&B integration query failed."
+        assert "customer-integration-error-canary" not in json.dumps(result)
 
     def test_unknown_typename_falls_back(self, mock_api):
         """Forward-compat: an Integration kind that's neither Slack nor Webhook

--- a/tests/test_detail_level.py
+++ b/tests/test_detail_level.py
@@ -106,6 +106,17 @@ class TestProcessTracesDetailLevel:
         assert trace["id"] == "t1"
         assert "inputs" not in trace
 
+    def test_process_traces_never_logs_trace_identifiers(self, caplog):
+        traces = self._make_traces()
+        traces[0]["id"] = "customer-trace-id-canary"
+        traces[0]["trace_id"] = "customer-root-id-canary"
+
+        with caplog.at_level("DEBUG"):
+            process_traces(traces, detail_level="schema")
+
+        assert "customer-trace-id-canary" not in caplog.text
+        assert "customer-root-id-canary" not in caplog.text
+
 
 class TestSchemaProjection:
     """Verify detail_level='schema' passes server-side column projection."""

--- a/tests/test_infer_schema.py
+++ b/tests/test_infer_schema.py
@@ -160,10 +160,12 @@ class TestInferTraceSchema:
 
     @patch("wandb_mcp_server.mcp_tools.count_traces.count_traces")
     def test_query_failure_returns_error(self, mock_count):
-        mock_count.side_effect = Exception("Network timeout")
+        mock_count.side_effect = Exception("customer-error-canary")
 
         result = json.loads(infer_trace_schema("e", "p"))
-        assert "error" in result
+        assert result["error"] == "schema_query_failed"
+        assert result["message"] == "The Weave trace schema query failed."
+        assert "customer-error-canary" not in json.dumps(result)
 
     @patch("wandb_mcp_server.mcp_tools.count_traces.count_traces")
     def test_pydantic_trace_objects_handled(self, mock_count):

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -479,13 +479,14 @@ class TestGetArtifactDetails:
     def test_api_error_returns_json(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_api.artifact.side_effect = Exception("Artifact not found")
+        mock_api.artifact.side_effect = Exception("customer-artifact-error-canary")
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(get_artifact_details("team/proj/model:v99"))
 
-        assert "error" in result
-        assert "Artifact not found" in result["message"]
+        assert result["error"] == "api_error"
+        assert result["message"] == "The W&B artifact detail query failed."
+        assert "customer-artifact-error-canary" not in json.dumps(result)
 
 
 class TestCompareArtifactVersions:

--- a/tests/test_resolve_trace_roots.py
+++ b/tests/test_resolve_trace_roots.py
@@ -179,13 +179,14 @@ class TestResolveTraceRootsTool:
         from wandb_mcp_server.mcp_tools.resolve_trace_roots import resolve_trace_roots
 
         mock_svc = MagicMock()
-        mock_svc.resolve_trace_roots.side_effect = ValueError("connection failed")
+        mock_svc.resolve_trace_roots.side_effect = ValueError("customer-error-canary")
         mock_get_svc.return_value = mock_svc
 
         result = json.loads(resolve_trace_roots("entity", "project", ["t1"]))
 
         assert result["error"] == "resolve_failed"
-        assert "connection failed" in result["message"]
+        assert result["message"] == "Trace-root resolution failed."
+        assert "customer-error-canary" not in json.dumps(result)
 
     @patch("wandb_mcp_server.mcp_tools.resolve_trace_roots.get_trace_service")
     def test_tool_deduplicates_in_response(self, mock_get_svc):

--- a/tests/test_summarize_evaluation.py
+++ b/tests/test_summarize_evaluation.py
@@ -258,12 +258,13 @@ class TestSummarizeEvaluation:
     def test_query_failure_returns_error(self, mock_get_svc, _mock_count):
         mock_service = MagicMock()
         mock_get_svc.return_value = mock_service
-        mock_service.query_traces.side_effect = Exception("Connection refused")
+        mock_service.query_traces.side_effect = Exception("customer-error-canary")
 
         result = json.loads(summarize_evaluation("ent", "proj"))
 
         assert result["error"] == "evaluation_query_failed"
-        assert "Connection refused" in result["message"]
+        assert result["message"] == "The evaluation trace query failed."
+        assert "customer-error-canary" not in json.dumps(result)
 
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.count_traces", side_effect=[1, 0])
     @patch("wandb_mcp_server.mcp_tools.summarize_evaluation.get_trace_service")

--- a/tests/test_weave_api.py
+++ b/tests/test_weave_api.py
@@ -19,6 +19,7 @@ from wandb_mcp_server.weave_api.models import (
 )
 from wandb_mcp_server.weave_api.processors import TraceProcessor
 from wandb_mcp_server.weave_api.query_builder import QueryBuilder
+from wandb_mcp_server.weave_api.service import TraceService
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +54,14 @@ class TestTraceProcessor(unittest.TestCase):
         complex_object = {"__type__": "ComplexObject", "data": "a" * 200}
         result = TraceProcessor.truncate_value(complex_object, max_length=50)
         assert result == {"type": "ComplexObject"}
+
+    def test_truncate_value_never_logs_customer_type(self):
+        canary = "customer-complex-type-canary"
+        with self.assertLogs("wandb_mcp_server.weave_api.processors", level="INFO") as captured:
+            result = TraceProcessor.truncate_value({"__type__": canary}, max_length=50)
+
+        assert result == {"type": canary}
+        assert canary not in "\n".join(captured.output)
 
     def test_count_tokens(self):
         text = "This is a test of the token counter."
@@ -164,6 +173,47 @@ class TestQueryBuilder(unittest.TestCase):
         assert QueryBuilder.datetime_to_timestamp("2021-01-01T00:00:00+00:00") == 1609459200
         assert QueryBuilder.datetime_to_timestamp("invalid_datetime") == 0
         assert QueryBuilder.datetime_to_timestamp("") == 0
+
+    def test_invalid_filters_never_log_customer_values_or_paths(self):
+        canaries = (
+            "customer-datetime-canary",
+            "customer-status-canary",
+            "customer-attribute-path-canary",
+            "customer-attribute-value-canary",
+        )
+        with self.assertLogs("wandb_mcp_server.weave_api.query_builder", level="WARNING") as captured:
+            assert QueryBuilder.datetime_to_timestamp(canaries[0]) == 0
+            QueryBuilder.build_query_expression(
+                {
+                    "status": {"value": canaries[1]},
+                    "attributes": {
+                        canaries[2]: {"$contains": {"value": canaries[3]}},
+                    },
+                }
+            )
+
+        logs = "\n".join(captured.output)
+        for canary in canaries:
+            assert canary not in logs
+
+    def test_trace_service_never_logs_columns_or_trace_ids(self):
+        column_canary = "attributes.customer-column-canary"
+        invalid_canary = "customer-invalid-column-canary"
+        trace_canary = "customer-trace-id-canary"
+        service = TraceService(api_key="test-key", server_url="https://trace.example")
+
+        with self.assertLogs("wandb_mcp_server.weave_api.service", level="INFO") as captured:
+            service._validate_and_filter_columns([column_canary, invalid_canary])
+            service._add_synthetic_columns(
+                [{"id": trace_canary}],
+                ["costs", "status", "latency_ms"],
+                set(),
+            )
+
+        logs = "\n".join(captured.output)
+        assert column_canary not in logs
+        assert invalid_canary not in logs
+        assert trace_canary not in logs
 
     def test_separate_filters(self):
         filters = {"trace_roots_only": True, "op_name": "test_op", "status": "success", "latency": {"$gt": 1000}}
@@ -296,22 +346,62 @@ class TestWeaveApiClient(unittest.TestCase):
         assert results[0]["id"] == "1"
 
     @patch("requests.Session.post")
-    def test_query_traces_error_response(self, mock_post):
+    def test_query_traces_never_logs_customer_query(self, mock_post):
+        query_canary = "customer-query-canary"
         mock_response = Mock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad request"
+        mock_response.status_code = 200
+        mock_response.iter_lines.return_value = []
         mock_post.return_value = mock_response
 
         client = WeaveApiClient(api_key="test_key")
-        with pytest.raises(Exception, match="Error 400"):
-            list(client.query_traces({"project_id": "entity/project"}))
+        with self.assertLogs("wandb_mcp_server.weave_api.client", level="DEBUG") as captured:
+            list(
+                client.query_traces(
+                    {
+                        "project_id": "customer-entity/customer-project",
+                        "filter": {"query": query_canary},
+                    }
+                )
+            )
+
+        logs = "\n".join(captured.output)
+        assert query_canary not in logs
+        assert "customer-entity" not in logs
+        assert "customer-project" not in logs
+
+    @patch("requests.Session.post")
+    def test_query_traces_error_response(self, mock_post):
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.text = "upstream-customer-canary"
+        mock_post.return_value = mock_response
+
+        client = WeaveApiClient(api_key="test_key")
+        with self.assertLogs("wandb_mcp_server.weave_api.client", level="DEBUG") as captured:
+            with pytest.raises(Exception, match="network error") as caught:
+                list(client.query_traces({"project_id": "entity/project"}))
+        assert "upstream-customer-canary" not in "\n".join(captured.output)
+        assert "upstream-customer-canary" not in str(caught.value)
 
     @patch("requests.Session.post")
     def test_query_traces_network_error(self, mock_post):
+        query_canary = "network-query-canary"
         mock_post.side_effect = requests.RequestException("Network error")
         client = WeaveApiClient(api_key="test_key")
-        with pytest.raises(Exception, match="Failed to query Weave traces"):
-            list(client.query_traces({"project_id": "entity/project"}))
+        with self.assertLogs("wandb_mcp_server.weave_api.client", level="DEBUG") as captured:
+            with pytest.raises(Exception, match="Failed to query Weave traces"):
+                list(
+                    client.query_traces(
+                        {
+                            "project_id": "customer-entity/customer-project",
+                            "filter": {"query": query_canary},
+                        }
+                    )
+                )
+        logs = "\n".join(captured.output)
+        assert query_canary not in logs
+        assert "customer-entity" not in logs
+        assert "customer-project" not in logs
 
     def test_functional_queries_never_mount_retry_adapter(self):
         """Functional trace calls leave retry policy with the MCP caller."""

--- a/tests/test_weave_retry_safety.py
+++ b/tests/test_weave_retry_safety.py
@@ -104,6 +104,37 @@ def test_trace_count_attempts_once_and_preserves_retry_after(monkeypatch: pytest
     }
 
 
+def test_trace_count_never_logs_customer_request_content(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request_canary = "customer-filter-canary"
+    with _overloaded_weave_server(
+        status_code=400,
+        retry_after="0",
+        body=b"upstream-response-canary",
+    ) as (server_url, _attempts):
+        monkeypatch.setattr(count_module.WandBApiManager, "get_api_key", lambda: "test-key")
+        monkeypatch.setattr(count_module.WandBApiManager, "get_api", lambda: object())
+        monkeypatch.setattr("wandb_mcp_server.config.WF_TRACE_SERVER_URL", server_url)
+
+        with caplog.at_level("DEBUG"):
+            with pytest.raises(Exception):
+                count_module.count_traces(
+                    "customer-entity",
+                    "customer-project",
+                    filters={"trace_id": request_canary},
+                )
+
+    for protected in (
+        request_canary,
+        "customer-entity",
+        "customer-project",
+        "upstream-response-canary",
+    ):
+        assert protected not in caplog.text
+
+
 def test_trace_count_default_uses_validated_wandb_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

- prevent W&B and Weave request content, identifiers, infrastructure addresses, and upstream response text from entering application logs or analytics
- keep failed-tool telemetry low-cardinality while retaining useful Datadog error kinds
- stop automatic retry amplification for Weave Agent reads and preserve retryable 429/overload-503 responses with bounded Retry-After
- preserve all public tool signatures, successful response shapes, and feature gates

## Why

The prior staging candidate passed all functional checks but its privacy gate found customer-scoped request data in revision logs. The telemetry check also used a fixed propagation wait. This PR supplies the public runtime half of that remediation; the hosted release gate fix is tracked separately.

## Validation

- Ruff check and format: pass
- Bandit Medium/High: pass
- uv lock --check: pass
- full non-integration suite: 1,448 passed, 11 deselected
- focused overload and privacy canaries: pass
- wheel and sdist build: pass

No production or customer deployment is included.