### PR TITLE
fix(artifacts): accept entities in registry tools

### DIFF
--- a/src/wandb_mcp_server/mcp_tools/query_artifacts.py
+++ b/src/wandb_mcp_server/mcp_tools/query_artifacts.py
@@ -11,6 +11,11 @@ from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.registry_support import (
+    registry_error_result,
+    require_registry,
+    resolve_registry_organization,
+)
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -63,7 +68,7 @@ project_name : str, optional
 registry_name : str, optional
     Registry name. Required when source="registry".
 organization : str, optional
-    W&B organization name. Only used when source="registry".
+    W&B organization or entity name. Only used when source="registry".
 type_name : str, optional
     Artifact type (e.g., "model", "dataset"). Required for project source.
 source : str, optional
@@ -119,14 +124,17 @@ def list_artifact_versions(
                             "message": "registry_name is required when source='registry'",
                         }
                     )
-                reg_kwargs: Dict[str, Any] = {}
-                if organization is not None:
-                    reg_kwargs["organization"] = organization
-                registry = api.registry(registry_name, **reg_kwargs)
-                versions_iter = registry.collections(
+                resolved_organization = resolve_registry_organization(api, organization)
+                registry_search = api.registries(
+                    organization=resolved_organization,
+                    filter={"name": registry_name},
+                    per_page=1,
+                )
+                require_registry(registry_search)
+                versions_iter = registry_search.collections(
                     filter={"name": collection_name},
                     per_page=min(max_items, 100),
-                ).versions()
+                ).versions(per_page=min(max_items, 100))
             else:
                 if not type_name:
                     return json.dumps(
@@ -138,6 +146,16 @@ def list_artifact_versions(
                 qualified_name = collection_name
                 if "/" not in collection_name and entity_name and project_name:
                     qualified_name = f"{entity_name}/{project_name}/{collection_name}"
+                if not _is_qualified_collection_name(qualified_name):
+                    return json.dumps(
+                        {
+                            "error": "invalid_input",
+                            "message": (
+                                "Project artifact collections require collection_name='entity/project/name' "
+                                "or both entity_name and project_name."
+                            ),
+                        }
+                    )
                 versions_iter = api.artifacts(
                     type_name=type_name,
                     name=qualified_name,
@@ -164,8 +182,10 @@ def list_artifact_versions(
 
         except Exception as e:
             logger.error(f"Error in list_artifact_versions: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            ctx.mark_error(type(e).__name__)
+            if source == "registry":
+                return json.dumps(registry_error_result(e))
+            return json.dumps(_artifact_error_result(e, operation="list"))
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +219,8 @@ artifact_name : str
     Fully qualified artifact name with version or alias
     (e.g., "my-team/my-project/my-model:v3").
 type_name : str, optional
-    Artifact type hint for disambiguation.
+    Artifact type hint. If it is wrong, the artifact is still returned and the
+    response notes that the hint was ignored.
 include_files : bool, optional
     Whether to include the file manifest. Default: False.
 max_files : int, optional
@@ -233,7 +254,7 @@ def get_artifact_details(
         },
     ) as ctx:
         try:
-            artifact = api.artifact(artifact_name, type=type_name)
+            artifact, type_hint_ignored = _get_artifact(api, artifact_name, type_name)
 
             result: Dict[str, Any] = {
                 "artifact": {
@@ -257,13 +278,18 @@ def get_artifact_details(
 
             if include_files:
                 result["files"] = _list_files(artifact, max_files)
+            if type_hint_ignored:
+                result["warning"] = (
+                    "The supplied type_name did not match the artifact type and was ignored. "
+                    f"The artifact type is {getattr(artifact, 'type', None)!r}."
+                )
 
             return json.dumps(result)
 
         except Exception as e:
             logger.error(f"Error in get_artifact_details: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(_artifact_error_result(e, operation="get"))
 
 
 # ---------------------------------------------------------------------------
@@ -337,8 +363,8 @@ def compare_artifact_versions(
         },
     ) as ctx:
         try:
-            art_a = api.artifact(artifact_name_a, type=type_name)
-            art_b = api.artifact(artifact_name_b, type=type_name)
+            art_a, type_hint_ignored_a = _get_artifact(api, artifact_name_a, type_name)
+            art_b, type_hint_ignored_b = _get_artifact(api, artifact_name_b, type_name)
 
             meta_a = getattr(art_a, "metadata", {}) or {}
             meta_b = getattr(art_b, "metadata", {}) or {}
@@ -393,18 +419,64 @@ def compare_artifact_versions(
 
             if include_file_diff:
                 result["file_diff"] = _compute_file_diff(art_a, art_b, max_file_diff_entries)
+            if type_hint_ignored_a or type_hint_ignored_b:
+                result["warning"] = "The supplied type_name did not match at least one artifact and was ignored."
 
             return json.dumps(result)
 
         except Exception as e:
             logger.error(f"Error in compare_artifact_versions: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(_artifact_error_result(e, operation="compare"))
 
 
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _is_qualified_collection_name(name: str) -> bool:
+    parts = name.split("/")
+    return len(parts) == 3 and all(part.strip() for part in parts)
+
+
+def _get_artifact(api: Any, artifact_name: str, type_name: Optional[str]) -> tuple[Any, bool]:
+    """Fetch an artifact, treating type_name as a non-fatal validation hint."""
+    try:
+        return api.artifact(artifact_name, type=type_name), False
+    except ValueError as exc:
+        if type_name and "specified but this artifact is of type" in str(exc):
+            return api.artifact(artifact_name), True
+        raise
+
+
+def _artifact_error_result(exc: Exception, *, operation: str) -> Dict[str, Any]:
+    """Return stable, actionable artifact errors instead of SDK parser details."""
+    message = str(exc)
+    lowered = message.lower()
+    if "authentication" in lowered or "api key" in lowered or "unauth" in lowered:
+        return {"error": "authentication_failed", "message": "W&B authentication failed."}
+    if "unable to parse 'artifacts' response data" in lowered:
+        return {
+            "error": "resource_not_found",
+            "message": (
+                "No artifact collection matched that entity/project/name and type_name. "
+                "Verify the fully qualified collection path and its actual artifact type."
+            ),
+        }
+    if "artifact membership" in lowered and "not found" in lowered:
+        return {
+            "error": "resource_not_found",
+            "message": (
+                "The artifact version was not found. Use a fully qualified "
+                "'entity/project/collection:alias' name (for example ':latest' or ':v3'), "
+                "not an artifact membership display name."
+            ),
+        }
+    if "not found" in lowered or "could not find" in lowered:
+        noun = "artifact version" if operation != "list" else "artifact collection"
+        return {"error": "resource_not_found", "message": f"The requested W&B {noun} was not found."}
+    return {"error": "api_error", "message": message[:500]}
 
 
 def _serialize_artifact_summary(artifact: Any) -> Dict[str, Any]:

--- a/src/wandb_mcp_server/mcp_tools/query_registry.py
+++ b/src/wandb_mcp_server/mcp_tools/query_registry.py
@@ -11,6 +11,11 @@ from typing import Any, Dict, List, Optional
 
 from wandb_mcp_server.api_client import WandBApiManager
 from wandb_mcp_server.mcp_tools.tools_utils import track_tool_execution
+from wandb_mcp_server.registry_support import (
+    registry_error_result,
+    require_registry,
+    resolve_registry_organization,
+)
 from wandb_mcp_server.utils import get_rich_logger
 
 logger = get_rich_logger(__name__)
@@ -40,9 +45,10 @@ Typical workflow:
 </when_to_use>
 
 <critical_info>
-Requires the user's API key to have access to the organization. If no
-organization is specified, uses the default organization for the
-authenticated user.
+The organization parameter accepts either a W&B organization name or an
+entity name. Team and personal entities that map to one organization are
+resolved automatically. If no organization is specified and more than one is
+available, the response lists candidates and asks the caller to choose.
 Supports MongoDB-style filters on name, description, etc.
 (e.g., {"name": {"$regex": "model.*"}}).
 </critical_info>
@@ -50,7 +56,7 @@ Supports MongoDB-style filters on name, description, etc.
 Parameters
 ----------
 organization : str, optional
-    W&B organization name. Omit to use the authenticated user's default org.
+    W&B organization or entity name. Omit to resolve from the authenticated user.
 filter : dict, optional
     MongoDB-style filter dict (e.g., {"name": {"$regex": "model.*"}}).
 max_items : int, optional
@@ -81,9 +87,11 @@ def list_registries(
         max_items = min(max_items, MAX_ITEMS_CEILING)
 
         try:
-            kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
-            if organization is not None:
-                kwargs["organization"] = organization
+            resolved_organization = resolve_registry_organization(api, organization)
+            kwargs: Dict[str, Any] = {
+                "organization": resolved_organization,
+                "per_page": min(max_items, 100),
+            }
             if filter is not None:
                 kwargs["filter"] = filter
 
@@ -110,9 +118,9 @@ def list_registries(
             return json.dumps({"registries": registries, "count": len(registries), "truncated": truncated})
 
         except Exception as e:
-            logger.error(f"Error in list_registries: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Error in list_registries (%s)", type(e).__name__, exc_info=True)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(registry_error_result(e))
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +140,8 @@ list_artifact_versions_tool or get_artifact_details_tool.
 <critical_info>
 The registry_name is the short name (e.g., "model"), NOT the full name with
 the "wandb-registry-" prefix.
+The organization parameter also accepts an entity name and resolves it to the
+corresponding organization when the mapping is unambiguous.
 Supports MongoDB-style filters on name, description, tags, etc.
 </critical_info>
 
@@ -140,7 +150,7 @@ Parameters
 registry_name : str
     The registry short name (e.g., "model", "dataset", "my-registry").
 organization : str, optional
-    W&B organization name. Omit to use default.
+    W&B organization or entity name. Omit to resolve from the authenticated user.
 filter : dict, optional
     MongoDB-style filter (e.g., {"tag": "production"}).
 max_items : int, optional
@@ -178,10 +188,13 @@ def list_registry_collections(
         max_items = min(max_items, MAX_ITEMS_CEILING)
 
         try:
-            reg_kwargs: Dict[str, Any] = {}
-            if organization is not None:
-                reg_kwargs["organization"] = organization
-            registry = api.registry(registry_name, **reg_kwargs)
+            resolved_organization = resolve_registry_organization(api, organization)
+            registry_search = api.registries(
+                organization=resolved_organization,
+                filter={"name": registry_name},
+                per_page=1,
+            )
+            require_registry(registry_search)
 
             coll_kwargs: Dict[str, Any] = {"per_page": min(max_items, 100)}
             if filter is not None:
@@ -189,7 +202,7 @@ def list_registry_collections(
 
             collections: List[Dict[str, Any]] = []
             truncated = False
-            for coll in registry.collections(**coll_kwargs):
+            for coll in registry_search.collections(**coll_kwargs):
                 if len(collections) >= max_items:
                     truncated = True
                     break
@@ -216,6 +229,6 @@ def list_registry_collections(
             )
 
         except Exception as e:
-            logger.error(f"Error in list_registry_collections: {e}", exc_info=True)
-            ctx.mark_error(f"{type(e).__name__}: {e}")
-            return json.dumps({"error": "api_error", "message": str(e)[:500]})
+            logger.error("Error in list_registry_collections (%s)", type(e).__name__, exc_info=True)
+            ctx.mark_error(type(e).__name__)
+            return json.dumps(registry_error_result(e))

--- a/src/wandb_mcp_server/registry_support.py
+++ b/src/wandb_mcp_server/registry_support.py
@@ -1,0 +1,142 @@
+"""Shared organization resolution and error handling for Registry tools."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from wandb_mcp_server.wandb_graphql import fetch_registry_organization_info
+
+_MAX_ORGANIZATION_CANDIDATES = 20
+
+
+class OrganizationRequired(ValueError):
+    """Raised when an entity belongs to more than one organization."""
+
+    def __init__(self, candidates: tuple[str, ...], *, truncated: bool = False) -> None:
+        super().__init__("Specify organization because this entity can access more than one organization.")
+        self.candidates = candidates
+        self.truncated = truncated
+
+
+class OrganizationResolutionFailed(ValueError):
+    """Raised when an organization cannot be resolved for registry access."""
+
+
+def resolve_registry_organization(api: Any, organization_or_entity: str | None) -> str:
+    """Resolve either an organization display name or an entity to one organization."""
+    if organization_or_entity is not None:
+        if not isinstance(organization_or_entity, str) or not organization_or_entity.strip():
+            raise ValueError("organization must be a non-empty string when provided")
+        requested = organization_or_entity.strip()
+    else:
+        settings = getattr(api, "settings", None)
+        configured_org = settings.get("organization") if isinstance(settings, Mapping) else None
+        if isinstance(configured_org, str) and configured_org.strip():
+            return configured_org.strip()
+
+        configured_entity = settings.get("entity") if isinstance(settings, Mapping) else None
+        requested = (
+            configured_entity.strip() if isinstance(configured_entity, str) and configured_entity.strip() else None
+        )
+
+    data = fetch_registry_organization_info(api, requested)
+    if not isinstance(data, Mapping):
+        raise OrganizationResolutionFailed("W&B returned malformed organization data.")
+
+    direct_org = data.get("organization")
+    direct_name = _organization_name(direct_org)
+    if direct_name:
+        return direct_name
+
+    if requested is not None:
+        entity = data.get("entity")
+        if not isinstance(entity, Mapping):
+            raise OrganizationResolutionFailed(f"No W&B organization or entity named {requested!r} is accessible.")
+        team_org = _organization_name(entity.get("organization"))
+        if team_org:
+            return team_org
+        user = entity.get("user")
+        organizations = user.get("organizations") if isinstance(user, Mapping) else None
+    else:
+        viewer = data.get("viewer")
+        if not isinstance(viewer, Mapping):
+            raise OrganizationResolutionFailed("No W&B organization is available for the authenticated user.")
+        organizations = viewer.get("organizations")
+        default_entity = viewer.get("entity")
+        if isinstance(default_entity, str) and isinstance(organizations, list):
+            matching = [
+                item
+                for item in organizations
+                if isinstance(item, Mapping)
+                and isinstance(item.get("orgEntity"), Mapping)
+                and item["orgEntity"].get("name") == default_entity
+            ]
+            if len(matching) == 1:
+                organizations = matching
+
+    candidates = _organization_candidates(organizations)
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        truncated = len(candidates) > _MAX_ORGANIZATION_CANDIDATES
+        raise OrganizationRequired(candidates[:_MAX_ORGANIZATION_CANDIDATES], truncated=truncated)
+    raise OrganizationResolutionFailed("No W&B organization is available for registry access.")
+
+
+def registry_error_result(exc: Exception) -> dict[str, Any]:
+    """Map registry failures to stable, actionable tool errors."""
+    if isinstance(exc, OrganizationRequired):
+        return {
+            "error": "organization_required",
+            "message": str(exc),
+            "organization_candidates": list(exc.candidates),
+            "candidates_truncated": exc.truncated,
+        }
+    if isinstance(exc, OrganizationResolutionFailed):
+        return {"error": "organization_resolution_failed", "message": str(exc)}
+
+    message = str(exc)
+    lowered = message.lower()
+    if "authentication" in lowered or "api key" in lowered or "unauth" in lowered:
+        return {"error": "authentication_failed", "message": "W&B authentication failed."}
+    if "not found" in lowered or "could not find" in lowered:
+        return {
+            "error": "resource_not_found",
+            "message": "The requested W&B registry resource was not found.",
+        }
+    if isinstance(exc, TypeError) and "nonetype" in lowered:
+        return {
+            "error": "malformed_response",
+            "message": "W&B returned incomplete registry data. Verify the organization or entity and try again.",
+        }
+    return {"error": "api_error", "message": message[:500]}
+
+
+def require_registry(registries: Any) -> Any:
+    """Require one exact registry match without using the SDK's eager registry lookup."""
+    iterator = iter(registries)
+    try:
+        return next(iterator)
+    except StopIteration:
+        raise LookupError("Registry not found") from None
+
+
+def _organization_name(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    name = value.get("name")
+    org_entity = value.get("orgEntity")
+    if not isinstance(name, str) or not name.strip() or not isinstance(org_entity, Mapping):
+        return None
+    entity_name = org_entity.get("name")
+    if not isinstance(entity_name, str) or not entity_name.strip():
+        return None
+    return name.strip()
+
+
+def _organization_candidates(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, list):
+        return ()
+    names = {_organization_name(value) for value in values}
+    return tuple(sorted(name for name in names if name))

--- a/src/wandb_mcp_server/wandb_graphql.py
+++ b/src/wandb_mcp_server/wandb_graphql.py
@@ -8,6 +8,43 @@ from graphql import parse
 from graphql.language import ast as gql_ast
 
 
+REGISTRY_ORGANIZATION_QUERY = """
+query MCPRegistryOrganization($name: String!, $hasName: Boolean!) {
+  organization(name: $name) @include(if: $hasName) {
+    name
+    orgEntity {
+      name
+    }
+  }
+  entity(name: $name) @include(if: $hasName) {
+    organization {
+      name
+      orgEntity {
+        name
+      }
+    }
+    user {
+      organizations {
+        name
+        orgEntity {
+          name
+        }
+      }
+    }
+  }
+  viewer @skip(if: $hasName) {
+    entity
+    organizations {
+      name
+      orgEntity {
+        name
+      }
+    }
+  }
+}
+"""
+
+
 class GraphQLReadOnlyViolation(ValueError):
     """Raised when a GraphQL document contains a non-query operation."""
 
@@ -49,3 +86,12 @@ def execute_graphql(
             "W&B SDK compatibility error: query_wandb_tool requires wandb>=0.28.0 with ServiceApi.execute_graphql."
         )
     return execute(query, variables=variables_dict)
+
+
+def fetch_registry_organization_info(api: Any, name: str | None) -> dict[str, Any]:
+    """Fetch organization and entity candidates on the request-scoped transport."""
+    return execute_graphql(
+        api,
+        REGISTRY_ORGANIZATION_QUERY,
+        {"name": name or "", "hasName": name is not None},
+    )

--- a/tests/test_query_artifacts.py
+++ b/tests/test_query_artifacts.py
@@ -88,6 +88,7 @@ class TestListArtifactVersions:
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
         mock_registry = MagicMock()
+        mock_registry.__iter__.return_value = iter([MagicMock()])
         mock_collections = MagicMock()
         mock_collections.versions.return_value = iter(
             [
@@ -95,7 +96,8 @@ class TestListArtifactVersions:
             ]
         )
         mock_registry.collections.return_value = mock_collections
-        mock_api.registry.return_value = mock_registry
+        mock_api.settings = {"organization": "my-org"}
+        mock_api.registries.return_value = mock_registry
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(list_artifact_versions("my-model", registry_name="model-registry", source="registry"))
@@ -124,6 +126,32 @@ class TestListArtifactVersions:
 
         assert result["error"] == "invalid_input"
         assert "registry_name" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_project_source_requires_qualified_collection(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("my-model", type_name="model"))
+
+        assert result["error"] == "invalid_input"
+        assert "entity/project/name" in result["message"]
+        mock_api.artifacts.assert_not_called()
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_sdk_parse_error_becomes_resource_not_found(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        broken_versions = MagicMock()
+        broken_versions.__iter__.side_effect = ValueError("Unable to parse 'Artifacts' response data")
+        mock_api.artifacts.return_value = broken_versions
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(list_artifact_versions("team/project/missing", type_name="model"))
+
+        assert result["error"] == "resource_not_found"
+        assert "fully qualified collection path" in result["message"]
 
 
 class TestGetArtifactDetails:
@@ -184,8 +212,37 @@ class TestGetArtifactDetails:
 
         result = json.loads(get_artifact_details("team/proj/model:v99"))
 
-        assert "error" in result
-        assert "Artifact not found" in result["message"]
+        assert result["error"] == "resource_not_found"
+        assert "artifact version" in result["message"]
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_wrong_type_hint_is_retried_without_hint(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        artifact = _make_artifact(type="checkpoint")
+        mock_api.artifact.side_effect = [
+            ValueError("type model specified but this artifact is of type checkpoint"),
+            artifact,
+        ]
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model:v1", type_name="model"))
+
+        assert result["artifact"]["type"] == "checkpoint"
+        assert "ignored" in result["warning"]
+        assert mock_api.artifact.call_args_list[1].kwargs == {}
+
+    @patch("wandb_mcp_server.mcp_tools.query_artifacts.WandBApiManager")
+    def test_membership_not_found_has_collection_alias_guidance(self, mock_api_mgr):
+        mock_api = MagicMock()
+        mock_api.viewer = MagicMock()
+        mock_api.artifact.side_effect = Exception("artifact membership 'model-v2' not found")
+        mock_api_mgr.get_api.return_value = mock_api
+
+        result = json.loads(get_artifact_details("team/proj/model-v2"))
+
+        assert result["error"] == "resource_not_found"
+        assert "collection:alias" in result["message"]
 
 
 class TestCompareArtifactVersions:

--- a/tests/test_query_registry.py
+++ b/tests/test_query_registry.py
@@ -43,6 +43,7 @@ class TestListRegistries:
     def test_basic(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
         mock_api.registries.return_value = iter(
             [
                 _make_registry("models"),
@@ -62,6 +63,7 @@ class TestListRegistries:
     def test_filter_passed_through(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
         mock_api.registries.return_value = iter([_make_registry("models")])
         mock_api_mgr.get_api.return_value = mock_api
 
@@ -75,6 +77,7 @@ class TestListRegistries:
     def test_max_items_ceiling(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
         regs = [_make_registry(f"reg-{i}") for i in range(250)]
         mock_api.registries.return_value = iter(regs)
         mock_api_mgr.get_api.return_value = mock_api
@@ -88,6 +91,7 @@ class TestListRegistries:
     def test_api_error_returns_json(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
         mock_api.registries.side_effect = Exception("Connection refused")
         mock_api_mgr.get_api.return_value = mock_api
 
@@ -100,6 +104,7 @@ class TestListRegistries:
     def test_empty_result(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
         mock_api.registries.return_value = iter([])
         mock_api_mgr.get_api.return_value = mock_api
 
@@ -115,14 +120,16 @@ class TestListRegistryCollections:
     def test_basic(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
-        mock_registry.collections.return_value = iter(
+        mock_api.settings = {"organization": "my-org"}
+        mock_registry_search = MagicMock()
+        mock_registry_search.__iter__.return_value = iter([_make_registry()])
+        mock_registry_search.collections.return_value = iter(
             [
                 _make_collection("model-a"),
                 _make_collection("model-b"),
             ]
         )
-        mock_api.registry.return_value = mock_registry
+        mock_api.registries.return_value = mock_registry_search
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(list_registry_collections("my-registry"))
@@ -136,9 +143,11 @@ class TestListRegistryCollections:
     def test_empty(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
-        mock_registry.collections.return_value = iter([])
-        mock_api.registry.return_value = mock_registry
+        mock_api.settings = {"organization": "my-org"}
+        mock_registry_search = MagicMock()
+        mock_registry_search.__iter__.return_value = iter([_make_registry()])
+        mock_registry_search.collections.return_value = iter([])
+        mock_api.registries.return_value = mock_registry_search
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(list_registry_collections("my-registry"))
@@ -150,10 +159,12 @@ class TestListRegistryCollections:
     def test_collection_properties(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_registry = MagicMock()
+        mock_api.settings = {"organization": "my-org"}
+        mock_registry_search = MagicMock()
+        mock_registry_search.__iter__.return_value = iter([_make_registry()])
         coll = _make_collection("prod-model", tags=["production", "v2"], is_sequence=True)
-        mock_registry.collections.return_value = iter([coll])
-        mock_api.registry.return_value = mock_registry
+        mock_registry_search.collections.return_value = iter([coll])
+        mock_api.registries.return_value = mock_registry_search
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(list_registry_collections("my-registry"))
@@ -167,13 +178,13 @@ class TestListRegistryCollections:
     def test_api_error_returns_json(self, mock_api_mgr):
         mock_api = MagicMock()
         mock_api.viewer = MagicMock()
-        mock_api.registry.side_effect = Exception("Registry not found")
+        mock_api.settings = {"organization": "my-org"}
+        mock_api.registries.side_effect = Exception("Registry not found")
         mock_api_mgr.get_api.return_value = mock_api
 
         result = json.loads(list_registry_collections("nonexistent"))
 
-        assert "error" in result
-        assert "Registry not found" in result["message"]
+        assert result["error"] == "resource_not_found"
 
 
 class TestToolDescriptions:

--- a/tests/test_registry_support.py
+++ b/tests/test_registry_support.py
@@ -1,0 +1,63 @@
+"""Tests for registry organization and entity resolution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from wandb_mcp_server.registry_support import (
+    OrganizationRequired,
+    resolve_registry_organization,
+)
+
+
+@patch("wandb_mcp_server.registry_support.fetch_registry_organization_info")
+def test_explicit_organization_is_preserved(mock_fetch):
+    mock_fetch.return_value = {
+        "organization": {"name": "acme", "orgEntity": {"name": "acme-org"}},
+        "entity": None,
+    }
+
+    assert resolve_registry_organization(MagicMock(), "acme") == "acme"
+
+
+@patch("wandb_mcp_server.registry_support.fetch_registry_organization_info")
+def test_team_entity_resolves_to_organization(mock_fetch):
+    mock_fetch.return_value = {
+        "organization": None,
+        "entity": {
+            "organization": {"name": "Acme Corp", "orgEntity": {"name": "acme-org"}},
+            "user": None,
+        },
+    }
+
+    assert resolve_registry_organization(MagicMock(), "acme-team") == "Acme Corp"
+
+
+@patch("wandb_mcp_server.registry_support.fetch_registry_organization_info")
+def test_personal_entity_with_multiple_orgs_returns_candidates(mock_fetch):
+    mock_fetch.return_value = {
+        "organization": None,
+        "entity": {
+            "organization": None,
+            "user": {
+                "organizations": [
+                    {"name": "Beta", "orgEntity": {"name": "beta-org"}},
+                    {"name": "Alpha", "orgEntity": {"name": "alpha-org"}},
+                ]
+            },
+        },
+    }
+
+    with pytest.raises(OrganizationRequired) as error:
+        resolve_registry_organization(MagicMock(), "personal-entity")
+
+    assert error.value.candidates == ("Alpha", "Beta")
+
+
+@patch("wandb_mcp_server.registry_support.fetch_registry_organization_info")
+def test_configured_organization_avoids_resolution_query(mock_fetch):
+    api = MagicMock()
+    api.settings = {"organization": "configured-org"}
+
+    assert resolve_registry_organization(api, None) == "configured-org"
+    mock_fetch.assert_not_called()


### PR DESCRIPTION
## What

Allow the registry tools to accept either a W&B organization name or an entity name through the existing `organization` parameter.

This also replaces opaque artifact SDK failures with structured responses:

- ambiguous personal entities return `organization_required` and organization candidates
- invalid project collection paths return `invalid_input`
- missing artifact collections and versions return `resource_not_found`
- incorrect artifact type hints are retried without the hint

## Why

Agents commonly pass team or personal entity names to registry tools. The tools previously forwarded those values as organization names, which produced organization lookup failures and null crashes inside the W&B SDK.

Project artifact listing also exposed `Unable to parse Artifacts response data` when the collection path or type did not resolve. Artifact detail calls failed when an agent supplied a generic `model` type for a `checkpoint` or `lora` artifact.

## How

A request-scoped, read-only GraphQL query now resolves the input in this order:

1. an organization with the supplied name
2. an entity with one associated organization
3. the authenticated viewer when no value was supplied

When a personal entity has multiple organizations, the tool returns at most 20 sorted candidates instead of selecting one. Registry collection and version reads use `api.registries()` after resolution, avoiding the SDK eager `api.registry()` path that performed its own brittle organization lookup.

Project artifact listing validates the required `entity/project/name` shape before calling the SDK. Artifact detail and comparison calls treat `type_name` as a hint and retry without it only when the SDK reports a type mismatch.

This changes the tool response contract by adding stable error categories and optional `organization_candidates` and `warning` fields. It does not change authentication, permissions, dependencies, feature flags, or configuration defaults.

## Testing

- Full unit suite passed with one existing skipped test.
- Added coverage for direct organizations, team entities, ambiguous personal entities, configured organizations, invalid collection paths, parser-error mapping, incorrect type hints, and artifact membership guidance.
- `ruff check .` passed.
- `ruff format --check .` passed.

The organization query was tested with mocked W&B responses. It was not exercised against a live hosted or Dedicated endpoint in this workspace.

## Anything Else

Organization candidates use organization display names because the public Registry SDK accepts those names in its `organization` parameter.